### PR TITLE
[Correction] Fixed 'version' data property and several 'has-link' instances

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -1463,13 +1463,11 @@ skos:altLabel a owl:AnnotationProperty ;
     rdfs:label "version"@en ;
     rdfs:subPropertyOf :d3fend-catalog-data-property,
         :d3fend-external-control-data-property ;
-    rdfs:domain :CapabilityImplementation ;
-    rdfs:range xsd:string,
-        [ a rdfs:Datatype ;
+    rdfs:domain [ a owl:Class ;
             owl:unionOf (
-                    xsd:decimal
-                    xsd:integer
-                    xsd:string ) ] ;
+                    :CapabilityImplementation
+                    :ControlCatalog ) ] ;
+    rdfs:range xsd:string ;
     rdfs:comment "x version y: The product or service x has the version y." .
 
 :windows-registry-data-property a owl:DatatypeProperty ;
@@ -15511,21 +15509,21 @@ order to constitute a complete standard. For a complete definition of all requir
     rdfs:label "NIST SP 800-53 R3" ;
     :archived-at "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2013-04-30"^^xsd:anyURI ;
     rdfs:seeAlso "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2013-04-30" ;
-    :version 3 .
+    :version "3"^^xsd:string .
 
 :NIST_SP_800-53_R4 a :NISTSP800-53ControlCatalog,
         owl:NamedIndividual ;
     rdfs:label "NIST SP 800-53 R4" ;
     :archived-at "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2013-04-30"^^xsd:anyURI ;
     rdfs:seeAlso "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2015-01-22" ;
-    :version 4 .
+    :version "4"^^xsd:string .
 
 :NIST_SP_800-53_R5 a :NISTSP800-53ControlCatalog,
         owl:NamedIndividual ;
     rdfs:label "NIST SP 800-53 R5" ;
     :archived-at "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final"^^xsd:anyURI ;
     rdfs:seeAlso "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final" ;
-    :version 5 .
+    :version "5"^^xsd:string .
 
 :non-real-time-analytic a :AnalyticLatency,
         owl:NamedIndividual ;
