### PR TITLE
Add ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 build
 dist
+docker-compose.yml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+name: Tests & Build
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+  workflow_dispatch:
+
+jobs:
+  test-job:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: |
+        docker-compose build  --pull --force-rm d3fend-ontology
+
+    - name: Test
+      run:  docker-compose run --rm d3fend-ontology
+
+    - name: Cleanup
+      run: docker-compose down && docker-compose rm --force
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: d3fend.ttl
+        path: dist/public/d3fend.ttl

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,7 @@ dist: distdir
 	cp build/d3fend-public.json dist/public/d3fend.json
 	@cp build/d3fend.csv dist/public/d3fend.csv ||  echo "${RED}WARNING: build/d3fend.csv not found to include in dist. Manually run: ${YELLOW} make build/d3fend.csv ${RESET} ${RESET}"
 	cp build/d3fend-architecture.owl dist/public/d3fend-architecture.owl
+	chmod 644 dist/public/d3fend.ttl
 	$(END)
 
 all: build dist test ## build all, check for unallowed content, and test load files


### PR DESCRIPTION
## This PR

- use docker-compose to build the ontologies
- publish on github the resulting `d3fend.ttl` that can then be inspected to ensure that the output is coherent with the desired one.

## Note

- this PR introduces a `chmod 644 dist/public/d3fend.ttl` so that github can access this file after it is built by docker. This is needed because this file is originally built with `0600`  permission 

@netfl0 