### PR TITLE
Reviewed and modified Credential Access Technique, Brute Force, and Brute Force subclasses

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2672,6 +2672,9 @@ Container images become containers at runtime and in the case of Docker containe
     rdfs:label "Credential Access Technique" ;
     rdfs:subClassOf :OffensiveTechnique,
         [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :Credential ],
+        [ a owl:Restriction ;
             owl:onProperty :enables ;
             owl:someValuesFrom :CredentialAccess ] .
 
@@ -9377,6 +9380,9 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:label "Password Guessing" ;
     rdfs:subClassOf :T1110,
         [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :Password ],
+        [ a owl:Restriction ;
             owl:onProperty :modifies ;
             owl:someValuesFrom :AuthenticationLog ],
         [ a owl:Restriction ;
@@ -9389,12 +9395,15 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :T1110,
         [ a owl:Restriction ;
             owl:onProperty :accesses ;
-            owl:someValuesFrom :EncryptedCredential ] ;
+            owl:someValuesFrom :Password ] ;
     :attack-id "T1110.002" .
 
 :T1110.003 a owl:Class ;
     rdfs:label "Password Spraying" ;
     rdfs:subClassOf :T1110,
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :Password ],
         [ a owl:Restriction ;
             owl:onProperty :may-create ;
             owl:someValuesFrom :IntranetAdministrativeNetworkTraffic ],


### PR DESCRIPTION
Edits will  indicate more precisely the main digital artifacts being accessed (here the passwords are tested by some means of trial and error.)  Result with defense-to-offense query from D3-SPP now results in new matches the the password-specific classes under Brute Force.