@@ -16510,7 +16508,7 @@ This requires filesystem data to determine whether files have been created.""" ;
 :Reference-Database_for_receiving_storing_and_compiling_information_about_email_messages a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Database for receiving, storing and compiling information about email messages" ;
-    :has-link "https://patents.google.com/patent/US20050091319A1/" ;
+    :has-link "https://patents.google.com/patent/US20050091319A1/"^^xsd:anyURI ;
     :kb-author "Steven Kirsch" ;
     :kb-reference-of :DomainNameReputationAnalysis,
         :IPReputationAnalysis ;
@@ -16883,7 +16881,7 @@ If a process is conducting a traversal of the directory and accessing files acco
 :Reference-Finding_phishing_sites a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Finding phishing sites" ;
-    :has-link "https://patents.google.com/patent/US8839418B2/" ;
+    :has-link "https://patents.google.com/patent/US8839418B2/"^^xsd:anyURI ;
     :kb-author "Geoffrey John Hulten, Paul Stephen Rehfuss, Robert Rounthwaite, Joshua Theodore Goodman, Gopalakrishnan Seshadrinathan, Anthony P. Penta, Manav Mishra, Roderic C. Deyo, Elliott Jeb Haber, David Aaron Ward Snelling" ;
     :kb-reference-of :DomainNameReputationAnalysis,
         :IPReputationAnalysis,
@@ -18169,7 +18167,7 @@ All of these behaviors call into the Windows API, which uses the NamedPipe WINRE
 :Reference-Reputation_of_an_entity_associated_with_a_content_item a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Reputation of an entity associated with a content item" ;
-    :has-link "https://patents.google.com/patent/US20060253584A1" ;
+    :has-link "https://patents.google.com/patent/US20060253584A1"^^xsd:anyURI ;
     :kb-author "Christopher Dixon, Thomas Pinckney" ;
     :kb-reference-of :FileHashReputationAnalysis ;
     :kb-reference-title "Reputation of an entity associated with a content item" .
@@ -18934,7 +18932,7 @@ Based on the trust rating an alert is generated identifying the incoming email m
 :Reference-Technical_Specifications_for_Construction_and_Management_of_Sensitive_Compartmented_Information_Facilities a owl:NamedIndividual,
         :SpecificationReference ;
     rdfs:label "Reference - Technical Specifications for Construction and Management of Sensitive Compartmented Information Facilities" ;
-    :has-link "https://www.dni.gov/files/Governance/IC-Tech-Specs-for-Const-and-Mgmt-of-SCIFs-v15.pdf" ;
+    :has-link "https://www.dni.gov/files/Governance/IC-Tech-Specs-for-Const-and-Mgmt-of-SCIFs-v15.pdf"^^xsd:anyURI ;
     :kb-author "National Counterintelligence and Security Center" ;
     :kb-reference-of :RFShielding ;
     :kb-reference-title "Technical Specifications for Construction and Management of Sensitive Compartmented Information Facilities" .
@@ -18965,7 +18963,7 @@ In various embodiments, a name server transmits a canonical name as resolution t
 :Reference-Testing_Metrics_for_Password_Creation_Policies_by_Attacking_Large_Sets_of_Revealed_Passwords a :AcademicPaperReference,
         owl:NamedIndividual ;
     rdfs:label "Reference - Testing Metrics for Password Creation Policies by Attacking Large Sets of Revealed Passwords" ;
-    :has-link "https://www.cs.umd.edu/~jkatz/security/downloads/passwords_revealed-weir.pdf" ;
+    :has-link "https://www.cs.umd.edu/~jkatz/security/downloads/passwords_revealed-weir.pdf"^^xsd:anyURI ;
     :kb-author "Matt Weir, Sudhir Aggarwal, Michael Collins, Henry Stern" ;
     :kb-reference-of :StrongPasswordPolicy ;
     :kb-reference-title "Testing Metrics for Password Creation Policies by Attacking Large Sets of Revealed Passwords" .
@@ -19159,7 +19157,7 @@ Could be applied to a number of different types of monitoring depending on what 
 :Reference-UsingSpanningTreeProtocolSTPToEnhanceLayer2NetworkTopologyMaps a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Using spanning tree protocol (STP) to enhance layer-2 topology maps" ;
-    :has-link "https://"^^xsd:anyURI ;
+    :has-link "https://patents.google.com/patent/US8045488B2"^^xsd:anyURI ;
     :kb-abstract "Spanning Tree Protocol (STP) data is obtained via network switch (SNMP) queries to enhance identification of switch-to-switch links in Layer-2 mapping. In particular, by analyzing the STP data, ambiguity in determining switch uplink ports may be reduced. Specifically, the STP data can be used in conjunction with other topography data to provide Layer-2 connectivity for nodes on a network topology. Layer-2 address mapping tables are collected from a topology mapping, and STP data is collected, along with address translation tables (ARP) tables. Using this information, switches are identified using Layer-2 address tables. The STP data can be correlated by comparing data in switches, identifying switch ports directly connected to other switch ports, and eliminating direct switch-to-switch port connections from consideration for further Layer-2 node mappings." ;
     :kb-author "Michael Jon Swan" ;
     :kb-organization "SolarWinds Worldwide LLC" ;


### PR DESCRIPTION
This Pull Request is the result of a discussion in issue https://github.com/d3fend/d3fend-ontology/issues/89.

In accordance with the approach chosen in the discussion, the following changes were made:
1) The version's `rdfs:domain` has been updated and now it is a union: `('Capability Implementation' and 'Control Catalog')`.

2) The version's `rdfs:range` has been updated and now it is `xsd:string`.

3) All numeric instances of `version` data property are converted to the corresponding strings.

4) Added a link to the patent for the individual `Reference - Using spanning tree protocol (STP) to enhance layer-2 topology maps`.

5) The types of some instances of `has-link` data propertiey have been converted to `xsd:anyURI`. 
**Nonte:** Although there is a `make-has-links-anyURI.rq` query execution stage in the pipeline of the ontology building (so the final ontology will contain the correct types), I believe that the `d3fend-protege.ttl` file itself is better maintained in a consistent state

Resolves #89 