### PR TITLE
#184. Initial implementation of CWE weaknesses taxonomy. 

### DIFF
--- a/extensions/cwe/.gitignore
+++ b/extensions/cwe/.gitignore
@@ -1,0 +1,6 @@
+*.jar
+node_modules
+package*json
+*.nt
+*.ttl
+cwec_latest.xml

--- a/extensions/cwe/Makefile
+++ b/extensions/cwe/Makefile
@@ -10,7 +10,7 @@ install-yarrrml-mapper:
 install-deps: install-yarrrml-parser install-yarrrml-mapper
 
 # Pull CWE file; unzip; convert versioned into stable target 'cwec.xml' for YARRRML (and RML) specification
-download-cwe: cwec_latest.xml
+download-cwe:
 	curl https://cwe.mitre.org/data/xml/cwec_latest.xml.zip -o cwec_latest.xml.zip
 	unzip cwec_latest.xml.zip
 	rm cwec_latest.xml.zip

--- a/extensions/cwe/Makefile
+++ b/extensions/cwe/Makefile
@@ -1,0 +1,37 @@
+# Install yarrrml-parser
+install-yarrrml-parser:
+	npm i @rmlio/yarrrml-parser
+
+# Install yarrml-mapper jar
+install-yarrrml-mapper:
+	wget https://github.com/RMLio/rmlmapper-java/releases/download/v6.1.3/rmlmapper-6.1.3-r367-all.jar
+
+# Put in the bin/jar directory
+install-deps: install-yarrrml-parser install-yarrrml-mapper
+
+# Pull CWE file; unzip; convert versioned into stable target 'cwec.xml' for YARRRML (and RML) specification
+download-cwe: cwec_latest.xml
+	curl https://cwe.mitre.org/data/xml/cwec_latest.xml.zip -o cwec_latest.xml.zip
+	unzip cwec_latest.xml.zip
+	rm cwec_latest.xml.zip
+	mv -f "$$(find . -type f -name 'cwec_v*.xml')" "cwec_latest.xml"
+
+# Run parser on YARRRML file
+parse-yarrrml: cwe-yarrrml.yaml
+	yarrrml-parser -i cwe-yarrrml.yaml -o cwe-rules.rml.ttl
+
+# Run mapper on d3fend-protege.ttl; as of 2023-06-19, rmlmapper doesn't have .ttl as serializationformat.
+create-cwe-triples: download-cwe parse-yarrrml
+	java -jar rmlmapper-6.1.3-r367-all.jar -m cwe-rules.rml.ttl --output cwe-all-out.nt
+
+# Run robot to merge to defend-protege.ttl (assume ROBOT in place in bin; test)
+# Use --add-prefix to prevent replacement of dcterms/skos prefixes with ns1, ns2 during robot's merge
+merge-cwe-with-d3fend: create-cwe-triples
+	java -jar ../../bin/robot.jar merge --include-annotations true --input ../../src/ontology/d3fend-protege.ttl --input cwe-all-out.nt --output ../../src/ontology/d3fend-protege.ttl --add-prefix "dcterms: http://purl.org/dc/terms/" --add-prefix "skos: http://www.w3.org/2004/02/skos/core#"
+	cd ../..; make format
+	@echo "Now use Protege to manually remove the subClassOf :Weakness statements that were on Top 25 classes and aren't pillars, as they are not direct subclasses of :Weakness.  Hint: Reference git diff on d3fend-protege.tll and search for - on :Weakness."
+
+clean:
+	rm -Rf *ttl *nt
+
+all: merge-cwe-with-d3fend

--- a/extensions/cwe/Makefile
+++ b/extensions/cwe/Makefile
@@ -1,6 +1,6 @@
 # Install yarrrml-parser
 install-yarrrml-parser:
-	npm i @rmlio/yarrrml-parser
+	npm install
 
 # Install yarrml-mapper jar
 install-yarrrml-mapper:
@@ -18,7 +18,7 @@ download-cwe:
 
 # Run parser on YARRRML file
 parse-yarrrml: cwe-yarrrml.yaml
-	yarrrml-parser -i cwe-yarrrml.yaml -o cwe-rules.rml.ttl
+	node_modules/.bin/yarrrml-parser -i cwe-yarrrml.yaml -o cwe-rules.rml.ttl
 
 # Run mapper on d3fend-protege.ttl; as of 2023-06-19, rmlmapper doesn't have .ttl as serializationformat.
 create-cwe-triples: download-cwe parse-yarrrml

--- a/extensions/cwe/README.md
+++ b/extensions/cwe/README.md
@@ -40,11 +40,11 @@ The introduction of YARRRML as an implementation appears to be by the [RML.io](h
 
 Depending on the needs, YARRRML and RML alternatives exist.   Capabilities vary and cross-compatibility is not assured.
 
-The Python-based Morph KGC (and kglab, which embeds it) can use YARRRML directly to directly perform knowledge graph construction.  They also support .ttl as an output serialization format.  However, the Morph KGC team has categorized the ability to use parent references in XPath as [an enhancement rather than a bug](https://github.com/morph-kgc/morph-kgc/issues/98), which is unfortunate since RML.io's implementation and the [CARML](https://github.com/carml/carml-jar) implementation do handle parent path references in Xpath and the [RML spec](https://rml.io/specs/rml/) _[not sure what specification is considered canonical other than one on RML.io cite]_ seems to indicate this should be possible.  Intermediate RML can be generated directly in the Morph KGC with the code block:
+The Python-based [Morph KGC](https://github.com/morph-kgc/morph-kgc) (and [kglab](https://github.com/DerwenAI/kglab/), which embeds it) can use YARRRML directly to directly perform knowledge graph construction.  They also support .ttl as an output serialization format.  However, the Morph KGC team has categorized the ability to use parent references in XPath as [an enhancement rather than a bug](https://github.com/morph-kgc/morph-kgc/issues/98), which is unfortunate since RML.io's implementation and the [CARML](https://github.com/carml/carml-jar) implementation do handle parent path references in Xpath and the [RML spec](https://rml.io/specs/rml/) _[not sure what specification is considered canonical other than one on RML.io cite]_ seems to indicate this should be possible.  Intermediate RML can be generated directly in the Morph KGC with the code block:
 
 ```
 rml_mapping = morph_kgc.mapping.load_yarrrml()
-rml_mapping.serialize(destionation="morph-kgc.rml.ttl`)
+rml_mapping.serialize(destination="morph-kgc.rml.ttl`)
 ```
 
 However, the resulting RML file did not work with other RML mapping engines.

--- a/extensions/cwe/README.md
+++ b/extensions/cwe/README.md
@@ -1,0 +1,71 @@
+
+# CWE -> D3FEND Converter
+
+This directory holds a Makefile and documents the steps necessary to all CWE to Original add of Top-25 CWEs to d3fend-protege.ttl.  
+
+- This only converts the Research Concepts View (aka Graph) of CWE into a D3FEND taxonomy for CWE Weaknesses.
+
+- Future work will be required to extend this capability for ongoing CWE updates
+
+## How to use 
+
+To accomplish add in of CWE tree structure for the Research Concepts View (aka View 1000, Research Concepts Graph), here are the manual steps:
+
+1. `cd extensions/cwe/`
+
+  (i.e., go to the directory in which this README.md is located.)
+
+2. `make install-deps` 
+
+  This will install the # Add all CWE to Original add of Top-25 CWEs to d3fend-protege.ttl
+
+To accomplish add in of CWE tree structure for CWE-1000 / Research
+Concepts View (aka Graph), here are the manual steps.
+
+3. `make all`
+
+4. Review diffs to d3fend-protege.ttl manually. _Example: First time use, the Top 25 classes already present were direct subclasses of Weakness but this was no longer wanted given entire taxonomy with intermediate clases were available; statements were already there and deletions may be required_.
+
+## Notes on RML and YARRRML technology
+
+### RML and YARRML Introduction
+
+RML is a declarative language for converting non-linked data formats into linked data.  RML is encoded in Turtle.  It allows extraction and tranformation steps that includes inputs from relational databases, csv, json, and xml files.  It is an extension of R2RML, which had a focus on relational data.
+
+YARRRML is an effort to provide a more concise, and easier-to-use language for the same kinds of data transformation, where YARRRML is converted into RML and then used with RML engines.
+
+The introduction of YARRRML as an implementation appears to be by the [RML.io](https://rml.io/) group.  The [YARRRML Parser](https://github.com/RMLio/yarrrml-parser) and [YARRRML Mapper](https://github.com/RMLio/rmlmapper-java) were developed by the group and ultimately were used for translating the CWE XML catalog file into the CWE Research Concept taxonomy of D3FEND classes representing CWE weaknesses.
+
+### Alternative Implementations
+
+Depending on the needs, YARRRML and RML alternatives exist.   Capabilities vary and cross-compatibility is not assured.
+
+The Python-based Morph KGC (and kglab, which embeds it) can use YARRRML directly to directly perform knowledge graph construction.  They also support .ttl as an output serialization format.  However, the Morph KGC team has categorized the ability to use parent references in XPath as [an enhancement rather than a bug](https://github.com/morph-kgc/morph-kgc/issues/98), which is unfortunate since RML.io's implementation and the [CARML](https://github.com/carml/carml-jar) implementation do handle parent path references in Xpath and the [RML spec](https://rml.io/specs/rml/) _[not sure what specification is considered canonical other than one on RML.io cite]_ seems to indicate this should be possible.  Intermediate RML can be generated directly in the Morph KGC with the code block:
+
+```
+rml_mapping = morph_kgc.mapping.load_yarrrml()
+rml_mapping.serialize(destionation="morph-kgc.rml.ttl`)
+```
+
+However, the resulting RML file did not work with other RML mapping engines.
+
+CARML does not offer pre-built jars though appeared to be compatible with YARRRML Parser code.
+
+Yatter did not work for RML examples tried. But minimal use, so may work out well later.
+
+### Learning Resources 
+
+The [RML spec](https://rml.io/specs/rml/) has many examples.
+
+The recommendations for YARRRRML users suggested in Section 9.1 of the paper ["Path-based and triplication approaches to mapping data into RDF:
+usability analysis and recommendations"](https://www.semantic-web-journal.net/system/files/swj3348.pdf) are very helpful in debugging YARRRML.
+
+[Matey](https://rml.io/yarrrml/matey/) is live page is available for experimentning with YARRRML, but error messages are suppressed for some operations.
+
+The many pitfalls for new users of YARRRML are noted by the ShEXML creators in their paper ["ShExML: improving the usability of heterogeneous data mapping languages for first-time users"](https://pubmed.ncbi.nlm.nih.gov/33816968/)
+
+
+### Non-RML approaches
+
+- [ShExML](https://github.com/herminiogg/ShExML)
+- Python code with other RDF libraries

--- a/extensions/cwe/cwe-yarrrml.yaml
+++ b/extensions/cwe/cwe-yarrrml.yaml
@@ -1,0 +1,36 @@
+prefixes:
+  d3f: http://d3fend.mitre.org/ontologies/d3fend.owl#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  owl: http://www.w3.org/2002/07/owl#
+sources:
+  cwe-pillar-source:
+    access: "cwec_latest.xml"
+    referenceFormulation: xpath
+    iterator: "/Weakness_Catalog/Weaknesses/Weakness[@Abstraction = 'Pillar']"
+  cwe-source:
+    access: "cwec_latest.xml"
+    referenceFormulation: xpath
+    iterator: "/Weakness_Catalog/Weaknesses/Weakness[@Status != 'Deprecated']"
+  cwe-rel-source:
+    access: "./cwec_latest.xml"
+    referenceFormulation: xpath
+    iterator: "/Weakness_Catalog/Weaknesses/Weakness/Related_Weaknesses/Related_Weakness[@Nature = 'ChildOf' and @View_ID='1000']"
+mappings:
+  Pillar:
+    sources: cwe-pillar-source
+    s: d3f:CWE-$(./@ID)
+    po:
+      - [rdfs:subClassOf, d3f:Weakness~iri]
+  Weakness:
+    sources: cwe-source
+    s: d3f:CWE-$(./@ID)
+    po:
+      - [d3f:cwe-id, "CWE-$(./@ID)"]
+      - [rdfs:label, "$(./@Name)"]
+  RelatedWeakness:
+    sources: cwe-rel-source
+    s: d3f:CWE-$(./../../@ID)
+    po:
+      - [rdfs:subClassOf, d3f:CWE-$(./@CWE_ID)~iri]

--- a/extensions/cwe/package.json
+++ b/extensions/cwe/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@rmlio/yarrrml-parser": "^1.5.2"
+  }
+}

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -3279,9 +3279,60 @@ Management servers with enterprise policies for account management provide the a
     rdfs:subClassOf :ArchiveFile ;
     :definition "A custom archive file is an archive file conforming to a custom format; that is, an archive file that does not conform to a common standard." .
 
+:CWE-5 a owl:Class ;
+    rdfs:label "J2EE Misconfiguration: Data Transmission Without Encryption" ;
+    rdfs:subClassOf :CWE-319 ;
+    :cwe-id "CWE-5" .
+
+:CWE-6 a owl:Class ;
+    rdfs:label "J2EE Misconfiguration: Insufficient Session-ID Length" ;
+    rdfs:subClassOf :CWE-334 ;
+    :cwe-id "CWE-6" .
+
+:CWE-7 a owl:Class ;
+    rdfs:label "J2EE Misconfiguration: Missing Custom Error Page" ;
+    rdfs:subClassOf :CWE-756 ;
+    :cwe-id "CWE-7" .
+
+:CWE-8 a owl:Class ;
+    rdfs:label "J2EE Misconfiguration: Entity Bean Declared Remote" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-8" .
+
+:CWE-9 a owl:Class ;
+    rdfs:label "J2EE Misconfiguration: Weak Access Permissions for EJB Methods" ;
+    rdfs:subClassOf :CWE-266 ;
+    :cwe-id "CWE-9" .
+
+:CWE-11 a owl:Class ;
+    rdfs:label "ASP.NET Misconfiguration: Creating Debug Binary" ;
+    rdfs:subClassOf :CWE-489 ;
+    :cwe-id "CWE-11" .
+
+:CWE-12 a owl:Class ;
+    rdfs:label "ASP.NET Misconfiguration: Missing Custom Error Page" ;
+    rdfs:subClassOf :CWE-756 ;
+    :cwe-id "CWE-12" .
+
+:CWE-13 a owl:Class ;
+    rdfs:label "ASP.NET Misconfiguration: Password in Configuration File" ;
+    rdfs:subClassOf :CWE-260 ;
+    :cwe-id "CWE-13" .
+
+:CWE-14 a owl:Class ;
+    rdfs:label "Compiler Removal of Code to Clear Buffers" ;
+    rdfs:subClassOf :CWE-733 ;
+    :cwe-id "CWE-14" .
+
+:CWE-15 a owl:Class ;
+    rdfs:label "External Control of System or Configuration Setting" ;
+    rdfs:subClassOf :CWE-610,
+        :CWE-642 ;
+    :cwe-id "CWE-15" .
+
 :CWE-20 a owl:Class ;
     rdfs:label "Improper Input Validation" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-707,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
@@ -3289,15 +3340,273 @@ Management servers with enterprise policies for account management provide the a
 
 :CWE-22 a owl:Class ;
     rdfs:label "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-668,
+        :CWE-706,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-22" .
 
+:CWE-23 a owl:Class ;
+    rdfs:label "Relative Path Traversal" ;
+    rdfs:subClassOf :CWE-22 ;
+    :cwe-id "CWE-23" .
+
+:CWE-24 a owl:Class ;
+    rdfs:label "Path Traversal: '../filedir'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-24" .
+
+:CWE-25 a owl:Class ;
+    rdfs:label "Path Traversal: '/../filedir'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-25" .
+
+:CWE-26 a owl:Class ;
+    rdfs:label "Path Traversal: '/dir/../filename'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-26" .
+
+:CWE-27 a owl:Class ;
+    rdfs:label "Path Traversal: 'dir/../../filename'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-27" .
+
+:CWE-28 a owl:Class ;
+    rdfs:label "Path Traversal: '..\\filedir'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-28" .
+
+:CWE-29 a owl:Class ;
+    rdfs:label "Path Traversal: '\\..\\filename'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-29" .
+
+:CWE-30 a owl:Class ;
+    rdfs:label "Path Traversal: '\\dir\\..\\filename'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-30" .
+
+:CWE-31 a owl:Class ;
+    rdfs:label "Path Traversal: 'dir\\..\\..\\filename'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-31" .
+
+:CWE-32 a owl:Class ;
+    rdfs:label "Path Traversal: '...' (Triple Dot)" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-32" .
+
+:CWE-33 a owl:Class ;
+    rdfs:label "Path Traversal: '....' (Multiple Dot)" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-33" .
+
+:CWE-34 a owl:Class ;
+    rdfs:label "Path Traversal: '....//'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-34" .
+
+:CWE-35 a owl:Class ;
+    rdfs:label "Path Traversal: '.../...//'" ;
+    rdfs:subClassOf :CWE-23 ;
+    :cwe-id "CWE-35" .
+
+:CWE-36 a owl:Class ;
+    rdfs:label "Absolute Path Traversal" ;
+    rdfs:subClassOf :CWE-22 ;
+    :cwe-id "CWE-36" .
+
+:CWE-37 a owl:Class ;
+    rdfs:label "Path Traversal: '/absolute/pathname/here'" ;
+    rdfs:subClassOf :CWE-36,
+        :CWE-160 ;
+    :cwe-id "CWE-37" .
+
+:CWE-38 a owl:Class ;
+    rdfs:label "Path Traversal: '\\absolute\\pathname\\here'" ;
+    rdfs:subClassOf :CWE-36 ;
+    :cwe-id "CWE-38" .
+
+:CWE-39 a owl:Class ;
+    rdfs:label "Path Traversal: 'C:dirname'" ;
+    rdfs:subClassOf :CWE-36 ;
+    :cwe-id "CWE-39" .
+
+:CWE-40 a owl:Class ;
+    rdfs:label "Path Traversal: '\\\\UNC\\share\\name\\' (Windows UNC Share)" ;
+    rdfs:subClassOf :CWE-36 ;
+    :cwe-id "CWE-40" .
+
+:CWE-41 a owl:Class ;
+    rdfs:label "Improper Resolution of Path Equivalence" ;
+    rdfs:subClassOf :CWE-706 ;
+    :cwe-id "CWE-41" .
+
+:CWE-42 a owl:Class ;
+    rdfs:label "Path Equivalence: 'filename.' (Trailing Dot)" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-162 ;
+    :cwe-id "CWE-42" .
+
+:CWE-43 a owl:Class ;
+    rdfs:label "Path Equivalence: 'filename....' (Multiple Trailing Dot)" ;
+    rdfs:subClassOf :CWE-42,
+        :CWE-163 ;
+    :cwe-id "CWE-43" .
+
+:CWE-44 a owl:Class ;
+    rdfs:label "Path Equivalence: 'file.name' (Internal Dot)" ;
+    rdfs:subClassOf :CWE-41 ;
+    :cwe-id "CWE-44" .
+
+:CWE-45 a owl:Class ;
+    rdfs:label "Path Equivalence: 'file...name' (Multiple Internal Dot)" ;
+    rdfs:subClassOf :CWE-44,
+        :CWE-165 ;
+    :cwe-id "CWE-45" .
+
+:CWE-46 a owl:Class ;
+    rdfs:label "Path Equivalence: 'filename ' (Trailing Space)" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-162 ;
+    :cwe-id "CWE-46" .
+
+:CWE-47 a owl:Class ;
+    rdfs:label "Path Equivalence: ' filename' (Leading Space)" ;
+    rdfs:subClassOf :CWE-41 ;
+    :cwe-id "CWE-47" .
+
+:CWE-48 a owl:Class ;
+    rdfs:label "Path Equivalence: 'file name' (Internal Whitespace)" ;
+    rdfs:subClassOf :CWE-41 ;
+    :cwe-id "CWE-48" .
+
+:CWE-49 a owl:Class ;
+    rdfs:label "Path Equivalence: 'filename/' (Trailing Slash)" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-162 ;
+    :cwe-id "CWE-49" .
+
+:CWE-50 a owl:Class ;
+    rdfs:label "Path Equivalence: '//multiple/leading/slash'" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-161 ;
+    :cwe-id "CWE-50" .
+
+:CWE-51 a owl:Class ;
+    rdfs:label "Path Equivalence: '/multiple//internal/slash'" ;
+    rdfs:subClassOf :CWE-41 ;
+    :cwe-id "CWE-51" .
+
+:CWE-52 a owl:Class ;
+    rdfs:label "Path Equivalence: '/multiple/trailing/slash//'" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-163 ;
+    :cwe-id "CWE-52" .
+
+:CWE-53 a owl:Class ;
+    rdfs:label "Path Equivalence: '\\multiple\\\\internal\\backslash'" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-165 ;
+    :cwe-id "CWE-53" .
+
+:CWE-54 a owl:Class ;
+    rdfs:label "Path Equivalence: 'filedir\\' (Trailing Backslash)" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-162 ;
+    :cwe-id "CWE-54" .
+
+:CWE-55 a owl:Class ;
+    rdfs:label "Path Equivalence: '/./' (Single Dot Directory)" ;
+    rdfs:subClassOf :CWE-41 ;
+    :cwe-id "CWE-55" .
+
+:CWE-56 a owl:Class ;
+    rdfs:label "Path Equivalence: 'filedir*' (Wildcard)" ;
+    rdfs:subClassOf :CWE-41,
+        :CWE-155 ;
+    :cwe-id "CWE-56" .
+
+:CWE-57 a owl:Class ;
+    rdfs:label "Path Equivalence: 'fakedir/../realdir/filename'" ;
+    rdfs:subClassOf :CWE-41 ;
+    :cwe-id "CWE-57" .
+
+:CWE-58 a owl:Class ;
+    rdfs:label "Path Equivalence: Windows 8.3 Filename" ;
+    rdfs:subClassOf :CWE-41 ;
+    :cwe-id "CWE-58" .
+
+:CWE-59 a owl:Class ;
+    rdfs:label "Improper Link Resolution Before File Access ('Link Following')" ;
+    rdfs:subClassOf :CWE-706 ;
+    :cwe-id "CWE-59" .
+
+:CWE-61 a owl:Class ;
+    rdfs:label "UNIX Symbolic Link (Symlink) Following" ;
+    rdfs:subClassOf :CWE-59 ;
+    :cwe-id "CWE-61" .
+
+:CWE-62 a owl:Class ;
+    rdfs:label "UNIX Hard Link" ;
+    rdfs:subClassOf :CWE-59 ;
+    :cwe-id "CWE-62" .
+
+:CWE-64 a owl:Class ;
+    rdfs:label "Windows Shortcut Following (.LNK)" ;
+    rdfs:subClassOf :CWE-59 ;
+    :cwe-id "CWE-64" .
+
+:CWE-65 a owl:Class ;
+    rdfs:label "Windows Hard Link" ;
+    rdfs:subClassOf :CWE-59 ;
+    :cwe-id "CWE-65" .
+
+:CWE-66 a owl:Class ;
+    rdfs:label "Improper Handling of File Names that Identify Virtual Resources" ;
+    rdfs:subClassOf :CWE-706 ;
+    :cwe-id "CWE-66" .
+
+:CWE-67 a owl:Class ;
+    rdfs:label "Improper Handling of Windows Device Names" ;
+    rdfs:subClassOf :CWE-66 ;
+    :cwe-id "CWE-67" .
+
+:CWE-69 a owl:Class ;
+    rdfs:label "Improper Handling of Windows ::DATA Alternate Data Stream" ;
+    rdfs:subClassOf :CWE-66 ;
+    :cwe-id "CWE-69" .
+
+:CWE-72 a owl:Class ;
+    rdfs:label "Improper Handling of Apple HFS+ Alternate Data Stream Path" ;
+    rdfs:subClassOf :CWE-66 ;
+    :cwe-id "CWE-72" .
+
+:CWE-73 a owl:Class ;
+    rdfs:label "External Control of File Name or Path" ;
+    rdfs:subClassOf :CWE-610,
+        :CWE-642 ;
+    :cwe-id "CWE-73" .
+
+:CWE-74 a owl:Class ;
+    rdfs:label "Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')" ;
+    rdfs:subClassOf :CWE-707 ;
+    :cwe-id "CWE-74" .
+
+:CWE-75 a owl:Class ;
+    rdfs:label "Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)" ;
+    rdfs:subClassOf :CWE-74 ;
+    :cwe-id "CWE-75" .
+
+:CWE-76 a owl:Class ;
+    rdfs:label "Improper Neutralization of Equivalent Special Elements" ;
+    rdfs:subClassOf :CWE-75 ;
+    :cwe-id "CWE-76" .
+
 :CWE-77 a owl:Class ;
     rdfs:label "Improper Neutralization of Special Elements used in a Command ('Command Injection')" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-74,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
@@ -3305,7 +3614,7 @@ Management servers with enterprise policies for account management provide the a
 
 :CWE-78 a owl:Class ;
     rdfs:label "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-77,
         [ a owl:Restriction ;
             owl:onProperty :may-be-weakness-of ;
             owl:someValuesFrom :EvalFunction ],
@@ -3319,23 +3628,85 @@ Management servers with enterprise policies for account management provide the a
 
 :CWE-79 a owl:Class ;
     rdfs:label "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-74,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-79" .
 
+:CWE-80 a owl:Class ;
+    rdfs:label "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)" ;
+    rdfs:subClassOf :CWE-79 ;
+    :cwe-id "CWE-80" .
+
+:CWE-81 a owl:Class ;
+    rdfs:label "Improper Neutralization of Script in an Error Message Web Page" ;
+    rdfs:subClassOf :CWE-79 ;
+    :cwe-id "CWE-81" .
+
+:CWE-82 a owl:Class ;
+    rdfs:label "Improper Neutralization of Script in Attributes of IMG Tags in a Web Page" ;
+    rdfs:subClassOf :CWE-83 ;
+    :cwe-id "CWE-82" .
+
+:CWE-83 a owl:Class ;
+    rdfs:label "Improper Neutralization of Script in Attributes in a Web Page" ;
+    rdfs:subClassOf :CWE-79 ;
+    :cwe-id "CWE-83" .
+
+:CWE-84 a owl:Class ;
+    rdfs:label "Improper Neutralization of Encoded URI Schemes in a Web Page" ;
+    rdfs:subClassOf :CWE-79 ;
+    :cwe-id "CWE-84" .
+
+:CWE-85 a owl:Class ;
+    rdfs:label "Doubled Character XSS Manipulations" ;
+    rdfs:subClassOf :CWE-79 ;
+    :cwe-id "CWE-85" .
+
+:CWE-86 a owl:Class ;
+    rdfs:label "Improper Neutralization of Invalid Characters in Identifiers in Web Pages" ;
+    rdfs:subClassOf :CWE-79,
+        :CWE-436 ;
+    :cwe-id "CWE-86" .
+
+:CWE-87 a owl:Class ;
+    rdfs:label "Improper Neutralization of Alternate XSS Syntax" ;
+    rdfs:subClassOf :CWE-79 ;
+    :cwe-id "CWE-87" .
+
+:CWE-88 a owl:Class ;
+    rdfs:label "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')" ;
+    rdfs:subClassOf :CWE-77 ;
+    :cwe-id "CWE-88" .
+
 :CWE-89 a owl:Class ;
     rdfs:label "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-943,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-89" .
 
+:CWE-90 a owl:Class ;
+    rdfs:label "Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')" ;
+    rdfs:subClassOf :CWE-943 ;
+    :cwe-id "CWE-90" .
+
+:CWE-91 a owl:Class ;
+    rdfs:label "XML Injection (aka Blind XPath Injection)" ;
+    rdfs:subClassOf :CWE-74 ;
+    :cwe-id "CWE-91" .
+
+:CWE-93 a owl:Class ;
+    rdfs:label "Improper Neutralization of CRLF Sequences ('CRLF Injection')" ;
+    rdfs:subClassOf :CWE-74 ;
+    :cwe-id "CWE-93" .
+
 :CWE-94 a owl:Class ;
     rdfs:label "Improper Control of Generation of Code ('Code Injection')" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-74,
+        :CWE-913,
         [ a owl:Restriction ;
             owl:onProperty :may-be-weakness-of ;
             owl:someValuesFrom :EvalFunction ],
@@ -3344,99 +3715,1871 @@ Management servers with enterprise policies for account management provide the a
             owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-94" .
 
+:CWE-95 a owl:Class ;
+    rdfs:label "Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')" ;
+    rdfs:subClassOf :CWE-94 ;
+    :cwe-id "CWE-95" .
+
+:CWE-96 a owl:Class ;
+    rdfs:label "Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')" ;
+    rdfs:subClassOf :CWE-94 ;
+    :cwe-id "CWE-96" .
+
+:CWE-97 a owl:Class ;
+    rdfs:label "Improper Neutralization of Server-Side Includes (SSI) Within a Web Page" ;
+    rdfs:subClassOf :CWE-96 ;
+    :cwe-id "CWE-97" .
+
+:CWE-98 a owl:Class ;
+    rdfs:label "Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')" ;
+    rdfs:subClassOf :CWE-706,
+        :CWE-829 ;
+    :cwe-id "CWE-98" .
+
+:CWE-99 a owl:Class ;
+    rdfs:label "Improper Control of Resource Identifiers ('Resource Injection')" ;
+    rdfs:subClassOf :CWE-74 ;
+    :cwe-id "CWE-99" .
+
+:CWE-102 a owl:Class ;
+    rdfs:label "Struts: Duplicate Validation Forms" ;
+    rdfs:subClassOf :CWE-694,
+        :CWE-1173 ;
+    :cwe-id "CWE-102" .
+
+:CWE-103 a owl:Class ;
+    rdfs:label "Struts: Incomplete validate() Method Definition" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-103" .
+
+:CWE-104 a owl:Class ;
+    rdfs:label "Struts: Form Bean Does Not Extend Validation Class" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-104" .
+
+:CWE-105 a owl:Class ;
+    rdfs:label "Struts: Form Field Without Validator" ;
+    rdfs:subClassOf :CWE-1173 ;
+    :cwe-id "CWE-105" .
+
+:CWE-106 a owl:Class ;
+    rdfs:label "Struts: Plug-in Framework not in Use" ;
+    rdfs:subClassOf :CWE-1173 ;
+    :cwe-id "CWE-106" .
+
+:CWE-107 a owl:Class ;
+    rdfs:label "Struts: Unused Validation Form" ;
+    rdfs:subClassOf :CWE-1164 ;
+    :cwe-id "CWE-107" .
+
+:CWE-108 a owl:Class ;
+    rdfs:label "Struts: Unvalidated Action Form" ;
+    rdfs:subClassOf :CWE-1173 ;
+    :cwe-id "CWE-108" .
+
+:CWE-109 a owl:Class ;
+    rdfs:label "Struts: Validator Turned Off" ;
+    rdfs:subClassOf :CWE-1173 ;
+    :cwe-id "CWE-109" .
+
+:CWE-110 a owl:Class ;
+    rdfs:label "Struts: Validator Without Form Field" ;
+    rdfs:subClassOf :CWE-1164 ;
+    :cwe-id "CWE-110" .
+
+:CWE-111 a owl:Class ;
+    rdfs:label "Direct Use of Unsafe JNI" ;
+    rdfs:subClassOf :CWE-695 ;
+    :cwe-id "CWE-111" .
+
+:CWE-112 a owl:Class ;
+    rdfs:label "Missing XML Validation" ;
+    rdfs:subClassOf :CWE-1286 ;
+    :cwe-id "CWE-112" .
+
+:CWE-113 a owl:Class ;
+    rdfs:label "Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')" ;
+    rdfs:subClassOf :CWE-93,
+        :CWE-436 ;
+    :cwe-id "CWE-113" .
+
+:CWE-114 a owl:Class ;
+    rdfs:label "Process Control" ;
+    rdfs:subClassOf :CWE-73 ;
+    :cwe-id "CWE-114" .
+
+:CWE-115 a owl:Class ;
+    rdfs:label "Misinterpretation of Input" ;
+    rdfs:subClassOf :CWE-436 ;
+    :cwe-id "CWE-115" .
+
+:CWE-116 a owl:Class ;
+    rdfs:label "Improper Encoding or Escaping of Output" ;
+    rdfs:subClassOf :CWE-707 ;
+    :cwe-id "CWE-116" .
+
+:CWE-117 a owl:Class ;
+    rdfs:label "Improper Output Neutralization for Logs" ;
+    rdfs:subClassOf :CWE-116 ;
+    :cwe-id "CWE-117" .
+
+:CWE-118 a owl:Class ;
+    rdfs:label "Incorrect Access of Indexable Resource ('Range Error')" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-118" .
+
 :CWE-119 a owl:Class ;
     rdfs:label "Improper Restriction of Operations within the Bounds of a Memory Buffer" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-118,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :RawMemoryAccessFunction ] ;
     :cwe-id "CWE-119" .
 
+:CWE-120 a owl:Class ;
+    rdfs:label "Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-120" .
+
+:CWE-121 a owl:Class ;
+    rdfs:label "Stack-based Buffer Overflow" ;
+    rdfs:subClassOf :CWE-787,
+        :CWE-788 ;
+    :cwe-id "CWE-121" .
+
+:CWE-122 a owl:Class ;
+    rdfs:label "Heap-based Buffer Overflow" ;
+    rdfs:subClassOf :CWE-787,
+        :CWE-788 ;
+    :cwe-id "CWE-122" .
+
+:CWE-123 a owl:Class ;
+    rdfs:label "Write-what-where Condition" ;
+    rdfs:subClassOf :CWE-787 ;
+    :cwe-id "CWE-123" .
+
+:CWE-124 a owl:Class ;
+    rdfs:label "Buffer Underwrite ('Buffer Underflow')" ;
+    rdfs:subClassOf :CWE-786,
+        :CWE-787 ;
+    :cwe-id "CWE-124" .
+
 :CWE-125 a owl:Class ;
     rdfs:label "Out-of-bounds Read" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-119,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :RawMemoryAccessFunction ] ;
     :cwe-id "CWE-125" .
 
+:CWE-126 a owl:Class ;
+    rdfs:label "Buffer Over-read" ;
+    rdfs:subClassOf :CWE-125,
+        :CWE-788 ;
+    :cwe-id "CWE-126" .
+
+:CWE-127 a owl:Class ;
+    rdfs:label "Buffer Under-read" ;
+    rdfs:subClassOf :CWE-125,
+        :CWE-786 ;
+    :cwe-id "CWE-127" .
+
+:CWE-128 a owl:Class ;
+    rdfs:label "Wrap-around Error" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-128" .
+
+:CWE-129 a owl:Class ;
+    rdfs:label "Improper Validation of Array Index" ;
+    rdfs:subClassOf :CWE-1285 ;
+    :cwe-id "CWE-129" .
+
+:CWE-130 a owl:Class ;
+    rdfs:label "Improper Handling of Length Parameter Inconsistency" ;
+    rdfs:subClassOf :CWE-240 ;
+    :cwe-id "CWE-130" .
+
+:CWE-131 a owl:Class ;
+    rdfs:label "Incorrect Calculation of Buffer Size" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-131" .
+
+:CWE-134 a owl:Class ;
+    rdfs:label "Use of Externally-Controlled Format String" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-134" .
+
+:CWE-135 a owl:Class ;
+    rdfs:label "Incorrect Calculation of Multi-Byte String Length" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-135" .
+
+:CWE-138 a owl:Class ;
+    rdfs:label "Improper Neutralization of Special Elements" ;
+    rdfs:subClassOf :CWE-707 ;
+    :cwe-id "CWE-138" .
+
+:CWE-140 a owl:Class ;
+    rdfs:label "Improper Neutralization of Delimiters" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-140" .
+
+:CWE-141 a owl:Class ;
+    rdfs:label "Improper Neutralization of Parameter/Argument Delimiters" ;
+    rdfs:subClassOf :CWE-140 ;
+    :cwe-id "CWE-141" .
+
+:CWE-142 a owl:Class ;
+    rdfs:label "Improper Neutralization of Value Delimiters" ;
+    rdfs:subClassOf :CWE-140 ;
+    :cwe-id "CWE-142" .
+
+:CWE-143 a owl:Class ;
+    rdfs:label "Improper Neutralization of Record Delimiters" ;
+    rdfs:subClassOf :CWE-140 ;
+    :cwe-id "CWE-143" .
+
+:CWE-144 a owl:Class ;
+    rdfs:label "Improper Neutralization of Line Delimiters" ;
+    rdfs:subClassOf :CWE-140 ;
+    :cwe-id "CWE-144" .
+
+:CWE-145 a owl:Class ;
+    rdfs:label "Improper Neutralization of Section Delimiters" ;
+    rdfs:subClassOf :CWE-140 ;
+    :cwe-id "CWE-145" .
+
+:CWE-146 a owl:Class ;
+    rdfs:label "Improper Neutralization of Expression/Command Delimiters" ;
+    rdfs:subClassOf :CWE-140 ;
+    :cwe-id "CWE-146" .
+
+:CWE-147 a owl:Class ;
+    rdfs:label "Improper Neutralization of Input Terminators" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-147" .
+
+:CWE-148 a owl:Class ;
+    rdfs:label "Improper Neutralization of Input Leaders" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-148" .
+
+:CWE-149 a owl:Class ;
+    rdfs:label "Improper Neutralization of Quoting Syntax" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-149" .
+
+:CWE-150 a owl:Class ;
+    rdfs:label "Improper Neutralization of Escape, Meta, or Control Sequences" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-150" .
+
+:CWE-151 a owl:Class ;
+    rdfs:label "Improper Neutralization of Comment Delimiters" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-151" .
+
+:CWE-152 a owl:Class ;
+    rdfs:label "Improper Neutralization of Macro Symbols" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-152" .
+
+:CWE-153 a owl:Class ;
+    rdfs:label "Improper Neutralization of Substitution Characters" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-153" .
+
+:CWE-154 a owl:Class ;
+    rdfs:label "Improper Neutralization of Variable Name Delimiters" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-154" .
+
+:CWE-155 a owl:Class ;
+    rdfs:label "Improper Neutralization of Wildcards or Matching Symbols" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-155" .
+
+:CWE-156 a owl:Class ;
+    rdfs:label "Improper Neutralization of Whitespace" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-156" .
+
+:CWE-157 a owl:Class ;
+    rdfs:label "Failure to Sanitize Paired Delimiters" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-157" .
+
+:CWE-158 a owl:Class ;
+    rdfs:label "Improper Neutralization of Null Byte or NUL Character" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-158" .
+
+:CWE-159 a owl:Class ;
+    rdfs:label "Improper Handling of Invalid Use of Special Elements" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-159" .
+
+:CWE-160 a owl:Class ;
+    rdfs:label "Improper Neutralization of Leading Special Elements" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-160" .
+
+:CWE-161 a owl:Class ;
+    rdfs:label "Improper Neutralization of Multiple Leading Special Elements" ;
+    rdfs:subClassOf :CWE-160 ;
+    :cwe-id "CWE-161" .
+
+:CWE-162 a owl:Class ;
+    rdfs:label "Improper Neutralization of Trailing Special Elements" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-162" .
+
+:CWE-163 a owl:Class ;
+    rdfs:label "Improper Neutralization of Multiple Trailing Special Elements" ;
+    rdfs:subClassOf :CWE-162 ;
+    :cwe-id "CWE-163" .
+
+:CWE-164 a owl:Class ;
+    rdfs:label "Improper Neutralization of Internal Special Elements" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-164" .
+
+:CWE-165 a owl:Class ;
+    rdfs:label "Improper Neutralization of Multiple Internal Special Elements" ;
+    rdfs:subClassOf :CWE-164 ;
+    :cwe-id "CWE-165" .
+
+:CWE-166 a owl:Class ;
+    rdfs:label "Improper Handling of Missing Special Element" ;
+    rdfs:subClassOf :CWE-159,
+        :CWE-703 ;
+    :cwe-id "CWE-166" .
+
+:CWE-167 a owl:Class ;
+    rdfs:label "Improper Handling of Additional Special Element" ;
+    rdfs:subClassOf :CWE-159,
+        :CWE-703 ;
+    :cwe-id "CWE-167" .
+
+:CWE-168 a owl:Class ;
+    rdfs:label "Improper Handling of Inconsistent Special Elements" ;
+    rdfs:subClassOf :CWE-159,
+        :CWE-703 ;
+    :cwe-id "CWE-168" .
+
+:CWE-170 a owl:Class ;
+    rdfs:label "Improper Null Termination" ;
+    rdfs:subClassOf :CWE-707 ;
+    :cwe-id "CWE-170" .
+
+:CWE-172 a owl:Class ;
+    rdfs:label "Encoding Error" ;
+    rdfs:subClassOf :CWE-707 ;
+    :cwe-id "CWE-172" .
+
+:CWE-173 a owl:Class ;
+    rdfs:label "Improper Handling of Alternate Encoding" ;
+    rdfs:subClassOf :CWE-172 ;
+    :cwe-id "CWE-173" .
+
+:CWE-174 a owl:Class ;
+    rdfs:label "Double Decoding of the Same Data" ;
+    rdfs:subClassOf :CWE-172,
+        :CWE-675 ;
+    :cwe-id "CWE-174" .
+
+:CWE-175 a owl:Class ;
+    rdfs:label "Improper Handling of Mixed Encoding" ;
+    rdfs:subClassOf :CWE-172 ;
+    :cwe-id "CWE-175" .
+
+:CWE-176 a owl:Class ;
+    rdfs:label "Improper Handling of Unicode Encoding" ;
+    rdfs:subClassOf :CWE-172 ;
+    :cwe-id "CWE-176" .
+
+:CWE-177 a owl:Class ;
+    rdfs:label "Improper Handling of URL Encoding (Hex Encoding)" ;
+    rdfs:subClassOf :CWE-172 ;
+    :cwe-id "CWE-177" .
+
+:CWE-178 a owl:Class ;
+    rdfs:label "Improper Handling of Case Sensitivity" ;
+    rdfs:subClassOf :CWE-706 ;
+    :cwe-id "CWE-178" .
+
+:CWE-179 a owl:Class ;
+    rdfs:label "Incorrect Behavior Order: Early Validation" ;
+    rdfs:subClassOf :CWE-20,
+        :CWE-696 ;
+    :cwe-id "CWE-179" .
+
+:CWE-180 a owl:Class ;
+    rdfs:label "Incorrect Behavior Order: Validate Before Canonicalize" ;
+    rdfs:subClassOf :CWE-179 ;
+    :cwe-id "CWE-180" .
+
+:CWE-181 a owl:Class ;
+    rdfs:label "Incorrect Behavior Order: Validate Before Filter" ;
+    rdfs:subClassOf :CWE-179 ;
+    :cwe-id "CWE-181" .
+
+:CWE-182 a owl:Class ;
+    rdfs:label "Collapse of Data into Unsafe Value" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-182" .
+
+:CWE-183 a owl:Class ;
+    rdfs:label "Permissive List of Allowed Inputs" ;
+    rdfs:subClassOf :CWE-697 ;
+    :cwe-id "CWE-183" .
+
+:CWE-184 a owl:Class ;
+    rdfs:label "Incomplete List of Disallowed Inputs" ;
+    rdfs:subClassOf :CWE-693,
+        :CWE-1023 ;
+    :cwe-id "CWE-184" .
+
+:CWE-185 a owl:Class ;
+    rdfs:label "Incorrect Regular Expression" ;
+    rdfs:subClassOf :CWE-697 ;
+    :cwe-id "CWE-185" .
+
+:CWE-186 a owl:Class ;
+    rdfs:label "Overly Restrictive Regular Expression" ;
+    rdfs:subClassOf :CWE-185 ;
+    :cwe-id "CWE-186" .
+
+:CWE-187 a owl:Class ;
+    rdfs:label "Partial String Comparison" ;
+    rdfs:subClassOf :CWE-1023 ;
+    :cwe-id "CWE-187" .
+
+:CWE-188 a owl:Class ;
+    rdfs:label "Reliance on Data/Memory Layout" ;
+    rdfs:subClassOf :CWE-435,
+        :CWE-1105 ;
+    :cwe-id "CWE-188" .
+
 :CWE-190 a owl:Class ;
     rdfs:label "Integer Overflow or Wraparound" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-682,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :MathematicalFunction ] ;
     :cwe-id "CWE-190" .
 
+:CWE-191 a owl:Class ;
+    rdfs:label "Integer Underflow (Wrap or Wraparound)" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-191" .
+
+:CWE-192 a owl:Class ;
+    rdfs:label "Integer Coercion Error" ;
+    rdfs:subClassOf :CWE-681 ;
+    :cwe-id "CWE-192" .
+
+:CWE-193 a owl:Class ;
+    rdfs:label "Off-by-one Error" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-193" .
+
+:CWE-194 a owl:Class ;
+    rdfs:label "Unexpected Sign Extension" ;
+    rdfs:subClassOf :CWE-681 ;
+    :cwe-id "CWE-194" .
+
+:CWE-195 a owl:Class ;
+    rdfs:label "Signed to Unsigned Conversion Error" ;
+    rdfs:subClassOf :CWE-681 ;
+    :cwe-id "CWE-195" .
+
+:CWE-196 a owl:Class ;
+    rdfs:label "Unsigned to Signed Conversion Error" ;
+    rdfs:subClassOf :CWE-681 ;
+    :cwe-id "CWE-196" .
+
+:CWE-197 a owl:Class ;
+    rdfs:label "Numeric Truncation Error" ;
+    rdfs:subClassOf :CWE-681 ;
+    :cwe-id "CWE-197" .
+
+:CWE-198 a owl:Class ;
+    rdfs:label "Use of Incorrect Byte Ordering" ;
+    rdfs:subClassOf :CWE-188 ;
+    :cwe-id "CWE-198" .
+
+:CWE-200 a owl:Class ;
+    rdfs:label "Exposure of Sensitive Information to an Unauthorized Actor" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-200" .
+
+:CWE-201 a owl:Class ;
+    rdfs:label "Insertion of Sensitive Information Into Sent Data" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-201" .
+
+:CWE-202 a owl:Class ;
+    rdfs:label "Exposure of Sensitive Information Through Data Queries" ;
+    rdfs:subClassOf :CWE-1230 ;
+    :cwe-id "CWE-202" .
+
+:CWE-203 a owl:Class ;
+    rdfs:label "Observable Discrepancy" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-203" .
+
+:CWE-204 a owl:Class ;
+    rdfs:label "Observable Response Discrepancy" ;
+    rdfs:subClassOf :CWE-203 ;
+    :cwe-id "CWE-204" .
+
+:CWE-205 a owl:Class ;
+    rdfs:label "Observable Behavioral Discrepancy" ;
+    rdfs:subClassOf :CWE-203 ;
+    :cwe-id "CWE-205" .
+
+:CWE-206 a owl:Class ;
+    rdfs:label "Observable Internal Behavioral Discrepancy" ;
+    rdfs:subClassOf :CWE-205 ;
+    :cwe-id "CWE-206" .
+
+:CWE-207 a owl:Class ;
+    rdfs:label "Observable Behavioral Discrepancy With Equivalent Products" ;
+    rdfs:subClassOf :CWE-205 ;
+    :cwe-id "CWE-207" .
+
+:CWE-208 a owl:Class ;
+    rdfs:label "Observable Timing Discrepancy" ;
+    rdfs:subClassOf :CWE-203 ;
+    :cwe-id "CWE-208" .
+
+:CWE-209 a owl:Class ;
+    rdfs:label "Generation of Error Message Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-200,
+        :CWE-755 ;
+    :cwe-id "CWE-209" .
+
+:CWE-210 a owl:Class ;
+    rdfs:label "Self-generated Error Message Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-209 ;
+    :cwe-id "CWE-210" .
+
+:CWE-211 a owl:Class ;
+    rdfs:label "Externally-Generated Error Message Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-209 ;
+    :cwe-id "CWE-211" .
+
+:CWE-212 a owl:Class ;
+    rdfs:label "Improper Removal of Sensitive Information Before Storage or Transfer" ;
+    rdfs:subClassOf :CWE-669 ;
+    :cwe-id "CWE-212" .
+
+:CWE-213 a owl:Class ;
+    rdfs:label "Exposure of Sensitive Information Due to Incompatible Policies" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-213" .
+
+:CWE-214 a owl:Class ;
+    rdfs:label "Invocation of Process Using Visible Sensitive Information" ;
+    rdfs:subClassOf :CWE-497 ;
+    :cwe-id "CWE-214" .
+
+:CWE-215 a owl:Class ;
+    rdfs:label "Insertion of Sensitive Information Into Debugging Code" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-215" .
+
+:CWE-219 a owl:Class ;
+    rdfs:label "Storage of File with Sensitive Data Under Web Root" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-219" .
+
+:CWE-220 a owl:Class ;
+    rdfs:label "Storage of File With Sensitive Data Under FTP Root" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-220" .
+
+:CWE-221 a owl:Class ;
+    rdfs:label "Information Loss or Omission" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-221" .
+
+:CWE-222 a owl:Class ;
+    rdfs:label "Truncation of Security-relevant Information" ;
+    rdfs:subClassOf :CWE-221 ;
+    :cwe-id "CWE-222" .
+
+:CWE-223 a owl:Class ;
+    rdfs:label "Omission of Security-relevant Information" ;
+    rdfs:subClassOf :CWE-221 ;
+    :cwe-id "CWE-223" .
+
+:CWE-224 a owl:Class ;
+    rdfs:label "Obscured Security-relevant Information by Alternate Name" ;
+    rdfs:subClassOf :CWE-221 ;
+    :cwe-id "CWE-224" .
+
+:CWE-226 a owl:Class ;
+    rdfs:label "Sensitive Information in Resource Not Removed Before Reuse" ;
+    rdfs:subClassOf :CWE-212,
+        :CWE-459 ;
+    :cwe-id "CWE-226" .
+
+:CWE-228 a owl:Class ;
+    rdfs:label "Improper Handling of Syntactically Invalid Structure" ;
+    rdfs:subClassOf :CWE-703,
+        :CWE-707 ;
+    :cwe-id "CWE-228" .
+
+:CWE-229 a owl:Class ;
+    rdfs:label "Improper Handling of Values" ;
+    rdfs:subClassOf :CWE-228 ;
+    :cwe-id "CWE-229" .
+
+:CWE-230 a owl:Class ;
+    rdfs:label "Improper Handling of Missing Values" ;
+    rdfs:subClassOf :CWE-229 ;
+    :cwe-id "CWE-230" .
+
+:CWE-231 a owl:Class ;
+    rdfs:label "Improper Handling of Extra Values" ;
+    rdfs:subClassOf :CWE-229 ;
+    :cwe-id "CWE-231" .
+
+:CWE-232 a owl:Class ;
+    rdfs:label "Improper Handling of Undefined Values" ;
+    rdfs:subClassOf :CWE-229 ;
+    :cwe-id "CWE-232" .
+
+:CWE-233 a owl:Class ;
+    rdfs:label "Improper Handling of Parameters" ;
+    rdfs:subClassOf :CWE-228 ;
+    :cwe-id "CWE-233" .
+
+:CWE-234 a owl:Class ;
+    rdfs:label "Failure to Handle Missing Parameter" ;
+    rdfs:subClassOf :CWE-233 ;
+    :cwe-id "CWE-234" .
+
+:CWE-235 a owl:Class ;
+    rdfs:label "Improper Handling of Extra Parameters" ;
+    rdfs:subClassOf :CWE-233 ;
+    :cwe-id "CWE-235" .
+
+:CWE-236 a owl:Class ;
+    rdfs:label "Improper Handling of Undefined Parameters" ;
+    rdfs:subClassOf :CWE-233 ;
+    :cwe-id "CWE-236" .
+
+:CWE-237 a owl:Class ;
+    rdfs:label "Improper Handling of Structural Elements" ;
+    rdfs:subClassOf :CWE-228 ;
+    :cwe-id "CWE-237" .
+
+:CWE-238 a owl:Class ;
+    rdfs:label "Improper Handling of Incomplete Structural Elements" ;
+    rdfs:subClassOf :CWE-237 ;
+    :cwe-id "CWE-238" .
+
+:CWE-239 a owl:Class ;
+    rdfs:label "Failure to Handle Incomplete Element" ;
+    rdfs:subClassOf :CWE-237 ;
+    :cwe-id "CWE-239" .
+
+:CWE-240 a owl:Class ;
+    rdfs:label "Improper Handling of Inconsistent Structural Elements" ;
+    rdfs:subClassOf :CWE-237,
+        :CWE-707 ;
+    :cwe-id "CWE-240" .
+
+:CWE-241 a owl:Class ;
+    rdfs:label "Improper Handling of Unexpected Data Type" ;
+    rdfs:subClassOf :CWE-228 ;
+    :cwe-id "CWE-241" .
+
+:CWE-242 a owl:Class ;
+    rdfs:label "Use of Inherently Dangerous Function" ;
+    rdfs:subClassOf :CWE-1177 ;
+    :cwe-id "CWE-242" .
+
+:CWE-243 a owl:Class ;
+    rdfs:label "Creation of chroot Jail Without Changing Working Directory" ;
+    rdfs:subClassOf :CWE-573,
+        :CWE-669 ;
+    :cwe-id "CWE-243" .
+
+:CWE-244 a owl:Class ;
+    rdfs:label "Improper Clearing of Heap Memory Before Release ('Heap Inspection')" ;
+    rdfs:subClassOf :CWE-226 ;
+    :cwe-id "CWE-244" .
+
+:CWE-245 a owl:Class ;
+    rdfs:label "J2EE Bad Practices: Direct Management of Connections" ;
+    rdfs:subClassOf :CWE-695 ;
+    :cwe-id "CWE-245" .
+
+:CWE-246 a owl:Class ;
+    rdfs:label "J2EE Bad Practices: Direct Use of Sockets" ;
+    rdfs:subClassOf :CWE-695 ;
+    :cwe-id "CWE-246" .
+
+:CWE-248 a owl:Class ;
+    rdfs:label "Uncaught Exception" ;
+    rdfs:subClassOf :CWE-703,
+        :CWE-705 ;
+    :cwe-id "CWE-248" .
+
+:CWE-250 a owl:Class ;
+    rdfs:label "Execution with Unnecessary Privileges" ;
+    rdfs:subClassOf :CWE-269,
+        :CWE-657 ;
+    :cwe-id "CWE-250" .
+
+:CWE-252 a owl:Class ;
+    rdfs:label "Unchecked Return Value" ;
+    rdfs:subClassOf :CWE-754 ;
+    :cwe-id "CWE-252" .
+
+:CWE-253 a owl:Class ;
+    rdfs:label "Incorrect Check of Function Return Value" ;
+    rdfs:subClassOf :CWE-573,
+        :CWE-754 ;
+    :cwe-id "CWE-253" .
+
+:CWE-256 a owl:Class ;
+    rdfs:label "Plaintext Storage of a Password" ;
+    rdfs:subClassOf :CWE-522 ;
+    :cwe-id "CWE-256" .
+
+:CWE-257 a owl:Class ;
+    rdfs:label "Storing Passwords in a Recoverable Format" ;
+    rdfs:subClassOf :CWE-522 ;
+    :cwe-id "CWE-257" .
+
+:CWE-258 a owl:Class ;
+    rdfs:label "Empty Password in Configuration File" ;
+    rdfs:subClassOf :CWE-260,
+        :CWE-521 ;
+    :cwe-id "CWE-258" .
+
+:CWE-259 a owl:Class ;
+    rdfs:label "Use of Hard-coded Password" ;
+    rdfs:subClassOf :CWE-798 ;
+    :cwe-id "CWE-259" .
+
+:CWE-260 a owl:Class ;
+    rdfs:label "Password in Configuration File" ;
+    rdfs:subClassOf :CWE-522 ;
+    :cwe-id "CWE-260" .
+
+:CWE-261 a owl:Class ;
+    rdfs:label "Weak Encoding for Password" ;
+    rdfs:subClassOf :CWE-522 ;
+    :cwe-id "CWE-261" .
+
+:CWE-262 a owl:Class ;
+    rdfs:label "Not Using Password Aging" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-262" .
+
+:CWE-263 a owl:Class ;
+    rdfs:label "Password Aging with Long Expiration" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-263" .
+
+:CWE-266 a owl:Class ;
+    rdfs:label "Incorrect Privilege Assignment" ;
+    rdfs:subClassOf :CWE-269 ;
+    :cwe-id "CWE-266" .
+
+:CWE-267 a owl:Class ;
+    rdfs:label "Privilege Defined With Unsafe Actions" ;
+    rdfs:subClassOf :CWE-269 ;
+    :cwe-id "CWE-267" .
+
+:CWE-268 a owl:Class ;
+    rdfs:label "Privilege Chaining" ;
+    rdfs:subClassOf :CWE-269 ;
+    :cwe-id "CWE-268" .
+
+:CWE-269 a owl:Class ;
+    rdfs:label "Improper Privilege Management" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-269" .
+
+:CWE-270 a owl:Class ;
+    rdfs:label "Privilege Context Switching Error" ;
+    rdfs:subClassOf :CWE-269 ;
+    :cwe-id "CWE-270" .
+
+:CWE-271 a owl:Class ;
+    rdfs:label "Privilege Dropping / Lowering Errors" ;
+    rdfs:subClassOf :CWE-269 ;
+    :cwe-id "CWE-271" .
+
+:CWE-272 a owl:Class ;
+    rdfs:label "Least Privilege Violation" ;
+    rdfs:subClassOf :CWE-271 ;
+    :cwe-id "CWE-272" .
+
+:CWE-273 a owl:Class ;
+    rdfs:label "Improper Check for Dropped Privileges" ;
+    rdfs:subClassOf :CWE-271,
+        :CWE-754 ;
+    :cwe-id "CWE-273" .
+
+:CWE-274 a owl:Class ;
+    rdfs:label "Improper Handling of Insufficient Privileges" ;
+    rdfs:subClassOf :CWE-269,
+        :CWE-755 ;
+    :cwe-id "CWE-274" .
+
 :CWE-276 a owl:Class ;
     rdfs:label "Incorrect Default Permissions" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-732,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :ApplicationInstaller ] ;
     :cwe-id "CWE-276" .
 
+:CWE-277 a owl:Class ;
+    rdfs:label "Insecure Inherited Permissions" ;
+    rdfs:subClassOf :CWE-732 ;
+    :cwe-id "CWE-277" .
+
+:CWE-278 a owl:Class ;
+    rdfs:label "Insecure Preserved Inherited Permissions" ;
+    rdfs:subClassOf :CWE-732 ;
+    :cwe-id "CWE-278" .
+
+:CWE-279 a owl:Class ;
+    rdfs:label "Incorrect Execution-Assigned Permissions" ;
+    rdfs:subClassOf :CWE-732 ;
+    :cwe-id "CWE-279" .
+
+:CWE-280 a owl:Class ;
+    rdfs:label "Improper Handling of Insufficient Permissions or Privileges " ;
+    rdfs:subClassOf :CWE-755 ;
+    :cwe-id "CWE-280" .
+
+:CWE-281 a owl:Class ;
+    rdfs:label "Improper Preservation of Permissions" ;
+    rdfs:subClassOf :CWE-732 ;
+    :cwe-id "CWE-281" .
+
+:CWE-282 a owl:Class ;
+    rdfs:label "Improper Ownership Management" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-282" .
+
+:CWE-283 a owl:Class ;
+    rdfs:label "Unverified Ownership" ;
+    rdfs:subClassOf :CWE-282 ;
+    :cwe-id "CWE-283" .
+
+:CWE-284 a owl:Class ;
+    rdfs:label "Improper Access Control" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-284" .
+
+:CWE-285 a owl:Class ;
+    rdfs:label "Improper Authorization" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-285" .
+
+:CWE-286 a owl:Class ;
+    rdfs:label "Incorrect User Management" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-286" .
+
 :CWE-287 a owl:Class ;
     rdfs:label "Improper Authentication" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-284,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :AuthenticationFunction ] ;
     :cwe-id "CWE-287" .
 
+:CWE-288 a owl:Class ;
+    rdfs:label "Authentication Bypass Using an Alternate Path or Channel" ;
+    rdfs:subClassOf :CWE-306 ;
+    :cwe-id "CWE-288" .
+
+:CWE-289 a owl:Class ;
+    rdfs:label "Authentication Bypass by Alternate Name" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-289" .
+
+:CWE-290 a owl:Class ;
+    rdfs:label "Authentication Bypass by Spoofing" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-290" .
+
+:CWE-291 a owl:Class ;
+    rdfs:label "Reliance on IP Address for Authentication" ;
+    rdfs:subClassOf :CWE-290,
+        :CWE-471,
+        :CWE-923 ;
+    :cwe-id "CWE-291" .
+
+:CWE-293 a owl:Class ;
+    rdfs:label "Using Referer Field for Authentication" ;
+    rdfs:subClassOf :CWE-290 ;
+    :cwe-id "CWE-293" .
+
+:CWE-294 a owl:Class ;
+    rdfs:label "Authentication Bypass by Capture-replay" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-294" .
+
+:CWE-295 a owl:Class ;
+    rdfs:label "Improper Certificate Validation" ;
+    rdfs:subClassOf :CWE-287 ;
+    :cwe-id "CWE-295" .
+
+:CWE-296 a owl:Class ;
+    rdfs:label "Improper Following of a Certificate's Chain of Trust" ;
+    rdfs:subClassOf :CWE-295,
+        :CWE-573 ;
+    :cwe-id "CWE-296" .
+
+:CWE-297 a owl:Class ;
+    rdfs:label "Improper Validation of Certificate with Host Mismatch" ;
+    rdfs:subClassOf :CWE-295,
+        :CWE-923 ;
+    :cwe-id "CWE-297" .
+
+:CWE-298 a owl:Class ;
+    rdfs:label "Improper Validation of Certificate Expiration" ;
+    rdfs:subClassOf :CWE-295,
+        :CWE-672 ;
+    :cwe-id "CWE-298" .
+
+:CWE-299 a owl:Class ;
+    rdfs:label "Improper Check for Certificate Revocation" ;
+    rdfs:subClassOf :CWE-295,
+        :CWE-404 ;
+    :cwe-id "CWE-299" .
+
+:CWE-300 a owl:Class ;
+    rdfs:label "Channel Accessible by Non-Endpoint" ;
+    rdfs:subClassOf :CWE-923 ;
+    :cwe-id "CWE-300" .
+
+:CWE-301 a owl:Class ;
+    rdfs:label "Reflection Attack in an Authentication Protocol" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-301" .
+
+:CWE-302 a owl:Class ;
+    rdfs:label "Authentication Bypass by Assumed-Immutable Data" ;
+    rdfs:subClassOf :CWE-807,
+        :CWE-1390 ;
+    :cwe-id "CWE-302" .
+
+:CWE-303 a owl:Class ;
+    rdfs:label "Incorrect Implementation of Authentication Algorithm" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-303" .
+
+:CWE-304 a owl:Class ;
+    rdfs:label "Missing Critical Step in Authentication" ;
+    rdfs:subClassOf :CWE-303,
+        :CWE-573 ;
+    :cwe-id "CWE-304" .
+
+:CWE-305 a owl:Class ;
+    rdfs:label "Authentication Bypass by Primary Weakness" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-305" .
+
 :CWE-306 a owl:Class ;
     rdfs:label "Missing Authentication for Critical Function" ;
-    rdfs:subClassOf :Weakness ;
+    rdfs:subClassOf :CWE-287 ;
     :comment "Too broad to map to digital artifacts as it could consume any resource." ;
     :cwe-id "CWE-306" .
 
+:CWE-307 a owl:Class ;
+    rdfs:label "Improper Restriction of Excessive Authentication Attempts" ;
+    rdfs:subClassOf :CWE-799,
+        :CWE-1390 ;
+    :cwe-id "CWE-307" .
+
+:CWE-308 a owl:Class ;
+    rdfs:label "Use of Single-factor Authentication" ;
+    rdfs:subClassOf :CWE-654,
+        :CWE-1390 ;
+    :cwe-id "CWE-308" .
+
+:CWE-309 a owl:Class ;
+    rdfs:label "Use of Password System for Primary Authentication" ;
+    rdfs:subClassOf :CWE-654,
+        :CWE-1390 ;
+    :cwe-id "CWE-309" .
+
+:CWE-311 a owl:Class ;
+    rdfs:label "Missing Encryption of Sensitive Data" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-311" .
+
+:CWE-312 a owl:Class ;
+    rdfs:label "Cleartext Storage of Sensitive Information" ;
+    rdfs:subClassOf :CWE-311,
+        :CWE-922 ;
+    :cwe-id "CWE-312" .
+
+:CWE-313 a owl:Class ;
+    rdfs:label "Cleartext Storage in a File or on Disk" ;
+    rdfs:subClassOf :CWE-312 ;
+    :cwe-id "CWE-313" .
+
+:CWE-314 a owl:Class ;
+    rdfs:label "Cleartext Storage in the Registry" ;
+    rdfs:subClassOf :CWE-312 ;
+    :cwe-id "CWE-314" .
+
+:CWE-315 a owl:Class ;
+    rdfs:label "Cleartext Storage of Sensitive Information in a Cookie" ;
+    rdfs:subClassOf :CWE-312 ;
+    :cwe-id "CWE-315" .
+
+:CWE-316 a owl:Class ;
+    rdfs:label "Cleartext Storage of Sensitive Information in Memory" ;
+    rdfs:subClassOf :CWE-312 ;
+    :cwe-id "CWE-316" .
+
+:CWE-317 a owl:Class ;
+    rdfs:label "Cleartext Storage of Sensitive Information in GUI" ;
+    rdfs:subClassOf :CWE-312 ;
+    :cwe-id "CWE-317" .
+
+:CWE-318 a owl:Class ;
+    rdfs:label "Cleartext Storage of Sensitive Information in Executable" ;
+    rdfs:subClassOf :CWE-312 ;
+    :cwe-id "CWE-318" .
+
+:CWE-319 a owl:Class ;
+    rdfs:label "Cleartext Transmission of Sensitive Information" ;
+    rdfs:subClassOf :CWE-311 ;
+    :cwe-id "CWE-319" .
+
+:CWE-321 a owl:Class ;
+    rdfs:label "Use of Hard-coded Cryptographic Key" ;
+    rdfs:subClassOf :CWE-798 ;
+    :cwe-id "CWE-321" .
+
+:CWE-322 a owl:Class ;
+    rdfs:label "Key Exchange without Entity Authentication" ;
+    rdfs:subClassOf :CWE-306 ;
+    :cwe-id "CWE-322" .
+
+:CWE-323 a owl:Class ;
+    rdfs:label "Reusing a Nonce, Key Pair in Encryption" ;
+    rdfs:subClassOf :CWE-344 ;
+    :cwe-id "CWE-323" .
+
+:CWE-324 a owl:Class ;
+    rdfs:label "Use of a Key Past its Expiration Date" ;
+    rdfs:subClassOf :CWE-672 ;
+    :cwe-id "CWE-324" .
+
+:CWE-325 a owl:Class ;
+    rdfs:label "Missing Cryptographic Step" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-325" .
+
+:CWE-326 a owl:Class ;
+    rdfs:label "Inadequate Encryption Strength" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-326" .
+
+:CWE-327 a owl:Class ;
+    rdfs:label "Use of a Broken or Risky Cryptographic Algorithm" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-327" .
+
+:CWE-328 a owl:Class ;
+    rdfs:label "Use of Weak Hash" ;
+    rdfs:subClassOf :CWE-326,
+        :CWE-327 ;
+    :cwe-id "CWE-328" .
+
+:CWE-329 a owl:Class ;
+    rdfs:label "Generation of Predictable IV with CBC Mode" ;
+    rdfs:subClassOf :CWE-573,
+        :CWE-1204 ;
+    :cwe-id "CWE-329" .
+
+:CWE-330 a owl:Class ;
+    rdfs:label "Use of Insufficiently Random Values" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-330" .
+
+:CWE-331 a owl:Class ;
+    rdfs:label "Insufficient Entropy" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-331" .
+
+:CWE-332 a owl:Class ;
+    rdfs:label "Insufficient Entropy in PRNG" ;
+    rdfs:subClassOf :CWE-331 ;
+    :cwe-id "CWE-332" .
+
+:CWE-333 a owl:Class ;
+    rdfs:label "Improper Handling of Insufficient Entropy in TRNG" ;
+    rdfs:subClassOf :CWE-331,
+        :CWE-703 ;
+    :cwe-id "CWE-333" .
+
+:CWE-334 a owl:Class ;
+    rdfs:label "Small Space of Random Values" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-334" .
+
+:CWE-335 a owl:Class ;
+    rdfs:label "Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-335" .
+
+:CWE-336 a owl:Class ;
+    rdfs:label "Same Seed in Pseudo-Random Number Generator (PRNG)" ;
+    rdfs:subClassOf :CWE-335 ;
+    :cwe-id "CWE-336" .
+
+:CWE-337 a owl:Class ;
+    rdfs:label "Predictable Seed in Pseudo-Random Number Generator (PRNG)" ;
+    rdfs:subClassOf :CWE-335 ;
+    :cwe-id "CWE-337" .
+
+:CWE-338 a owl:Class ;
+    rdfs:label "Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-338" .
+
+:CWE-339 a owl:Class ;
+    rdfs:label "Small Seed Space in PRNG" ;
+    rdfs:subClassOf :CWE-335 ;
+    :cwe-id "CWE-339" .
+
+:CWE-340 a owl:Class ;
+    rdfs:label "Generation of Predictable Numbers or Identifiers" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-340" .
+
+:CWE-341 a owl:Class ;
+    rdfs:label "Predictable from Observable State" ;
+    rdfs:subClassOf :CWE-340 ;
+    :cwe-id "CWE-341" .
+
+:CWE-342 a owl:Class ;
+    rdfs:label "Predictable Exact Value from Previous Values" ;
+    rdfs:subClassOf :CWE-340 ;
+    :cwe-id "CWE-342" .
+
+:CWE-343 a owl:Class ;
+    rdfs:label "Predictable Value Range from Previous Values" ;
+    rdfs:subClassOf :CWE-340 ;
+    :cwe-id "CWE-343" .
+
+:CWE-344 a owl:Class ;
+    rdfs:label "Use of Invariant Value in Dynamically Changing Context" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-344" .
+
+:CWE-345 a owl:Class ;
+    rdfs:label "Insufficient Verification of Data Authenticity" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-345" .
+
+:CWE-346 a owl:Class ;
+    rdfs:label "Origin Validation Error" ;
+    rdfs:subClassOf :CWE-284,
+        :CWE-345 ;
+    :cwe-id "CWE-346" .
+
+:CWE-347 a owl:Class ;
+    rdfs:label "Improper Verification of Cryptographic Signature" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-347" .
+
+:CWE-348 a owl:Class ;
+    rdfs:label "Use of Less Trusted Source" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-348" .
+
+:CWE-349 a owl:Class ;
+    rdfs:label "Acceptance of Extraneous Untrusted Data With Trusted Data" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-349" .
+
+:CWE-350 a owl:Class ;
+    rdfs:label "Reliance on Reverse DNS Resolution for a Security-Critical Action" ;
+    rdfs:subClassOf :CWE-290,
+        :CWE-807 ;
+    :cwe-id "CWE-350" .
+
+:CWE-351 a owl:Class ;
+    rdfs:label "Insufficient Type Distinction" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-351" .
+
 :CWE-352 a owl:Class ;
     rdfs:label "Cross-Site Request Forgery (CSRF)" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-345,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-352" .
 
+:CWE-353 a owl:Class ;
+    rdfs:label "Missing Support for Integrity Check" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-353" .
+
+:CWE-354 a owl:Class ;
+    rdfs:label "Improper Validation of Integrity Check Value" ;
+    rdfs:subClassOf :CWE-345,
+        :CWE-754 ;
+    :cwe-id "CWE-354" .
+
+:CWE-356 a owl:Class ;
+    rdfs:label "Product UI does not Warn User of Unsafe Actions" ;
+    rdfs:subClassOf :CWE-221 ;
+    :cwe-id "CWE-356" .
+
+:CWE-357 a owl:Class ;
+    rdfs:label "Insufficient UI Warning of Dangerous Operations" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-357" .
+
+:CWE-358 a owl:Class ;
+    rdfs:label "Improperly Implemented Security Check for Standard" ;
+    rdfs:subClassOf :CWE-573,
+        :CWE-693 ;
+    :cwe-id "CWE-358" .
+
+:CWE-359 a owl:Class ;
+    rdfs:label "Exposure of Private Personal Information to an Unauthorized Actor" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-359" .
+
+:CWE-360 a owl:Class ;
+    rdfs:label "Trust of System Event Data" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-360" .
+
 :CWE-362 a owl:Class ;
     rdfs:label "Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-691,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :SharedResourceAccessFunction ] ;
     :cwe-id "CWE-362" .
 
+:CWE-363 a owl:Class ;
+    rdfs:label "Race Condition Enabling Link Following" ;
+    rdfs:subClassOf :CWE-367 ;
+    :cwe-id "CWE-363" .
+
+:CWE-364 a owl:Class ;
+    rdfs:label "Signal Handler Race Condition" ;
+    rdfs:subClassOf :CWE-362 ;
+    :cwe-id "CWE-364" .
+
+:CWE-366 a owl:Class ;
+    rdfs:label "Race Condition within a Thread" ;
+    rdfs:subClassOf :CWE-362 ;
+    :cwe-id "CWE-366" .
+
+:CWE-367 a owl:Class ;
+    rdfs:label "Time-of-check Time-of-use (TOCTOU) Race Condition" ;
+    rdfs:subClassOf :CWE-362 ;
+    :cwe-id "CWE-367" .
+
+:CWE-368 a owl:Class ;
+    rdfs:label "Context Switching Race Condition" ;
+    rdfs:subClassOf :CWE-362 ;
+    :cwe-id "CWE-368" .
+
+:CWE-369 a owl:Class ;
+    rdfs:label "Divide By Zero" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-369" .
+
+:CWE-370 a owl:Class ;
+    rdfs:label "Missing Check for Certificate Revocation after Initial Check" ;
+    rdfs:subClassOf :CWE-299 ;
+    :cwe-id "CWE-370" .
+
+:CWE-372 a owl:Class ;
+    rdfs:label "Incomplete Internal State Distinction" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-372" .
+
+:CWE-374 a owl:Class ;
+    rdfs:label "Passing Mutable Objects to an Untrusted Method" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-374" .
+
+:CWE-375 a owl:Class ;
+    rdfs:label "Returning a Mutable Object to an Untrusted Caller" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-375" .
+
+:CWE-377 a owl:Class ;
+    rdfs:label "Insecure Temporary File" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-377" .
+
+:CWE-378 a owl:Class ;
+    rdfs:label "Creation of Temporary File With Insecure Permissions" ;
+    rdfs:subClassOf :CWE-377 ;
+    :cwe-id "CWE-378" .
+
+:CWE-379 a owl:Class ;
+    rdfs:label "Creation of Temporary File in Directory with Insecure Permissions" ;
+    rdfs:subClassOf :CWE-377 ;
+    :cwe-id "CWE-379" .
+
+:CWE-382 a owl:Class ;
+    rdfs:label "J2EE Bad Practices: Use of System.exit()" ;
+    rdfs:subClassOf :CWE-705 ;
+    :cwe-id "CWE-382" .
+
+:CWE-383 a owl:Class ;
+    rdfs:label "J2EE Bad Practices: Direct Use of Threads" ;
+    rdfs:subClassOf :CWE-695 ;
+    :cwe-id "CWE-383" .
+
+:CWE-384 a owl:Class ;
+    rdfs:label "Session Fixation" ;
+    rdfs:subClassOf :CWE-610 ;
+    :cwe-id "CWE-384" .
+
+:CWE-385 a owl:Class ;
+    rdfs:label "Covert Timing Channel" ;
+    rdfs:subClassOf :CWE-514 ;
+    :cwe-id "CWE-385" .
+
+:CWE-386 a owl:Class ;
+    rdfs:label "Symbolic Name not Mapping to Correct Object" ;
+    rdfs:subClassOf :CWE-706 ;
+    :cwe-id "CWE-386" .
+
+:CWE-390 a owl:Class ;
+    rdfs:label "Detection of Error Condition Without Action" ;
+    rdfs:subClassOf :CWE-755 ;
+    :cwe-id "CWE-390" .
+
+:CWE-391 a owl:Class ;
+    rdfs:label "Unchecked Error Condition" ;
+    rdfs:subClassOf :CWE-754 ;
+    :cwe-id "CWE-391" .
+
+:CWE-392 a owl:Class ;
+    rdfs:label "Missing Report of Error Condition" ;
+    rdfs:subClassOf :CWE-684,
+        :CWE-703 ;
+    :cwe-id "CWE-392" .
+
+:CWE-393 a owl:Class ;
+    rdfs:label "Return of Wrong Status Code" ;
+    rdfs:subClassOf :CWE-684,
+        :CWE-703 ;
+    :cwe-id "CWE-393" .
+
+:CWE-394 a owl:Class ;
+    rdfs:label "Unexpected Status Code or Return Value" ;
+    rdfs:subClassOf :CWE-754 ;
+    :cwe-id "CWE-394" .
+
+:CWE-395 a owl:Class ;
+    rdfs:label "Use of NullPointerException Catch to Detect NULL Pointer Dereference" ;
+    rdfs:subClassOf :CWE-705,
+        :CWE-755 ;
+    :cwe-id "CWE-395" .
+
+:CWE-396 a owl:Class ;
+    rdfs:label "Declaration of Catch for Generic Exception" ;
+    rdfs:subClassOf :CWE-221,
+        :CWE-705,
+        :CWE-755 ;
+    :cwe-id "CWE-396" .
+
+:CWE-397 a owl:Class ;
+    rdfs:label "Declaration of Throws for Generic Exception" ;
+    rdfs:subClassOf :CWE-221,
+        :CWE-703,
+        :CWE-705 ;
+    :cwe-id "CWE-397" .
+
 :CWE-400 a owl:Class ;
     rdfs:label "Uncontrolled Resource Consumption" ;
-    rdfs:subClassOf :Weakness ;
+    rdfs:subClassOf :CWE-664 ;
     :comment "Cannot directly relate to artifacts due to breadth. Resource monitoring and limiting allocation is an approach to counter." ;
     :cwe-id "CWE-400" .
 
+:CWE-401 a owl:Class ;
+    rdfs:label "Missing Release of Memory after Effective Lifetime" ;
+    rdfs:subClassOf :CWE-772 ;
+    :cwe-id "CWE-401" .
+
+:CWE-402 a owl:Class ;
+    rdfs:label "Transmission of Private Resources into a New Sphere ('Resource Leak')" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-402" .
+
+:CWE-403 a owl:Class ;
+    rdfs:label "Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')" ;
+    rdfs:subClassOf :CWE-402 ;
+    :cwe-id "CWE-403" .
+
+:CWE-404 a owl:Class ;
+    rdfs:label "Improper Resource Shutdown or Release" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-404" .
+
+:CWE-405 a owl:Class ;
+    rdfs:label "Asymmetric Resource Consumption (Amplification)" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-405" .
+
+:CWE-406 a owl:Class ;
+    rdfs:label "Insufficient Control of Network Message Volume (Network Amplification)" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-406" .
+
+:CWE-407 a owl:Class ;
+    rdfs:label "Inefficient Algorithmic Complexity" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-407" .
+
+:CWE-408 a owl:Class ;
+    rdfs:label "Incorrect Behavior Order: Early Amplification" ;
+    rdfs:subClassOf :CWE-405,
+        :CWE-696 ;
+    :cwe-id "CWE-408" .
+
+:CWE-409 a owl:Class ;
+    rdfs:label "Improper Handling of Highly Compressed Data (Data Amplification)" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-409" .
+
+:CWE-410 a owl:Class ;
+    rdfs:label "Insufficient Resource Pool" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-410" .
+
+:CWE-412 a owl:Class ;
+    rdfs:label "Unrestricted Externally Accessible Lock" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-412" .
+
+:CWE-413 a owl:Class ;
+    rdfs:label "Improper Resource Locking" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-413" .
+
+:CWE-414 a owl:Class ;
+    rdfs:label "Missing Lock Check" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-414" .
+
+:CWE-415 a owl:Class ;
+    rdfs:label "Double Free" ;
+    rdfs:subClassOf :CWE-666,
+        :CWE-825,
+        :CWE-1341 ;
+    :cwe-id "CWE-415" .
+
 :CWE-416 a owl:Class ;
     rdfs:label "Use After Free" ;
-    rdfs:subClassOf :Weakness ;
+    rdfs:subClassOf :CWE-825 ;
     :cwe-id "CWE-416" ;
     :todo "Model these memory artifacts." .
 
+:CWE-419 a owl:Class ;
+    rdfs:label "Unprotected Primary Channel" ;
+    rdfs:subClassOf :CWE-923 ;
+    :cwe-id "CWE-419" .
+
+:CWE-420 a owl:Class ;
+    rdfs:label "Unprotected Alternate Channel" ;
+    rdfs:subClassOf :CWE-923 ;
+    :cwe-id "CWE-420" .
+
+:CWE-421 a owl:Class ;
+    rdfs:label "Race Condition During Access to Alternate Channel" ;
+    rdfs:subClassOf :CWE-362,
+        :CWE-420 ;
+    :cwe-id "CWE-421" .
+
+:CWE-422 a owl:Class ;
+    rdfs:label "Unprotected Windows Messaging Channel ('Shatter')" ;
+    rdfs:subClassOf :CWE-360,
+        :CWE-420 ;
+    :cwe-id "CWE-422" .
+
+:CWE-424 a owl:Class ;
+    rdfs:label "Improper Protection of Alternate Path" ;
+    rdfs:subClassOf :CWE-638,
+        :CWE-693 ;
+    :cwe-id "CWE-424" .
+
+:CWE-425 a owl:Class ;
+    rdfs:label "Direct Request ('Forced Browsing')" ;
+    rdfs:subClassOf :CWE-288,
+        :CWE-424,
+        :CWE-862 ;
+    :cwe-id "CWE-425" .
+
+:CWE-426 a owl:Class ;
+    rdfs:label "Untrusted Search Path" ;
+    rdfs:subClassOf :CWE-642,
+        :CWE-673 ;
+    :cwe-id "CWE-426" .
+
+:CWE-427 a owl:Class ;
+    rdfs:label "Uncontrolled Search Path Element" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-427" .
+
+:CWE-428 a owl:Class ;
+    rdfs:label "Unquoted Search Path or Element" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-428" .
+
+:CWE-430 a owl:Class ;
+    rdfs:label "Deployment of Wrong Handler" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-430" .
+
+:CWE-431 a owl:Class ;
+    rdfs:label "Missing Handler" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-431" .
+
+:CWE-432 a owl:Class ;
+    rdfs:label "Dangerous Signal Handler not Disabled During Sensitive Operations" ;
+    rdfs:subClassOf :CWE-364 ;
+    :cwe-id "CWE-432" .
+
+:CWE-433 a owl:Class ;
+    rdfs:label "Unparsed Raw Web Content Delivery" ;
+    rdfs:subClassOf :CWE-219 ;
+    :cwe-id "CWE-433" .
+
 :CWE-434 a owl:Class ;
     rdfs:label "Unrestricted Upload of File with Dangerous Type" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-669,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-434" .
 
+:CWE-435 a owl:Class ;
+    rdfs:label "Improper Interaction Between Multiple Correctly-Behaving Entities" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-435" .
+
+:CWE-436 a owl:Class ;
+    rdfs:label "Interpretation Conflict" ;
+    rdfs:subClassOf :CWE-435 ;
+    :cwe-id "CWE-436" .
+
+:CWE-437 a owl:Class ;
+    rdfs:label "Incomplete Model of Endpoint Features" ;
+    rdfs:subClassOf :CWE-436 ;
+    :cwe-id "CWE-437" .
+
+:CWE-439 a owl:Class ;
+    rdfs:label "Behavioral Change in New Version or Environment" ;
+    rdfs:subClassOf :CWE-435 ;
+    :cwe-id "CWE-439" .
+
+:CWE-440 a owl:Class ;
+    rdfs:label "Expected Behavior Violation" ;
+    rdfs:subClassOf :CWE-684 ;
+    :cwe-id "CWE-440" .
+
+:CWE-441 a owl:Class ;
+    rdfs:label "Unintended Proxy or Intermediary ('Confused Deputy')" ;
+    rdfs:subClassOf :CWE-610 ;
+    :cwe-id "CWE-441" .
+
+:CWE-444 a owl:Class ;
+    rdfs:label "Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')" ;
+    rdfs:subClassOf :CWE-436 ;
+    :cwe-id "CWE-444" .
+
+:CWE-446 a owl:Class ;
+    rdfs:label "UI Discrepancy for Security Feature" ;
+    rdfs:subClassOf :CWE-684 ;
+    :cwe-id "CWE-446" .
+
+:CWE-447 a owl:Class ;
+    rdfs:label "Unimplemented or Unsupported Feature in UI" ;
+    rdfs:subClassOf :CWE-446,
+        :CWE-671 ;
+    :cwe-id "CWE-447" .
+
+:CWE-448 a owl:Class ;
+    rdfs:label "Obsolete Feature in UI" ;
+    rdfs:subClassOf :CWE-446 ;
+    :cwe-id "CWE-448" .
+
+:CWE-449 a owl:Class ;
+    rdfs:label "The UI Performs the Wrong Action" ;
+    rdfs:subClassOf :CWE-446 ;
+    :cwe-id "CWE-449" .
+
+:CWE-450 a owl:Class ;
+    rdfs:label "Multiple Interpretations of UI Input" ;
+    rdfs:subClassOf :CWE-357 ;
+    :cwe-id "CWE-450" .
+
+:CWE-451 a owl:Class ;
+    rdfs:label "User Interface (UI) Misrepresentation of Critical Information" ;
+    rdfs:subClassOf :CWE-221,
+        :CWE-684 ;
+    :cwe-id "CWE-451" .
+
+:CWE-453 a owl:Class ;
+    rdfs:label "Insecure Default Variable Initialization" ;
+    rdfs:subClassOf :CWE-1188 ;
+    :cwe-id "CWE-453" .
+
+:CWE-454 a owl:Class ;
+    rdfs:label "External Initialization of Trusted Variables or Data Stores" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-454" .
+
+:CWE-455 a owl:Class ;
+    rdfs:label "Non-exit on Failed Initialization" ;
+    rdfs:subClassOf :CWE-636,
+        :CWE-665,
+        :CWE-705 ;
+    :cwe-id "CWE-455" .
+
+:CWE-456 a owl:Class ;
+    rdfs:label "Missing Initialization of a Variable" ;
+    rdfs:subClassOf :CWE-909 ;
+    :cwe-id "CWE-456" .
+
+:CWE-457 a owl:Class ;
+    rdfs:label "Use of Uninitialized Variable" ;
+    rdfs:subClassOf :CWE-908 ;
+    :cwe-id "CWE-457" .
+
+:CWE-459 a owl:Class ;
+    rdfs:label "Incomplete Cleanup" ;
+    rdfs:subClassOf :CWE-404 ;
+    :cwe-id "CWE-459" .
+
+:CWE-460 a owl:Class ;
+    rdfs:label "Improper Cleanup on Thrown Exception" ;
+    rdfs:subClassOf :CWE-459,
+        :CWE-755 ;
+    :cwe-id "CWE-460" .
+
+:CWE-462 a owl:Class ;
+    rdfs:label "Duplicate Key in Associative List (Alist)" ;
+    rdfs:subClassOf :CWE-694 ;
+    :cwe-id "CWE-462" .
+
+:CWE-463 a owl:Class ;
+    rdfs:label "Deletion of Data Structure Sentinel" ;
+    rdfs:subClassOf :CWE-707 ;
+    :cwe-id "CWE-463" .
+
+:CWE-464 a owl:Class ;
+    rdfs:label "Addition of Data Structure Sentinel" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-464" .
+
+:CWE-466 a owl:Class ;
+    rdfs:label "Return of Pointer Value Outside of Expected Range" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-466" .
+
+:CWE-467 a owl:Class ;
+    rdfs:label "Use of sizeof() on a Pointer Type" ;
+    rdfs:subClassOf :CWE-131 ;
+    :cwe-id "CWE-467" .
+
+:CWE-468 a owl:Class ;
+    rdfs:label "Incorrect Pointer Scaling" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-468" .
+
+:CWE-469 a owl:Class ;
+    rdfs:label "Use of Pointer Subtraction to Determine Size" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-469" .
+
+:CWE-470 a owl:Class ;
+    rdfs:label "Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')" ;
+    rdfs:subClassOf :CWE-610,
+        :CWE-913 ;
+    :cwe-id "CWE-470" .
+
+:CWE-471 a owl:Class ;
+    rdfs:label "Modification of Assumed-Immutable Data (MAID)" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-471" .
+
+:CWE-472 a owl:Class ;
+    rdfs:label "External Control of Assumed-Immutable Web Parameter" ;
+    rdfs:subClassOf :CWE-471,
+        :CWE-642 ;
+    :cwe-id "CWE-472" .
+
+:CWE-473 a owl:Class ;
+    rdfs:label "PHP External Variable Modification" ;
+    rdfs:subClassOf :CWE-471 ;
+    :cwe-id "CWE-473" .
+
+:CWE-474 a owl:Class ;
+    rdfs:label "Use of Function with Inconsistent Implementations" ;
+    rdfs:subClassOf :CWE-758 ;
+    :cwe-id "CWE-474" .
+
+:CWE-475 a owl:Class ;
+    rdfs:label "Undefined Behavior for Input to API" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-475" .
+
 :CWE-476 a owl:Class ;
     rdfs:label "NULL Pointer Dereference" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-710,
+        :CWE-754,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :PointerDereferencingFunction ] ;
     :cwe-id "CWE-476" .
 
+:CWE-477 a owl:Class ;
+    rdfs:label "Use of Obsolete Function" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-477" .
+
+:CWE-478 a owl:Class ;
+    rdfs:label "Missing Default Case in Multiple Condition Expression" ;
+    rdfs:subClassOf :CWE-1023 ;
+    :cwe-id "CWE-478" .
+
+:CWE-479 a owl:Class ;
+    rdfs:label "Signal Handler Use of a Non-reentrant Function" ;
+    rdfs:subClassOf :CWE-663,
+        :CWE-828 ;
+    :cwe-id "CWE-479" .
+
+:CWE-480 a owl:Class ;
+    rdfs:label "Use of Incorrect Operator" ;
+    rdfs:subClassOf :CWE-670 ;
+    :cwe-id "CWE-480" .
+
+:CWE-481 a owl:Class ;
+    rdfs:label "Assigning instead of Comparing" ;
+    rdfs:subClassOf :CWE-480 ;
+    :cwe-id "CWE-481" .
+
+:CWE-482 a owl:Class ;
+    rdfs:label "Comparing instead of Assigning" ;
+    rdfs:subClassOf :CWE-480 ;
+    :cwe-id "CWE-482" .
+
+:CWE-483 a owl:Class ;
+    rdfs:label "Incorrect Block Delimitation" ;
+    rdfs:subClassOf :CWE-670 ;
+    :cwe-id "CWE-483" .
+
+:CWE-484 a owl:Class ;
+    rdfs:label "Omitted Break Statement in Switch" ;
+    rdfs:subClassOf :CWE-670,
+        :CWE-710 ;
+    :cwe-id "CWE-484" .
+
+:CWE-486 a owl:Class ;
+    rdfs:label "Comparison of Classes by Name" ;
+    rdfs:subClassOf :CWE-1025 ;
+    :cwe-id "CWE-486" .
+
+:CWE-487 a owl:Class ;
+    rdfs:label "Reliance on Package-level Scope" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-487" .
+
+:CWE-488 a owl:Class ;
+    rdfs:label "Exposure of Data Element to Wrong Session" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-488" .
+
+:CWE-489 a owl:Class ;
+    rdfs:label "Active Debug Code" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-489" .
+
+:CWE-491 a owl:Class ;
+    rdfs:label "Public cloneable() Method Without Final ('Object Hijack')" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-491" .
+
+:CWE-492 a owl:Class ;
+    rdfs:label "Use of Inner Class Containing Sensitive Data" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-492" .
+
+:CWE-493 a owl:Class ;
+    rdfs:label "Critical Public Variable Without Final Modifier" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-493" .
+
+:CWE-494 a owl:Class ;
+    rdfs:label "Download of Code Without Integrity Check" ;
+    rdfs:subClassOf :CWE-345,
+        :CWE-669 ;
+    :cwe-id "CWE-494" .
+
+:CWE-495 a owl:Class ;
+    rdfs:label "Private Data Structure Returned From A Public Method" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-495" .
+
+:CWE-496 a owl:Class ;
+    rdfs:label "Public Data Assigned to Private Array-Typed Field" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-496" .
+
+:CWE-497 a owl:Class ;
+    rdfs:label "Exposure of Sensitive System Information to an Unauthorized Control Sphere" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-497" .
+
+:CWE-498 a owl:Class ;
+    rdfs:label "Cloneable Class Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-498" .
+
+:CWE-499 a owl:Class ;
+    rdfs:label "Serializable Class Containing Sensitive Data" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-499" .
+
+:CWE-500 a owl:Class ;
+    rdfs:label "Public Static Field Not Marked Final" ;
+    rdfs:subClassOf :CWE-493 ;
+    :cwe-id "CWE-500" .
+
+:CWE-501 a owl:Class ;
+    rdfs:label "Trust Boundary Violation" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-501" .
+
 :CWE-502 a owl:Class ;
     rdfs:label "Deserialization of Untrusted Data" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-913,
         [ a owl:Restriction ;
             owl:onProperty :may-be-weakness-of ;
             owl:someValuesFrom :UserInputFunction ],
@@ -3445,43 +5588,2585 @@ Management servers with enterprise policies for account management provide the a
             owl:someValuesFrom :DeserializationFunction ] ;
     :cwe-id "CWE-502" .
 
+:CWE-506 a owl:Class ;
+    rdfs:label "Embedded Malicious Code" ;
+    rdfs:subClassOf :CWE-912 ;
+    :cwe-id "CWE-506" .
+
+:CWE-507 a owl:Class ;
+    rdfs:label "Trojan Horse" ;
+    rdfs:subClassOf :CWE-506 ;
+    :cwe-id "CWE-507" .
+
+:CWE-508 a owl:Class ;
+    rdfs:label "Non-Replicating Malicious Code" ;
+    rdfs:subClassOf :CWE-507 ;
+    :cwe-id "CWE-508" .
+
+:CWE-509 a owl:Class ;
+    rdfs:label "Replicating Malicious Code (Virus or Worm)" ;
+    rdfs:subClassOf :CWE-507 ;
+    :cwe-id "CWE-509" .
+
+:CWE-510 a owl:Class ;
+    rdfs:label "Trapdoor" ;
+    rdfs:subClassOf :CWE-506 ;
+    :cwe-id "CWE-510" .
+
+:CWE-511 a owl:Class ;
+    rdfs:label "Logic/Time Bomb" ;
+    rdfs:subClassOf :CWE-506 ;
+    :cwe-id "CWE-511" .
+
+:CWE-512 a owl:Class ;
+    rdfs:label "Spyware" ;
+    rdfs:subClassOf :CWE-506 ;
+    :cwe-id "CWE-512" .
+
+:CWE-514 a owl:Class ;
+    rdfs:label "Covert Channel" ;
+    rdfs:subClassOf :CWE-1229 ;
+    :cwe-id "CWE-514" .
+
+:CWE-515 a owl:Class ;
+    rdfs:label "Covert Storage Channel" ;
+    rdfs:subClassOf :CWE-514 ;
+    :cwe-id "CWE-515" .
+
+:CWE-520 a owl:Class ;
+    rdfs:label ".NET Misconfiguration: Use of Impersonation" ;
+    rdfs:subClassOf :CWE-266 ;
+    :cwe-id "CWE-520" .
+
+:CWE-521 a owl:Class ;
+    rdfs:label "Weak Password Requirements" ;
+    rdfs:subClassOf :CWE-1391 ;
+    :cwe-id "CWE-521" .
+
+:CWE-522 a owl:Class ;
+    rdfs:label "Insufficiently Protected Credentials" ;
+    rdfs:subClassOf :CWE-668,
+        :CWE-1390 ;
+    :cwe-id "CWE-522" .
+
+:CWE-523 a owl:Class ;
+    rdfs:label "Unprotected Transport of Credentials" ;
+    rdfs:subClassOf :CWE-522 ;
+    :cwe-id "CWE-523" .
+
+:CWE-524 a owl:Class ;
+    rdfs:label "Use of Cache Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-524" .
+
+:CWE-525 a owl:Class ;
+    rdfs:label "Use of Web Browser Cache Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-524 ;
+    :cwe-id "CWE-525" .
+
+:CWE-526 a owl:Class ;
+    rdfs:label "Cleartext Storage of Sensitive Information in an Environment Variable" ;
+    rdfs:subClassOf :CWE-312 ;
+    :cwe-id "CWE-526" .
+
+:CWE-527 a owl:Class ;
+    rdfs:label "Exposure of Version-Control Repository to an Unauthorized Control Sphere" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-527" .
+
+:CWE-528 a owl:Class ;
+    rdfs:label "Exposure of Core Dump File to an Unauthorized Control Sphere" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-528" .
+
+:CWE-529 a owl:Class ;
+    rdfs:label "Exposure of Access Control List Files to an Unauthorized Control Sphere" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-529" .
+
+:CWE-530 a owl:Class ;
+    rdfs:label "Exposure of Backup File to an Unauthorized Control Sphere" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-530" .
+
+:CWE-531 a owl:Class ;
+    rdfs:label "Inclusion of Sensitive Information in Test Code" ;
+    rdfs:subClassOf :CWE-540 ;
+    :cwe-id "CWE-531" .
+
+:CWE-532 a owl:Class ;
+    rdfs:label "Insertion of Sensitive Information into Log File" ;
+    rdfs:subClassOf :CWE-538 ;
+    :cwe-id "CWE-532" .
+
+:CWE-535 a owl:Class ;
+    rdfs:label "Exposure of Information Through Shell Error Message" ;
+    rdfs:subClassOf :CWE-211 ;
+    :cwe-id "CWE-535" .
+
+:CWE-536 a owl:Class ;
+    rdfs:label "Servlet Runtime Error Message Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-211 ;
+    :cwe-id "CWE-536" .
+
+:CWE-537 a owl:Class ;
+    rdfs:label "Java Runtime Error Message Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-211 ;
+    :cwe-id "CWE-537" .
+
+:CWE-538 a owl:Class ;
+    rdfs:label "Insertion of Sensitive Information into Externally-Accessible File or Directory" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-538" .
+
+:CWE-539 a owl:Class ;
+    rdfs:label "Use of Persistent Cookies Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-539" .
+
+:CWE-540 a owl:Class ;
+    rdfs:label "Inclusion of Sensitive Information in Source Code" ;
+    rdfs:subClassOf :CWE-538 ;
+    :cwe-id "CWE-540" .
+
+:CWE-541 a owl:Class ;
+    rdfs:label "Inclusion of Sensitive Information in an Include File" ;
+    rdfs:subClassOf :CWE-540 ;
+    :cwe-id "CWE-541" .
+
+:CWE-543 a owl:Class ;
+    rdfs:label "Use of Singleton Pattern Without Synchronization in a Multithreaded Context" ;
+    rdfs:subClassOf :CWE-820 ;
+    :cwe-id "CWE-543" .
+
+:CWE-544 a owl:Class ;
+    rdfs:label "Missing Standardized Error Handling Mechanism" ;
+    rdfs:subClassOf :CWE-755 ;
+    :cwe-id "CWE-544" .
+
+:CWE-546 a owl:Class ;
+    rdfs:label "Suspicious Comment" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-546" .
+
+:CWE-547 a owl:Class ;
+    rdfs:label "Use of Hard-coded, Security-relevant Constants" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-547" .
+
+:CWE-548 a owl:Class ;
+    rdfs:label "Exposure of Information Through Directory Listing" ;
+    rdfs:subClassOf :CWE-497 ;
+    :cwe-id "CWE-548" .
+
+:CWE-549 a owl:Class ;
+    rdfs:label "Missing Password Field Masking" ;
+    rdfs:subClassOf :CWE-522 ;
+    :cwe-id "CWE-549" .
+
+:CWE-550 a owl:Class ;
+    rdfs:label "Server-generated Error Message Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-209 ;
+    :cwe-id "CWE-550" .
+
+:CWE-551 a owl:Class ;
+    rdfs:label "Incorrect Behavior Order: Authorization Before Parsing and Canonicalization" ;
+    rdfs:subClassOf :CWE-696,
+        :CWE-863 ;
+    :cwe-id "CWE-551" .
+
+:CWE-552 a owl:Class ;
+    rdfs:label "Files or Directories Accessible to External Parties" ;
+    rdfs:subClassOf :CWE-285,
+        :CWE-668 ;
+    :cwe-id "CWE-552" .
+
+:CWE-553 a owl:Class ;
+    rdfs:label "Command Shell in Externally Accessible Directory" ;
+    rdfs:subClassOf :CWE-552 ;
+    :cwe-id "CWE-553" .
+
+:CWE-554 a owl:Class ;
+    rdfs:label "ASP.NET Misconfiguration: Not Using Input Validation Framework" ;
+    rdfs:subClassOf :CWE-1173 ;
+    :cwe-id "CWE-554" .
+
+:CWE-555 a owl:Class ;
+    rdfs:label "J2EE Misconfiguration: Plaintext Password in Configuration File" ;
+    rdfs:subClassOf :CWE-260 ;
+    :cwe-id "CWE-555" .
+
+:CWE-556 a owl:Class ;
+    rdfs:label "ASP.NET Misconfiguration: Use of Identity Impersonation" ;
+    rdfs:subClassOf :CWE-266 ;
+    :cwe-id "CWE-556" .
+
+:CWE-558 a owl:Class ;
+    rdfs:label "Use of getlogin() in Multithreaded Application" ;
+    rdfs:subClassOf :CWE-663 ;
+    :cwe-id "CWE-558" .
+
+:CWE-560 a owl:Class ;
+    rdfs:label "Use of umask() with chmod-style Argument" ;
+    rdfs:subClassOf :CWE-687 ;
+    :cwe-id "CWE-560" .
+
+:CWE-561 a owl:Class ;
+    rdfs:label "Dead Code" ;
+    rdfs:subClassOf :CWE-1164 ;
+    :cwe-id "CWE-561" .
+
+:CWE-562 a owl:Class ;
+    rdfs:label "Return of Stack Variable Address" ;
+    rdfs:subClassOf :CWE-758 ;
+    :cwe-id "CWE-562" .
+
+:CWE-563 a owl:Class ;
+    rdfs:label "Assignment to Variable without Use" ;
+    rdfs:subClassOf :CWE-1164 ;
+    :cwe-id "CWE-563" .
+
+:CWE-564 a owl:Class ;
+    rdfs:label "SQL Injection: Hibernate" ;
+    rdfs:subClassOf :CWE-89 ;
+    :cwe-id "CWE-564" .
+
+:CWE-565 a owl:Class ;
+    rdfs:label "Reliance on Cookies without Validation and Integrity Checking" ;
+    rdfs:subClassOf :CWE-602,
+        :CWE-642 ;
+    :cwe-id "CWE-565" .
+
+:CWE-566 a owl:Class ;
+    rdfs:label "Authorization Bypass Through User-Controlled SQL Primary Key" ;
+    rdfs:subClassOf :CWE-639 ;
+    :cwe-id "CWE-566" .
+
+:CWE-567 a owl:Class ;
+    rdfs:label "Unsynchronized Access to Shared Data in a Multithreaded Context" ;
+    rdfs:subClassOf :CWE-820 ;
+    :cwe-id "CWE-567" .
+
+:CWE-568 a owl:Class ;
+    rdfs:label "finalize() Method Without super.finalize()" ;
+    rdfs:subClassOf :CWE-459,
+        :CWE-573 ;
+    :cwe-id "CWE-568" .
+
+:CWE-570 a owl:Class ;
+    rdfs:label "Expression is Always False" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-570" .
+
+:CWE-571 a owl:Class ;
+    rdfs:label "Expression is Always True" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-571" .
+
+:CWE-572 a owl:Class ;
+    rdfs:label "Call to Thread run() instead of start()" ;
+    rdfs:subClassOf :CWE-821 ;
+    :cwe-id "CWE-572" .
+
+:CWE-573 a owl:Class ;
+    rdfs:label "Improper Following of Specification by Caller" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-573" .
+
+:CWE-574 a owl:Class ;
+    rdfs:label "EJB Bad Practices: Use of Synchronization Primitives" ;
+    rdfs:subClassOf :CWE-695,
+        :CWE-821 ;
+    :cwe-id "CWE-574" .
+
+:CWE-575 a owl:Class ;
+    rdfs:label "EJB Bad Practices: Use of AWT Swing" ;
+    rdfs:subClassOf :CWE-695 ;
+    :cwe-id "CWE-575" .
+
+:CWE-576 a owl:Class ;
+    rdfs:label "EJB Bad Practices: Use of Java I/O" ;
+    rdfs:subClassOf :CWE-695 ;
+    :cwe-id "CWE-576" .
+
+:CWE-577 a owl:Class ;
+    rdfs:label "EJB Bad Practices: Use of Sockets" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-577" .
+
+:CWE-578 a owl:Class ;
+    rdfs:label "EJB Bad Practices: Use of Class Loader" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-578" .
+
+:CWE-579 a owl:Class ;
+    rdfs:label "J2EE Bad Practices: Non-serializable Object Stored in Session" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-579" .
+
+:CWE-580 a owl:Class ;
+    rdfs:label "clone() Method Without super.clone()" ;
+    rdfs:subClassOf :CWE-573,
+        :CWE-664 ;
+    :cwe-id "CWE-580" .
+
+:CWE-581 a owl:Class ;
+    rdfs:label "Object Model Violation: Just One of Equals and Hashcode Defined" ;
+    rdfs:subClassOf :CWE-573,
+        :CWE-697 ;
+    :cwe-id "CWE-581" .
+
+:CWE-582 a owl:Class ;
+    rdfs:label "Array Declared Public, Final, and Static" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-582" .
+
+:CWE-583 a owl:Class ;
+    rdfs:label "finalize() Method Declared Public" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-583" .
+
+:CWE-584 a owl:Class ;
+    rdfs:label "Return Inside Finally Block" ;
+    rdfs:subClassOf :CWE-705 ;
+    :cwe-id "CWE-584" .
+
+:CWE-585 a owl:Class ;
+    rdfs:label "Empty Synchronized Block" ;
+    rdfs:subClassOf :CWE-1071 ;
+    :cwe-id "CWE-585" .
+
+:CWE-586 a owl:Class ;
+    rdfs:label "Explicit Call to Finalize()" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-586" .
+
+:CWE-587 a owl:Class ;
+    rdfs:label "Assignment of a Fixed Address to a Pointer" ;
+    rdfs:subClassOf :CWE-344,
+        :CWE-758 ;
+    :cwe-id "CWE-587" .
+
+:CWE-588 a owl:Class ;
+    rdfs:label "Attempt to Access Child of a Non-structure Pointer" ;
+    rdfs:subClassOf :CWE-704,
+        :CWE-758 ;
+    :cwe-id "CWE-588" .
+
+:CWE-589 a owl:Class ;
+    rdfs:label "Call to Non-ubiquitous API" ;
+    rdfs:subClassOf :CWE-474 ;
+    :cwe-id "CWE-589" .
+
+:CWE-590 a owl:Class ;
+    rdfs:label "Free of Memory not on the Heap" ;
+    rdfs:subClassOf :CWE-762 ;
+    :cwe-id "CWE-590" .
+
+:CWE-591 a owl:Class ;
+    rdfs:label "Sensitive Data Storage in Improperly Locked Memory" ;
+    rdfs:subClassOf :CWE-413 ;
+    :cwe-id "CWE-591" .
+
+:CWE-593 a owl:Class ;
+    rdfs:label "Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created" ;
+    rdfs:subClassOf :CWE-666,
+        :CWE-1390 ;
+    :cwe-id "CWE-593" .
+
+:CWE-594 a owl:Class ;
+    rdfs:label "J2EE Framework: Saving Unserializable Objects to Disk" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-594" .
+
+:CWE-595 a owl:Class ;
+    rdfs:label "Comparison of Object References Instead of Object Contents" ;
+    rdfs:subClassOf :CWE-1025 ;
+    :cwe-id "CWE-595" .
+
+:CWE-597 a owl:Class ;
+    rdfs:label "Use of Wrong Operator in String Comparison" ;
+    rdfs:subClassOf :CWE-480,
+        :CWE-595 ;
+    :cwe-id "CWE-597" .
+
+:CWE-598 a owl:Class ;
+    rdfs:label "Use of GET Request Method With Sensitive Query Strings" ;
+    rdfs:subClassOf :CWE-201 ;
+    :cwe-id "CWE-598" .
+
+:CWE-599 a owl:Class ;
+    rdfs:label "Missing Validation of OpenSSL Certificate" ;
+    rdfs:subClassOf :CWE-295 ;
+    :cwe-id "CWE-599" .
+
+:CWE-600 a owl:Class ;
+    rdfs:label "Uncaught Exception in Servlet " ;
+    rdfs:subClassOf :CWE-248 ;
+    :cwe-id "CWE-600" .
+
+:CWE-601 a owl:Class ;
+    rdfs:label "URL Redirection to Untrusted Site ('Open Redirect')" ;
+    rdfs:subClassOf :CWE-610 ;
+    :cwe-id "CWE-601" .
+
+:CWE-602 a owl:Class ;
+    rdfs:label "Client-Side Enforcement of Server-Side Security" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-602" .
+
+:CWE-603 a owl:Class ;
+    rdfs:label "Use of Client-Side Authentication" ;
+    rdfs:subClassOf :CWE-602,
+        :CWE-1390 ;
+    :cwe-id "CWE-603" .
+
+:CWE-605 a owl:Class ;
+    rdfs:label "Multiple Binds to the Same Port" ;
+    rdfs:subClassOf :CWE-666,
+        :CWE-675 ;
+    :cwe-id "CWE-605" .
+
+:CWE-606 a owl:Class ;
+    rdfs:label "Unchecked Input for Loop Condition" ;
+    rdfs:subClassOf :CWE-1284 ;
+    :cwe-id "CWE-606" .
+
+:CWE-607 a owl:Class ;
+    rdfs:label "Public Static Final Field References Mutable Object" ;
+    rdfs:subClassOf :CWE-471 ;
+    :cwe-id "CWE-607" .
+
+:CWE-608 a owl:Class ;
+    rdfs:label "Struts: Non-private Field in ActionForm Class" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-608" .
+
+:CWE-609 a owl:Class ;
+    rdfs:label "Double-Checked Locking" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-609" .
+
+:CWE-610 a owl:Class ;
+    rdfs:label "Externally Controlled Reference to a Resource in Another Sphere" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-610" .
+
 :CWE-611 a owl:Class ;
     rdfs:label "Improper Restriction of XML External Entity Reference" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-610,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :ExternalContentInclusionFunction ] ;
     :cwe-id "CWE-611" .
 
+:CWE-612 a owl:Class ;
+    rdfs:label "Improper Authorization of Index Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-1230 ;
+    :cwe-id "CWE-612" .
+
+:CWE-613 a owl:Class ;
+    rdfs:label "Insufficient Session Expiration" ;
+    rdfs:subClassOf :CWE-672 ;
+    :cwe-id "CWE-613" .
+
+:CWE-614 a owl:Class ;
+    rdfs:label "Sensitive Cookie in HTTPS Session Without 'Secure' Attribute" ;
+    rdfs:subClassOf :CWE-319 ;
+    :cwe-id "CWE-614" .
+
+:CWE-615 a owl:Class ;
+    rdfs:label "Inclusion of Sensitive Information in Source Code Comments" ;
+    rdfs:subClassOf :CWE-540 ;
+    :cwe-id "CWE-615" .
+
+:CWE-616 a owl:Class ;
+    rdfs:label "Incomplete Identification of Uploaded File Variables (PHP)" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-616" .
+
+:CWE-617 a owl:Class ;
+    rdfs:label "Reachable Assertion" ;
+    rdfs:subClassOf :CWE-670 ;
+    :cwe-id "CWE-617" .
+
+:CWE-618 a owl:Class ;
+    rdfs:label "Exposed Unsafe ActiveX Method" ;
+    rdfs:subClassOf :CWE-749 ;
+    :cwe-id "CWE-618" .
+
+:CWE-619 a owl:Class ;
+    rdfs:label "Dangling Database Cursor ('Cursor Injection')" ;
+    rdfs:subClassOf :CWE-402 ;
+    :cwe-id "CWE-619" .
+
+:CWE-620 a owl:Class ;
+    rdfs:label "Unverified Password Change" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-620" .
+
+:CWE-621 a owl:Class ;
+    rdfs:label "Variable Extraction Error" ;
+    rdfs:subClassOf :CWE-914 ;
+    :cwe-id "CWE-621" .
+
+:CWE-622 a owl:Class ;
+    rdfs:label "Improper Validation of Function Hook Arguments" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-622" .
+
+:CWE-623 a owl:Class ;
+    rdfs:label "Unsafe ActiveX Control Marked Safe For Scripting" ;
+    rdfs:subClassOf :CWE-267 ;
+    :cwe-id "CWE-623" .
+
+:CWE-624 a owl:Class ;
+    rdfs:label "Executable Regular Expression Error" ;
+    rdfs:subClassOf :CWE-77 ;
+    :cwe-id "CWE-624" .
+
+:CWE-625 a owl:Class ;
+    rdfs:label "Permissive Regular Expression" ;
+    rdfs:subClassOf :CWE-185 ;
+    :cwe-id "CWE-625" .
+
+:CWE-626 a owl:Class ;
+    rdfs:label "Null Byte Interaction Error (Poison Null Byte)" ;
+    rdfs:subClassOf :CWE-147,
+        :CWE-436 ;
+    :cwe-id "CWE-626" .
+
+:CWE-627 a owl:Class ;
+    rdfs:label "Dynamic Variable Evaluation" ;
+    rdfs:subClassOf :CWE-914 ;
+    :cwe-id "CWE-627" .
+
+:CWE-628 a owl:Class ;
+    rdfs:label "Function Call with Incorrectly Specified Arguments" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-628" .
+
+:CWE-636 a owl:Class ;
+    rdfs:label "Not Failing Securely ('Failing Open')" ;
+    rdfs:subClassOf :CWE-657,
+        :CWE-755 ;
+    :cwe-id "CWE-636" .
+
+:CWE-637 a owl:Class ;
+    rdfs:label "Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')" ;
+    rdfs:subClassOf :CWE-657 ;
+    :cwe-id "CWE-637" .
+
+:CWE-638 a owl:Class ;
+    rdfs:label "Not Using Complete Mediation" ;
+    rdfs:subClassOf :CWE-657,
+        :CWE-862 ;
+    :cwe-id "CWE-638" .
+
+:CWE-639 a owl:Class ;
+    rdfs:label "Authorization Bypass Through User-Controlled Key" ;
+    rdfs:subClassOf :CWE-863 ;
+    :cwe-id "CWE-639" .
+
+:CWE-640 a owl:Class ;
+    rdfs:label "Weak Password Recovery Mechanism for Forgotten Password" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-640" .
+
+:CWE-641 a owl:Class ;
+    rdfs:label "Improper Restriction of Names for Files and Other Resources" ;
+    rdfs:subClassOf :CWE-99 ;
+    :cwe-id "CWE-641" .
+
+:CWE-642 a owl:Class ;
+    rdfs:label "External Control of Critical State Data" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-642" .
+
+:CWE-643 a owl:Class ;
+    rdfs:label "Improper Neutralization of Data within XPath Expressions ('XPath Injection')" ;
+    rdfs:subClassOf :CWE-91,
+        :CWE-943 ;
+    :cwe-id "CWE-643" .
+
+:CWE-644 a owl:Class ;
+    rdfs:label "Improper Neutralization of HTTP Headers for Scripting Syntax" ;
+    rdfs:subClassOf :CWE-116 ;
+    :cwe-id "CWE-644" .
+
+:CWE-645 a owl:Class ;
+    rdfs:label "Overly Restrictive Account Lockout Mechanism" ;
+    rdfs:subClassOf :CWE-287 ;
+    :cwe-id "CWE-645" .
+
+:CWE-646 a owl:Class ;
+    rdfs:label "Reliance on File Name or Extension of Externally-Supplied File" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-646" .
+
+:CWE-647 a owl:Class ;
+    rdfs:label "Use of Non-Canonical URL Paths for Authorization Decisions" ;
+    rdfs:subClassOf :CWE-863 ;
+    :cwe-id "CWE-647" .
+
+:CWE-648 a owl:Class ;
+    rdfs:label "Incorrect Use of Privileged APIs" ;
+    rdfs:subClassOf :CWE-269 ;
+    :cwe-id "CWE-648" .
+
+:CWE-649 a owl:Class ;
+    rdfs:label "Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-649" .
+
+:CWE-650 a owl:Class ;
+    rdfs:label "Trusting HTTP Permission Methods on the Server Side" ;
+    rdfs:subClassOf :CWE-436 ;
+    :cwe-id "CWE-650" .
+
+:CWE-651 a owl:Class ;
+    rdfs:label "Exposure of WSDL File Containing Sensitive Information" ;
+    rdfs:subClassOf :CWE-538 ;
+    :cwe-id "CWE-651" .
+
+:CWE-652 a owl:Class ;
+    rdfs:label "Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')" ;
+    rdfs:subClassOf :CWE-91,
+        :CWE-943 ;
+    :cwe-id "CWE-652" .
+
+:CWE-653 a owl:Class ;
+    rdfs:label "Improper Isolation or Compartmentalization" ;
+    rdfs:subClassOf :CWE-657,
+        :CWE-693 ;
+    :cwe-id "CWE-653" .
+
+:CWE-654 a owl:Class ;
+    rdfs:label "Reliance on a Single Factor in a Security Decision" ;
+    rdfs:subClassOf :CWE-657,
+        :CWE-693 ;
+    :cwe-id "CWE-654" .
+
+:CWE-655 a owl:Class ;
+    rdfs:label "Insufficient Psychological Acceptability" ;
+    rdfs:subClassOf :CWE-657,
+        :CWE-693 ;
+    :cwe-id "CWE-655" .
+
+:CWE-656 a owl:Class ;
+    rdfs:label "Reliance on Security Through Obscurity" ;
+    rdfs:subClassOf :CWE-657,
+        :CWE-693 ;
+    :cwe-id "CWE-656" .
+
+:CWE-657 a owl:Class ;
+    rdfs:label "Violation of Secure Design Principles" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-657" .
+
+:CWE-662 a owl:Class ;
+    rdfs:label "Improper Synchronization" ;
+    rdfs:subClassOf :CWE-664,
+        :CWE-691 ;
+    :cwe-id "CWE-662" .
+
+:CWE-663 a owl:Class ;
+    rdfs:label "Use of a Non-reentrant Function in a Concurrent Context" ;
+    rdfs:subClassOf :CWE-662 ;
+    :cwe-id "CWE-663" .
+
+:CWE-664 a owl:Class ;
+    rdfs:label "Improper Control of a Resource Through its Lifetime" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-664" .
+
+:CWE-665 a owl:Class ;
+    rdfs:label "Improper Initialization" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-665" .
+
+:CWE-666 a owl:Class ;
+    rdfs:label "Operation on Resource in Wrong Phase of Lifetime" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-666" .
+
+:CWE-667 a owl:Class ;
+    rdfs:label "Improper Locking" ;
+    rdfs:subClassOf :CWE-662 ;
+    :cwe-id "CWE-667" .
+
+:CWE-668 a owl:Class ;
+    rdfs:label "Exposure of Resource to Wrong Sphere" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-668" .
+
+:CWE-669 a owl:Class ;
+    rdfs:label "Incorrect Resource Transfer Between Spheres" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-669" .
+
+:CWE-670 a owl:Class ;
+    rdfs:label "Always-Incorrect Control Flow Implementation" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-670" .
+
+:CWE-671 a owl:Class ;
+    rdfs:label "Lack of Administrator Control over Security" ;
+    rdfs:subClassOf :CWE-657 ;
+    :cwe-id "CWE-671" .
+
+:CWE-672 a owl:Class ;
+    rdfs:label "Operation on a Resource after Expiration or Release" ;
+    rdfs:subClassOf :CWE-666 ;
+    :cwe-id "CWE-672" .
+
+:CWE-673 a owl:Class ;
+    rdfs:label "External Influence of Sphere Definition" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-673" .
+
+:CWE-674 a owl:Class ;
+    rdfs:label "Uncontrolled Recursion" ;
+    rdfs:subClassOf :CWE-834 ;
+    :cwe-id "CWE-674" .
+
+:CWE-675 a owl:Class ;
+    rdfs:label "Multiple Operations on Resource in Single-Operation Context" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-675" .
+
+:CWE-676 a owl:Class ;
+    rdfs:label "Use of Potentially Dangerous Function" ;
+    rdfs:subClassOf :CWE-1177 ;
+    :cwe-id "CWE-676" .
+
+:CWE-680 a owl:Class ;
+    rdfs:label "Integer Overflow to Buffer Overflow" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-680" .
+
+:CWE-681 a owl:Class ;
+    rdfs:label "Incorrect Conversion between Numeric Types" ;
+    rdfs:subClassOf :CWE-704 ;
+    :cwe-id "CWE-681" .
+
+:CWE-682 a owl:Class ;
+    rdfs:label "Incorrect Calculation" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-682" .
+
+:CWE-683 a owl:Class ;
+    rdfs:label "Function Call With Incorrect Order of Arguments" ;
+    rdfs:subClassOf :CWE-628 ;
+    :cwe-id "CWE-683" .
+
+:CWE-684 a owl:Class ;
+    rdfs:label "Incorrect Provision of Specified Functionality" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-684" .
+
+:CWE-685 a owl:Class ;
+    rdfs:label "Function Call With Incorrect Number of Arguments" ;
+    rdfs:subClassOf :CWE-628 ;
+    :cwe-id "CWE-685" .
+
+:CWE-686 a owl:Class ;
+    rdfs:label "Function Call With Incorrect Argument Type" ;
+    rdfs:subClassOf :CWE-628 ;
+    :cwe-id "CWE-686" .
+
+:CWE-687 a owl:Class ;
+    rdfs:label "Function Call With Incorrectly Specified Argument Value" ;
+    rdfs:subClassOf :CWE-628 ;
+    :cwe-id "CWE-687" .
+
+:CWE-688 a owl:Class ;
+    rdfs:label "Function Call With Incorrect Variable or Reference as Argument" ;
+    rdfs:subClassOf :CWE-628 ;
+    :cwe-id "CWE-688" .
+
+:CWE-689 a owl:Class ;
+    rdfs:label "Permission Race Condition During Resource Copy" ;
+    rdfs:subClassOf :CWE-362 ;
+    :cwe-id "CWE-689" .
+
+:CWE-690 a owl:Class ;
+    rdfs:label "Unchecked Return Value to NULL Pointer Dereference" ;
+    rdfs:subClassOf :CWE-476 ;
+    :cwe-id "CWE-690" .
+
+:CWE-691 a owl:Class ;
+    rdfs:label "Insufficient Control Flow Management" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-691" .
+
+:CWE-692 a owl:Class ;
+    rdfs:label "Incomplete Denylist to Cross-Site Scripting" ;
+    rdfs:subClassOf :CWE-79 ;
+    :cwe-id "CWE-692" .
+
+:CWE-693 a owl:Class ;
+    rdfs:label "Protection Mechanism Failure" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-693" .
+
+:CWE-694 a owl:Class ;
+    rdfs:label "Use of Multiple Resources with Duplicate Identifier" ;
+    rdfs:subClassOf :CWE-99,
+        :CWE-573 ;
+    :cwe-id "CWE-694" .
+
+:CWE-695 a owl:Class ;
+    rdfs:label "Use of Low-Level Functionality" ;
+    rdfs:subClassOf :CWE-573 ;
+    :cwe-id "CWE-695" .
+
+:CWE-696 a owl:Class ;
+    rdfs:label "Incorrect Behavior Order" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-696" .
+
+:CWE-697 a owl:Class ;
+    rdfs:label "Incorrect Comparison" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-697" .
+
+:CWE-698 a owl:Class ;
+    rdfs:label "Execution After Redirect (EAR)" ;
+    rdfs:subClassOf :CWE-670,
+        :CWE-705 ;
+    :cwe-id "CWE-698" .
+
+:CWE-703 a owl:Class ;
+    rdfs:label "Improper Check or Handling of Exceptional Conditions" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-703" .
+
+:CWE-704 a owl:Class ;
+    rdfs:label "Incorrect Type Conversion or Cast" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-704" .
+
+:CWE-705 a owl:Class ;
+    rdfs:label "Incorrect Control Flow Scoping" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-705" .
+
+:CWE-706 a owl:Class ;
+    rdfs:label "Use of Incorrectly-Resolved Name or Reference" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-706" .
+
+:CWE-707 a owl:Class ;
+    rdfs:label "Improper Neutralization" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-707" .
+
+:CWE-708 a owl:Class ;
+    rdfs:label "Incorrect Ownership Assignment" ;
+    rdfs:subClassOf :CWE-282 ;
+    :cwe-id "CWE-708" .
+
+:CWE-710 a owl:Class ;
+    rdfs:label "Improper Adherence to Coding Standards" ;
+    rdfs:subClassOf :Weakness ;
+    :cwe-id "CWE-710" .
+
+:CWE-732 a owl:Class ;
+    rdfs:label "Incorrect Permission Assignment for Critical Resource" ;
+    rdfs:subClassOf :CWE-285,
+        :CWE-668 ;
+    :cwe-id "CWE-732" .
+
+:CWE-733 a owl:Class ;
+    rdfs:label "Compiler Optimization Removal or Modification of Security-critical Code" ;
+    rdfs:subClassOf :CWE-1038 ;
+    :cwe-id "CWE-733" .
+
+:CWE-749 a owl:Class ;
+    rdfs:label "Exposed Dangerous Method or Function" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-749" .
+
+:CWE-754 a owl:Class ;
+    rdfs:label "Improper Check for Unusual or Exceptional Conditions" ;
+    rdfs:subClassOf :CWE-703 ;
+    :cwe-id "CWE-754" .
+
+:CWE-755 a owl:Class ;
+    rdfs:label "Improper Handling of Exceptional Conditions" ;
+    rdfs:subClassOf :CWE-703 ;
+    :cwe-id "CWE-755" .
+
+:CWE-756 a owl:Class ;
+    rdfs:label "Missing Custom Error Page" ;
+    rdfs:subClassOf :CWE-755 ;
+    :cwe-id "CWE-756" .
+
+:CWE-757 a owl:Class ;
+    rdfs:label "Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-757" .
+
+:CWE-758 a owl:Class ;
+    rdfs:label "Reliance on Undefined, Unspecified, or Implementation-Defined Behavior" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-758" .
+
+:CWE-759 a owl:Class ;
+    rdfs:label "Use of a One-Way Hash without a Salt" ;
+    rdfs:subClassOf :CWE-916 ;
+    :cwe-id "CWE-759" .
+
+:CWE-760 a owl:Class ;
+    rdfs:label "Use of a One-Way Hash with a Predictable Salt" ;
+    rdfs:subClassOf :CWE-916 ;
+    :cwe-id "CWE-760" .
+
+:CWE-761 a owl:Class ;
+    rdfs:label "Free of Pointer not at Start of Buffer" ;
+    rdfs:subClassOf :CWE-763 ;
+    :cwe-id "CWE-761" .
+
+:CWE-762 a owl:Class ;
+    rdfs:label "Mismatched Memory Management Routines" ;
+    rdfs:subClassOf :CWE-763 ;
+    :cwe-id "CWE-762" .
+
+:CWE-763 a owl:Class ;
+    rdfs:label "Release of Invalid Pointer or Reference" ;
+    rdfs:subClassOf :CWE-404 ;
+    :cwe-id "CWE-763" .
+
+:CWE-764 a owl:Class ;
+    rdfs:label "Multiple Locks of a Critical Resource" ;
+    rdfs:subClassOf :CWE-667,
+        :CWE-675 ;
+    :cwe-id "CWE-764" .
+
+:CWE-765 a owl:Class ;
+    rdfs:label "Multiple Unlocks of a Critical Resource" ;
+    rdfs:subClassOf :CWE-667,
+        :CWE-675 ;
+    :cwe-id "CWE-765" .
+
+:CWE-766 a owl:Class ;
+    rdfs:label "Critical Data Element Declared Public" ;
+    rdfs:subClassOf :CWE-1061 ;
+    :cwe-id "CWE-766" .
+
+:CWE-767 a owl:Class ;
+    rdfs:label "Access to Critical Private Variable via Public Method" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-767" .
+
+:CWE-768 a owl:Class ;
+    rdfs:label "Incorrect Short Circuit Evaluation" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-768" .
+
+:CWE-770 a owl:Class ;
+    rdfs:label "Allocation of Resources Without Limits or Throttling" ;
+    rdfs:subClassOf :CWE-400,
+        :CWE-665 ;
+    :cwe-id "CWE-770" .
+
+:CWE-771 a owl:Class ;
+    rdfs:label "Missing Reference to Active Allocated Resource" ;
+    rdfs:subClassOf :CWE-400 ;
+    :cwe-id "CWE-771" .
+
+:CWE-772 a owl:Class ;
+    rdfs:label "Missing Release of Resource after Effective Lifetime" ;
+    rdfs:subClassOf :CWE-404 ;
+    :cwe-id "CWE-772" .
+
+:CWE-773 a owl:Class ;
+    rdfs:label "Missing Reference to Active File Descriptor or Handle" ;
+    rdfs:subClassOf :CWE-771 ;
+    :cwe-id "CWE-773" .
+
+:CWE-774 a owl:Class ;
+    rdfs:label "Allocation of File Descriptors or Handles Without Limits or Throttling" ;
+    rdfs:subClassOf :CWE-770 ;
+    :cwe-id "CWE-774" .
+
+:CWE-775 a owl:Class ;
+    rdfs:label "Missing Release of File Descriptor or Handle after Effective Lifetime" ;
+    rdfs:subClassOf :CWE-772 ;
+    :cwe-id "CWE-775" .
+
+:CWE-776 a owl:Class ;
+    rdfs:label "Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')" ;
+    rdfs:subClassOf :CWE-405,
+        :CWE-674 ;
+    :cwe-id "CWE-776" .
+
+:CWE-777 a owl:Class ;
+    rdfs:label "Regular Expression without Anchors" ;
+    rdfs:subClassOf :CWE-625 ;
+    :cwe-id "CWE-777" .
+
+:CWE-778 a owl:Class ;
+    rdfs:label "Insufficient Logging" ;
+    rdfs:subClassOf :CWE-223,
+        :CWE-693 ;
+    :cwe-id "CWE-778" .
+
+:CWE-779 a owl:Class ;
+    rdfs:label "Logging of Excessive Data" ;
+    rdfs:subClassOf :CWE-400 ;
+    :cwe-id "CWE-779" .
+
+:CWE-780 a owl:Class ;
+    rdfs:label "Use of RSA Algorithm without OAEP" ;
+    rdfs:subClassOf :CWE-327 ;
+    :cwe-id "CWE-780" .
+
+:CWE-781 a owl:Class ;
+    rdfs:label "Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code" ;
+    rdfs:subClassOf :CWE-1285 ;
+    :cwe-id "CWE-781" .
+
+:CWE-782 a owl:Class ;
+    rdfs:label "Exposed IOCTL with Insufficient Access Control" ;
+    rdfs:subClassOf :CWE-749 ;
+    :cwe-id "CWE-782" .
+
+:CWE-783 a owl:Class ;
+    rdfs:label "Operator Precedence Logic Error" ;
+    rdfs:subClassOf :CWE-670 ;
+    :cwe-id "CWE-783" .
+
+:CWE-784 a owl:Class ;
+    rdfs:label "Reliance on Cookies without Validation and Integrity Checking in a Security Decision" ;
+    rdfs:subClassOf :CWE-565,
+        :CWE-807 ;
+    :cwe-id "CWE-784" .
+
+:CWE-785 a owl:Class ;
+    rdfs:label "Use of Path Manipulation Function without Maximum-sized Buffer" ;
+    rdfs:subClassOf :CWE-120,
+        :CWE-676 ;
+    :cwe-id "CWE-785" .
+
+:CWE-786 a owl:Class ;
+    rdfs:label "Access of Memory Location Before Start of Buffer" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-786" .
+
 :CWE-787 a owl:Class ;
     rdfs:label "Out-of-bounds Write" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-119,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :RawMemoryAccessFunction ] ;
     :cwe-id "CWE-787" .
 
+:CWE-788 a owl:Class ;
+    rdfs:label "Access of Memory Location After End of Buffer" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-788" .
+
+:CWE-789 a owl:Class ;
+    rdfs:label "Memory Allocation with Excessive Size Value" ;
+    rdfs:subClassOf :CWE-770,
+        :CWE-1284 ;
+    :cwe-id "CWE-789" .
+
+:CWE-790 a owl:Class ;
+    rdfs:label "Improper Filtering of Special Elements" ;
+    rdfs:subClassOf :CWE-138 ;
+    :cwe-id "CWE-790" .
+
+:CWE-791 a owl:Class ;
+    rdfs:label "Incomplete Filtering of Special Elements" ;
+    rdfs:subClassOf :CWE-790 ;
+    :cwe-id "CWE-791" .
+
+:CWE-792 a owl:Class ;
+    rdfs:label "Incomplete Filtering of One or More Instances of Special Elements" ;
+    rdfs:subClassOf :CWE-791 ;
+    :cwe-id "CWE-792" .
+
+:CWE-793 a owl:Class ;
+    rdfs:label "Only Filtering One Instance of a Special Element" ;
+    rdfs:subClassOf :CWE-792 ;
+    :cwe-id "CWE-793" .
+
+:CWE-794 a owl:Class ;
+    rdfs:label "Incomplete Filtering of Multiple Instances of Special Elements" ;
+    rdfs:subClassOf :CWE-792 ;
+    :cwe-id "CWE-794" .
+
+:CWE-795 a owl:Class ;
+    rdfs:label "Only Filtering Special Elements at a Specified Location" ;
+    rdfs:subClassOf :CWE-791 ;
+    :cwe-id "CWE-795" .
+
+:CWE-796 a owl:Class ;
+    rdfs:label "Only Filtering Special Elements Relative to a Marker" ;
+    rdfs:subClassOf :CWE-795 ;
+    :cwe-id "CWE-796" .
+
+:CWE-797 a owl:Class ;
+    rdfs:label "Only Filtering Special Elements at an Absolute Position" ;
+    rdfs:subClassOf :CWE-795 ;
+    :cwe-id "CWE-797" .
+
 :CWE-798 a owl:Class ;
     rdfs:label "Use of Hard-coded Credentials" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-344,
+        :CWE-671,
+        :CWE-1391,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :AuthenticationFunction ] ;
     :cwe-id "CWE-798" .
 
+:CWE-799 a owl:Class ;
+    rdfs:label "Improper Control of Interaction Frequency" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-799" .
+
+:CWE-804 a owl:Class ;
+    rdfs:label "Guessable CAPTCHA" ;
+    rdfs:subClassOf :CWE-863,
+        :CWE-1390 ;
+    :cwe-id "CWE-804" .
+
+:CWE-805 a owl:Class ;
+    rdfs:label "Buffer Access with Incorrect Length Value" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-805" .
+
+:CWE-806 a owl:Class ;
+    rdfs:label "Buffer Access Using Size of Source Buffer" ;
+    rdfs:subClassOf :CWE-805 ;
+    :cwe-id "CWE-806" .
+
+:CWE-807 a owl:Class ;
+    rdfs:label "Reliance on Untrusted Inputs in a Security Decision" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-807" .
+
+:CWE-820 a owl:Class ;
+    rdfs:label "Missing Synchronization" ;
+    rdfs:subClassOf :CWE-662 ;
+    :cwe-id "CWE-820" .
+
+:CWE-821 a owl:Class ;
+    rdfs:label "Incorrect Synchronization" ;
+    rdfs:subClassOf :CWE-662 ;
+    :cwe-id "CWE-821" .
+
+:CWE-822 a owl:Class ;
+    rdfs:label "Untrusted Pointer Dereference" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-822" .
+
+:CWE-823 a owl:Class ;
+    rdfs:label "Use of Out-of-range Pointer Offset" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-823" .
+
+:CWE-824 a owl:Class ;
+    rdfs:label "Access of Uninitialized Pointer" ;
+    rdfs:subClassOf :CWE-119 ;
+    :cwe-id "CWE-824" .
+
+:CWE-825 a owl:Class ;
+    rdfs:label "Expired Pointer Dereference" ;
+    rdfs:subClassOf :CWE-119,
+        :CWE-672 ;
+    :cwe-id "CWE-825" .
+
+:CWE-826 a owl:Class ;
+    rdfs:label "Premature Release of Resource During Expected Lifetime" ;
+    rdfs:subClassOf :CWE-666 ;
+    :cwe-id "CWE-826" .
+
+:CWE-827 a owl:Class ;
+    rdfs:label "Improper Control of Document Type Definition" ;
+    rdfs:subClassOf :CWE-706,
+        :CWE-829 ;
+    :cwe-id "CWE-827" .
+
+:CWE-828 a owl:Class ;
+    rdfs:label "Signal Handler with Functionality that is not Asynchronous-Safe" ;
+    rdfs:subClassOf :CWE-364 ;
+    :cwe-id "CWE-828" .
+
+:CWE-829 a owl:Class ;
+    rdfs:label "Inclusion of Functionality from Untrusted Control Sphere" ;
+    rdfs:subClassOf :CWE-669 ;
+    :cwe-id "CWE-829" .
+
+:CWE-830 a owl:Class ;
+    rdfs:label "Inclusion of Web Functionality from an Untrusted Source" ;
+    rdfs:subClassOf :CWE-829 ;
+    :cwe-id "CWE-830" .
+
+:CWE-831 a owl:Class ;
+    rdfs:label "Signal Handler Function Associated with Multiple Signals" ;
+    rdfs:subClassOf :CWE-364 ;
+    :cwe-id "CWE-831" .
+
+:CWE-832 a owl:Class ;
+    rdfs:label "Unlock of a Resource that is not Locked" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-832" .
+
+:CWE-833 a owl:Class ;
+    rdfs:label "Deadlock" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-833" .
+
+:CWE-834 a owl:Class ;
+    rdfs:label "Excessive Iteration" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-834" .
+
+:CWE-835 a owl:Class ;
+    rdfs:label "Loop with Unreachable Exit Condition ('Infinite Loop')" ;
+    rdfs:subClassOf :CWE-834 ;
+    :cwe-id "CWE-835" .
+
+:CWE-836 a owl:Class ;
+    rdfs:label "Use of Password Hash Instead of Password for Authentication" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-836" .
+
+:CWE-837 a owl:Class ;
+    rdfs:label "Improper Enforcement of a Single, Unique Action" ;
+    rdfs:subClassOf :CWE-799 ;
+    :cwe-id "CWE-837" .
+
+:CWE-838 a owl:Class ;
+    rdfs:label "Inappropriate Encoding for Output Context" ;
+    rdfs:subClassOf :CWE-116 ;
+    :cwe-id "CWE-838" .
+
+:CWE-839 a owl:Class ;
+    rdfs:label "Numeric Range Comparison Without Minimum Check" ;
+    rdfs:subClassOf :CWE-1023 ;
+    :cwe-id "CWE-839" .
+
+:CWE-841 a owl:Class ;
+    rdfs:label "Improper Enforcement of Behavioral Workflow" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-841" .
+
+:CWE-842 a owl:Class ;
+    rdfs:label "Placement of User into Incorrect Group" ;
+    rdfs:subClassOf :CWE-286 ;
+    :cwe-id "CWE-842" .
+
+:CWE-843 a owl:Class ;
+    rdfs:label "Access of Resource Using Incompatible Type ('Type Confusion')" ;
+    rdfs:subClassOf :CWE-704 ;
+    :cwe-id "CWE-843" .
+
 :CWE-862 a owl:Class ;
     rdfs:label "Missing Authorization" ;
-    rdfs:subClassOf :Weakness ;
+    rdfs:subClassOf :CWE-285 ;
     rdfs:comment "Broad and could apply to all resource accesses." ;
     :cwe-id "CWE-862" .
 
+:CWE-863 a owl:Class ;
+    rdfs:label "Incorrect Authorization" ;
+    rdfs:subClassOf :CWE-285 ;
+    :cwe-id "CWE-863" .
+
+:CWE-908 a owl:Class ;
+    rdfs:label "Use of Uninitialized Resource" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-908" .
+
+:CWE-909 a owl:Class ;
+    rdfs:label "Missing Initialization of Resource" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-909" .
+
+:CWE-910 a owl:Class ;
+    rdfs:label "Use of Expired File Descriptor" ;
+    rdfs:subClassOf :CWE-672 ;
+    :cwe-id "CWE-910" .
+
+:CWE-911 a owl:Class ;
+    rdfs:label "Improper Update of Reference Count" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-911" .
+
+:CWE-912 a owl:Class ;
+    rdfs:label "Hidden Functionality" ;
+    rdfs:subClassOf :CWE-684 ;
+    :cwe-id "CWE-912" .
+
+:CWE-913 a owl:Class ;
+    rdfs:label "Improper Control of Dynamically-Managed Code Resources" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-913" .
+
+:CWE-914 a owl:Class ;
+    rdfs:label "Improper Control of Dynamically-Identified Variables" ;
+    rdfs:subClassOf :CWE-99,
+        :CWE-913 ;
+    :cwe-id "CWE-914" .
+
+:CWE-915 a owl:Class ;
+    rdfs:label "Improperly Controlled Modification of Dynamically-Determined Object Attributes" ;
+    rdfs:subClassOf :CWE-913 ;
+    :cwe-id "CWE-915" .
+
+:CWE-916 a owl:Class ;
+    rdfs:label "Use of Password Hash With Insufficient Computational Effort" ;
+    rdfs:subClassOf :CWE-327 ;
+    :cwe-id "CWE-916" .
+
+:CWE-917 a owl:Class ;
+    rdfs:label "Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')" ;
+    rdfs:subClassOf :CWE-77 ;
+    :cwe-id "CWE-917" .
+
 :CWE-918 a owl:Class ;
     rdfs:label "Server-Side Request Forgery (SSRF)" ;
-    rdfs:subClassOf :Weakness,
+    rdfs:subClassOf :CWE-441,
         [ a owl:Restriction ;
             owl:onProperty :weakness-of ;
             owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-918" .
+
+:CWE-920 a owl:Class ;
+    rdfs:label "Improper Restriction of Power Consumption" ;
+    rdfs:subClassOf :CWE-400 ;
+    :cwe-id "CWE-920" .
+
+:CWE-921 a owl:Class ;
+    rdfs:label "Storage of Sensitive Data in a Mechanism without Access Control" ;
+    rdfs:subClassOf :CWE-922 ;
+    :cwe-id "CWE-921" .
+
+:CWE-922 a owl:Class ;
+    rdfs:label "Insecure Storage of Sensitive Information" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-922" .
+
+:CWE-923 a owl:Class ;
+    rdfs:label "Improper Restriction of Communication Channel to Intended Endpoints" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-923" .
+
+:CWE-924 a owl:Class ;
+    rdfs:label "Improper Enforcement of Message Integrity During Transmission in a Communication Channel" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-924" .
+
+:CWE-925 a owl:Class ;
+    rdfs:label "Improper Verification of Intent by Broadcast Receiver" ;
+    rdfs:subClassOf :CWE-940 ;
+    :cwe-id "CWE-925" .
+
+:CWE-926 a owl:Class ;
+    rdfs:label "Improper Export of Android Application Components" ;
+    rdfs:subClassOf :CWE-285 ;
+    :cwe-id "CWE-926" .
+
+:CWE-927 a owl:Class ;
+    rdfs:label "Use of Implicit Intent for Sensitive Communication" ;
+    rdfs:subClassOf :CWE-285,
+        :CWE-668 ;
+    :cwe-id "CWE-927" .
+
+:CWE-939 a owl:Class ;
+    rdfs:label "Improper Authorization in Handler for Custom URL Scheme" ;
+    rdfs:subClassOf :CWE-862 ;
+    :cwe-id "CWE-939" .
+
+:CWE-940 a owl:Class ;
+    rdfs:label "Improper Verification of Source of a Communication Channel" ;
+    rdfs:subClassOf :CWE-923 ;
+    :cwe-id "CWE-940" .
+
+:CWE-941 a owl:Class ;
+    rdfs:label "Incorrectly Specified Destination in a Communication Channel" ;
+    rdfs:subClassOf :CWE-923 ;
+    :cwe-id "CWE-941" .
+
+:CWE-942 a owl:Class ;
+    rdfs:label "Permissive Cross-domain Policy with Untrusted Domains" ;
+    rdfs:subClassOf :CWE-183,
+        :CWE-923 ;
+    :cwe-id "CWE-942" .
+
+:CWE-943 a owl:Class ;
+    rdfs:label "Improper Neutralization of Special Elements in Data Query Logic" ;
+    rdfs:subClassOf :CWE-74 ;
+    :cwe-id "CWE-943" .
+
+:CWE-1004 a owl:Class ;
+    rdfs:label "Sensitive Cookie Without 'HttpOnly' Flag" ;
+    rdfs:subClassOf :CWE-732 ;
+    :cwe-id "CWE-1004" .
+
+:CWE-1007 a owl:Class ;
+    rdfs:label "Insufficient Visual Distinction of Homoglyphs Presented to User" ;
+    rdfs:subClassOf :CWE-451 ;
+    :cwe-id "CWE-1007" .
+
+:CWE-1021 a owl:Class ;
+    rdfs:label "Improper Restriction of Rendered UI Layers or Frames" ;
+    rdfs:subClassOf :CWE-441,
+        :CWE-451 ;
+    :cwe-id "CWE-1021" .
+
+:CWE-1022 a owl:Class ;
+    rdfs:label "Use of Web Link to Untrusted Target with window.opener Access" ;
+    rdfs:subClassOf :CWE-266 ;
+    :cwe-id "CWE-1022" .
+
+:CWE-1023 a owl:Class ;
+    rdfs:label "Incomplete Comparison with Missing Factors" ;
+    rdfs:subClassOf :CWE-697 ;
+    :cwe-id "CWE-1023" .
+
+:CWE-1024 a owl:Class ;
+    rdfs:label "Comparison of Incompatible Types" ;
+    rdfs:subClassOf :CWE-697 ;
+    :cwe-id "CWE-1024" .
+
+:CWE-1025 a owl:Class ;
+    rdfs:label "Comparison Using Wrong Factors" ;
+    rdfs:subClassOf :CWE-697 ;
+    :cwe-id "CWE-1025" .
+
+:CWE-1037 a owl:Class ;
+    rdfs:label "Processor Optimization Removal or Modification of Security-critical Code" ;
+    rdfs:subClassOf :CWE-1038 ;
+    :cwe-id "CWE-1037" .
+
+:CWE-1038 a owl:Class ;
+    rdfs:label "Insecure Automated Optimizations" ;
+    rdfs:subClassOf :CWE-435,
+        :CWE-758 ;
+    :cwe-id "CWE-1038" .
+
+:CWE-1039 a owl:Class ;
+    rdfs:label "Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations" ;
+    rdfs:subClassOf :CWE-693,
+        :CWE-697 ;
+    :cwe-id "CWE-1039" .
+
+:CWE-1041 a owl:Class ;
+    rdfs:label "Use of Redundant Code" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1041" .
+
+:CWE-1042 a owl:Class ;
+    rdfs:label "Static Member Data Element outside of a Singleton Class Element" ;
+    rdfs:subClassOf :CWE-1176 ;
+    :cwe-id "CWE-1042" .
+
+:CWE-1043 a owl:Class ;
+    rdfs:label "Data Element Aggregating an Excessively Large Number of Non-Primitive Elements" ;
+    rdfs:subClassOf :CWE-1093 ;
+    :cwe-id "CWE-1043" .
+
+:CWE-1044 a owl:Class ;
+    rdfs:label "Architecture with Number of Horizontal Layers Outside of Expected Range" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1044" .
+
+:CWE-1045 a owl:Class ;
+    rdfs:label "Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1045" .
+
+:CWE-1046 a owl:Class ;
+    rdfs:label "Creation of Immutable Text Using String Concatenation" ;
+    rdfs:subClassOf :CWE-1176 ;
+    :cwe-id "CWE-1046" .
+
+:CWE-1047 a owl:Class ;
+    rdfs:label "Modules with Circular Dependencies" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1047" .
+
+:CWE-1048 a owl:Class ;
+    rdfs:label "Invokable Control Element with Large Number of Outward Calls" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1048" .
+
+:CWE-1049 a owl:Class ;
+    rdfs:label "Excessive Data Query Operations in a Large Data Table" ;
+    rdfs:subClassOf :CWE-1176 ;
+    :cwe-id "CWE-1049" .
+
+:CWE-1050 a owl:Class ;
+    rdfs:label "Excessive Platform Resource Consumption within a Loop" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-1050" .
+
+:CWE-1051 a owl:Class ;
+    rdfs:label "Initialization with Hard-Coded Network Resource Configuration Data" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-1051" .
+
+:CWE-1052 a owl:Class ;
+    rdfs:label "Excessive Use of Hard-Coded Literals in Initialization" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-1052" .
+
+:CWE-1053 a owl:Class ;
+    rdfs:label "Missing Documentation for Design" ;
+    rdfs:subClassOf :CWE-1059 ;
+    :cwe-id "CWE-1053" .
+
+:CWE-1054 a owl:Class ;
+    rdfs:label "Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer" ;
+    rdfs:subClassOf :CWE-1061 ;
+    :cwe-id "CWE-1054" .
+
+:CWE-1055 a owl:Class ;
+    rdfs:label "Multiple Inheritance from Concrete Classes" ;
+    rdfs:subClassOf :CWE-1093 ;
+    :cwe-id "CWE-1055" .
+
+:CWE-1056 a owl:Class ;
+    rdfs:label "Invokable Control Element with Variadic Parameters" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1056" .
+
+:CWE-1057 a owl:Class ;
+    rdfs:label "Data Access Operations Outside of Expected Data Manager Component" ;
+    rdfs:subClassOf :CWE-1061 ;
+    :cwe-id "CWE-1057" .
+
+:CWE-1058 a owl:Class ;
+    rdfs:label "Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element" ;
+    rdfs:subClassOf :CWE-662 ;
+    :cwe-id "CWE-1058" .
+
+:CWE-1059 a owl:Class ;
+    rdfs:label "Insufficient Technical Documentation" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1059" .
+
+:CWE-1060 a owl:Class ;
+    rdfs:label "Excessive Number of Inefficient Server-Side Data Accesses" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1060" .
+
+:CWE-1061 a owl:Class ;
+    rdfs:label "Insufficient Encapsulation" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1061" .
+
+:CWE-1062 a owl:Class ;
+    rdfs:label "Parent Class with References to Child Class" ;
+    rdfs:subClassOf :CWE-1061 ;
+    :cwe-id "CWE-1062" .
+
+:CWE-1063 a owl:Class ;
+    rdfs:label "Creation of Class Instance within a Static Code Block" ;
+    rdfs:subClassOf :CWE-1176 ;
+    :cwe-id "CWE-1063" .
+
+:CWE-1064 a owl:Class ;
+    rdfs:label "Invokable Control Element with Signature Containing an Excessive Number of Parameters" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1064" .
+
+:CWE-1065 a owl:Class ;
+    rdfs:label "Runtime Resource Management Control Element in a Component Built to Run on Application Servers" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1065" .
+
+:CWE-1066 a owl:Class ;
+    rdfs:label "Missing Serialization Control Element" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1066" .
+
+:CWE-1067 a owl:Class ;
+    rdfs:label "Excessive Execution of Sequential Searches of Data Resource" ;
+    rdfs:subClassOf :CWE-1176 ;
+    :cwe-id "CWE-1067" .
+
+:CWE-1068 a owl:Class ;
+    rdfs:label "Inconsistency Between Implementation and Documented Design" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1068" .
+
+:CWE-1069 a owl:Class ;
+    rdfs:label "Empty Exception Block" ;
+    rdfs:subClassOf :CWE-1071 ;
+    :cwe-id "CWE-1069" .
+
+:CWE-1070 a owl:Class ;
+    rdfs:label "Serializable Data Element Containing non-Serializable Item Elements" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1070" .
+
+:CWE-1071 a owl:Class ;
+    rdfs:label "Empty Code Block" ;
+    rdfs:subClassOf :CWE-1164 ;
+    :cwe-id "CWE-1071" .
+
+:CWE-1072 a owl:Class ;
+    rdfs:label "Data Resource Access without Use of Connection Pooling" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-1072" .
+
+:CWE-1073 a owl:Class ;
+    rdfs:label "Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-1073" .
+
+:CWE-1074 a owl:Class ;
+    rdfs:label "Class with Excessively Deep Inheritance" ;
+    rdfs:subClassOf :CWE-1093 ;
+    :cwe-id "CWE-1074" .
+
+:CWE-1075 a owl:Class ;
+    rdfs:label "Unconditional Control Flow Transfer outside of Switch Block" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1075" .
+
+:CWE-1076 a owl:Class ;
+    rdfs:label "Insufficient Adherence to Expected Conventions" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1076" .
+
+:CWE-1077 a owl:Class ;
+    rdfs:label "Floating Point Comparison with Incorrect Operator" ;
+    rdfs:subClassOf :CWE-697 ;
+    :cwe-id "CWE-1077" .
+
+:CWE-1078 a owl:Class ;
+    rdfs:label "Inappropriate Source Code Style or Formatting" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1078" .
+
+:CWE-1079 a owl:Class ;
+    rdfs:label "Parent Class without Virtual Destructor Method" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1079" .
+
+:CWE-1080 a owl:Class ;
+    rdfs:label "Source Code File with Excessive Number of Lines of Code" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1080" .
+
+:CWE-1082 a owl:Class ;
+    rdfs:label "Class Instance Self Destruction Control Element" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1082" .
+
+:CWE-1083 a owl:Class ;
+    rdfs:label "Data Access from Outside Expected Data Manager Component" ;
+    rdfs:subClassOf :CWE-1061 ;
+    :cwe-id "CWE-1083" .
+
+:CWE-1084 a owl:Class ;
+    rdfs:label "Invokable Control Element with Excessive File or Data Access Operations" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-1084" .
+
+:CWE-1085 a owl:Class ;
+    rdfs:label "Invokable Control Element with Excessive Volume of Commented-out Code" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1085" .
+
+:CWE-1086 a owl:Class ;
+    rdfs:label "Class with Excessive Number of Child Classes" ;
+    rdfs:subClassOf :CWE-1093 ;
+    :cwe-id "CWE-1086" .
+
+:CWE-1087 a owl:Class ;
+    rdfs:label "Class with Virtual Method without a Virtual Destructor" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1087" .
+
+:CWE-1088 a owl:Class ;
+    rdfs:label "Synchronous Access of Remote Resource without Timeout" ;
+    rdfs:subClassOf :CWE-821 ;
+    :cwe-id "CWE-1088" .
+
+:CWE-1089 a owl:Class ;
+    rdfs:label "Large Data Table with Excessive Number of Indices" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-1089" .
+
+:CWE-1090 a owl:Class ;
+    rdfs:label "Method Containing Access of a Member Element from Another Class" ;
+    rdfs:subClassOf :CWE-1061 ;
+    :cwe-id "CWE-1090" .
+
+:CWE-1091 a owl:Class ;
+    rdfs:label "Use of Object without Invoking Destructor Method" ;
+    rdfs:subClassOf :CWE-772,
+        :CWE-1076 ;
+    :cwe-id "CWE-1091" .
+
+:CWE-1092 a owl:Class ;
+    rdfs:label "Use of Same Invokable Control Element in Multiple Architectural Layers" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1092" .
+
+:CWE-1093 a owl:Class ;
+    rdfs:label "Excessively Complex Data Representation" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1093" .
+
+:CWE-1094 a owl:Class ;
+    rdfs:label "Excessive Index Range Scan for a Data Resource" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-1094" .
+
+:CWE-1095 a owl:Class ;
+    rdfs:label "Loop Condition Value Update within the Loop" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1095" .
+
+:CWE-1096 a owl:Class ;
+    rdfs:label "Singleton Class Instance Creation without Proper Locking or Synchronization" ;
+    rdfs:subClassOf :CWE-820 ;
+    :cwe-id "CWE-1096" .
+
+:CWE-1097 a owl:Class ;
+    rdfs:label "Persistent Storable Data Element without Associated Comparison Control Element" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1097" .
+
+:CWE-1098 a owl:Class ;
+    rdfs:label "Data Element containing Pointer Item without Proper Copy Control Element" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1098" .
+
+:CWE-1099 a owl:Class ;
+    rdfs:label "Inconsistent Naming Conventions for Identifiers" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1099" .
+
+:CWE-1100 a owl:Class ;
+    rdfs:label "Insufficient Isolation of System-Dependent Functions" ;
+    rdfs:subClassOf :CWE-1061 ;
+    :cwe-id "CWE-1100" .
+
+:CWE-1101 a owl:Class ;
+    rdfs:label "Reliance on Runtime Component in Generated Code" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1101" .
+
+:CWE-1102 a owl:Class ;
+    rdfs:label "Reliance on Machine-Dependent Data Representation" ;
+    rdfs:subClassOf :CWE-758 ;
+    :cwe-id "CWE-1102" .
+
+:CWE-1103 a owl:Class ;
+    rdfs:label "Use of Platform-Dependent Third Party Components" ;
+    rdfs:subClassOf :CWE-758 ;
+    :cwe-id "CWE-1103" .
+
+:CWE-1104 a owl:Class ;
+    rdfs:label "Use of Unmaintained Third Party Components" ;
+    rdfs:subClassOf :CWE-1357 ;
+    :cwe-id "CWE-1104" .
+
+:CWE-1105 a owl:Class ;
+    rdfs:label "Insufficient Encapsulation of Machine-Dependent Functionality" ;
+    rdfs:subClassOf :CWE-758,
+        :CWE-1061 ;
+    :cwe-id "CWE-1105" .
+
+:CWE-1106 a owl:Class ;
+    rdfs:label "Insufficient Use of Symbolic Constants" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1106" .
+
+:CWE-1107 a owl:Class ;
+    rdfs:label "Insufficient Isolation of Symbolic Constant Definitions" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1107" .
+
+:CWE-1108 a owl:Class ;
+    rdfs:label "Excessive Reliance on Global Variables" ;
+    rdfs:subClassOf :CWE-1076 ;
+    :cwe-id "CWE-1108" .
+
+:CWE-1109 a owl:Class ;
+    rdfs:label "Use of Same Variable for Multiple Purposes" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1109" .
+
+:CWE-1110 a owl:Class ;
+    rdfs:label "Incomplete Design Documentation" ;
+    rdfs:subClassOf :CWE-1059 ;
+    :cwe-id "CWE-1110" .
+
+:CWE-1111 a owl:Class ;
+    rdfs:label "Incomplete I/O Documentation" ;
+    rdfs:subClassOf :CWE-1059 ;
+    :cwe-id "CWE-1111" .
+
+:CWE-1112 a owl:Class ;
+    rdfs:label "Incomplete Documentation of Program Execution" ;
+    rdfs:subClassOf :CWE-1059 ;
+    :cwe-id "CWE-1112" .
+
+:CWE-1113 a owl:Class ;
+    rdfs:label "Inappropriate Comment Style" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1113" .
+
+:CWE-1114 a owl:Class ;
+    rdfs:label "Inappropriate Whitespace Style" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1114" .
+
+:CWE-1115 a owl:Class ;
+    rdfs:label "Source Code Element without Standard Prologue" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1115" .
+
+:CWE-1116 a owl:Class ;
+    rdfs:label "Inaccurate Comments" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1116" .
+
+:CWE-1117 a owl:Class ;
+    rdfs:label "Callable with Insufficient Behavioral Summary" ;
+    rdfs:subClassOf :CWE-1078 ;
+    :cwe-id "CWE-1117" .
+
+:CWE-1118 a owl:Class ;
+    rdfs:label "Insufficient Documentation of Error Handling Techniques" ;
+    rdfs:subClassOf :CWE-1059 ;
+    :cwe-id "CWE-1118" .
+
+:CWE-1119 a owl:Class ;
+    rdfs:label "Excessive Use of Unconditional Branching" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1119" .
+
+:CWE-1120 a owl:Class ;
+    rdfs:label "Excessive Code Complexity" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1120" .
+
+:CWE-1121 a owl:Class ;
+    rdfs:label "Excessive McCabe Cyclomatic Complexity" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1121" .
+
+:CWE-1122 a owl:Class ;
+    rdfs:label "Excessive Halstead Complexity" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1122" .
+
+:CWE-1123 a owl:Class ;
+    rdfs:label "Excessive Use of Self-Modifying Code" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1123" .
+
+:CWE-1124 a owl:Class ;
+    rdfs:label "Excessively Deep Nesting" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1124" .
+
+:CWE-1125 a owl:Class ;
+    rdfs:label "Excessive Attack Surface" ;
+    rdfs:subClassOf :CWE-1120 ;
+    :cwe-id "CWE-1125" .
+
+:CWE-1126 a owl:Class ;
+    rdfs:label "Declaration of Variable with Unnecessarily Wide Scope" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1126" .
+
+:CWE-1127 a owl:Class ;
+    rdfs:label "Compilation with Insufficient Warnings or Errors" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1127" .
+
+:CWE-1164 a owl:Class ;
+    rdfs:label "Irrelevant Code" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1164" .
+
+:CWE-1173 a owl:Class ;
+    rdfs:label "Improper Use of Validation Framework" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-1173" .
+
+:CWE-1174 a owl:Class ;
+    rdfs:label "ASP.NET Misconfiguration: Improper Model Validation" ;
+    rdfs:subClassOf :CWE-1173 ;
+    :cwe-id "CWE-1174" .
+
+:CWE-1176 a owl:Class ;
+    rdfs:label "Inefficient CPU Computation" ;
+    rdfs:subClassOf :CWE-405 ;
+    :cwe-id "CWE-1176" .
+
+:CWE-1177 a owl:Class ;
+    rdfs:label "Use of Prohibited Code" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1177" .
+
+:CWE-1188 a owl:Class ;
+    rdfs:label "Insecure Default Initialization of Resource" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-1188" .
+
+:CWE-1189 a owl:Class ;
+    rdfs:label "Improper Isolation of Shared Resources on System-on-a-Chip (SoC)" ;
+    rdfs:subClassOf :CWE-653,
+        :CWE-668 ;
+    :cwe-id "CWE-1189" .
+
+:CWE-1190 a owl:Class ;
+    rdfs:label "DMA Device Enabled Too Early in Boot Phase" ;
+    rdfs:subClassOf :CWE-696 ;
+    :cwe-id "CWE-1190" .
+
+:CWE-1191 a owl:Class ;
+    rdfs:label "On-Chip Debug and Test Interface With Improper Access Control" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1191" .
+
+:CWE-1192 a owl:Class ;
+    rdfs:label "System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers" ;
+    rdfs:subClassOf :CWE-657 ;
+    :cwe-id "CWE-1192" .
+
+:CWE-1193 a owl:Class ;
+    rdfs:label "Power-On of Untrusted Execution Core Before Enabling Fabric Access Control" ;
+    rdfs:subClassOf :CWE-696 ;
+    :cwe-id "CWE-1193" .
+
+:CWE-1204 a owl:Class ;
+    rdfs:label "Generation of Weak Initialization Vector (IV)" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-1204" .
+
+:CWE-1209 a owl:Class ;
+    rdfs:label "Failure to Disable Reserved Bits" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1209" .
+
+:CWE-1220 a owl:Class ;
+    rdfs:label "Insufficient Granularity of Access Control" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1220" .
+
+:CWE-1221 a owl:Class ;
+    rdfs:label "Incorrect Register Defaults or Module Parameters" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-1221" .
+
+:CWE-1222 a owl:Class ;
+    rdfs:label "Insufficient Granularity of Address Regions Protected by Register Locks" ;
+    rdfs:subClassOf :CWE-1220 ;
+    :cwe-id "CWE-1222" .
+
+:CWE-1223 a owl:Class ;
+    rdfs:label "Race Condition for Write-Once Attributes" ;
+    rdfs:subClassOf :CWE-362 ;
+    :cwe-id "CWE-1223" .
+
+:CWE-1224 a owl:Class ;
+    rdfs:label "Improper Restriction of Write-Once Bit Fields" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1224" .
+
+:CWE-1229 a owl:Class ;
+    rdfs:label "Creation of Emergent Resource" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-1229" .
+
+:CWE-1230 a owl:Class ;
+    rdfs:label "Exposure of Sensitive Information Through Metadata" ;
+    rdfs:subClassOf :CWE-285 ;
+    :cwe-id "CWE-1230" .
+
+:CWE-1231 a owl:Class ;
+    rdfs:label "Improper Prevention of Lock Bit Modification" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1231" .
+
+:CWE-1232 a owl:Class ;
+    rdfs:label "Improper Lock Behavior After Power State Transition" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-1232" .
+
+:CWE-1233 a owl:Class ;
+    rdfs:label "Security-Sensitive Hardware Controls with Missing Lock Bit Protection" ;
+    rdfs:subClassOf :CWE-284,
+        :CWE-667 ;
+    :cwe-id "CWE-1233" .
+
+:CWE-1234 a owl:Class ;
+    rdfs:label "Hardware Internal or Debug Modes Allow Override of Locks" ;
+    rdfs:subClassOf :CWE-667 ;
+    :cwe-id "CWE-1234" .
+
+:CWE-1235 a owl:Class ;
+    rdfs:label "Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations" ;
+    rdfs:subClassOf :CWE-400 ;
+    :cwe-id "CWE-1235" .
+
+:CWE-1236 a owl:Class ;
+    rdfs:label "Improper Neutralization of Formula Elements in a CSV File" ;
+    rdfs:subClassOf :CWE-74 ;
+    :cwe-id "CWE-1236" .
+
+:CWE-1239 a owl:Class ;
+    rdfs:label "Improper Zeroization of Hardware Register" ;
+    rdfs:subClassOf :CWE-226 ;
+    :cwe-id "CWE-1239" .
+
+:CWE-1240 a owl:Class ;
+    rdfs:label "Use of a Cryptographic Primitive with a Risky Implementation" ;
+    rdfs:subClassOf :CWE-327 ;
+    :cwe-id "CWE-1240" .
+
+:CWE-1241 a owl:Class ;
+    rdfs:label "Use of Predictable Algorithm in Random Number Generator" ;
+    rdfs:subClassOf :CWE-330 ;
+    :cwe-id "CWE-1241" .
+
+:CWE-1242 a owl:Class ;
+    rdfs:label "Inclusion of Undocumented Features or Chicken Bits" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1242" .
+
+:CWE-1243 a owl:Class ;
+    rdfs:label "Sensitive Non-Volatile Information Not Protected During Debug" ;
+    rdfs:subClassOf :CWE-1263 ;
+    :cwe-id "CWE-1243" .
+
+:CWE-1244 a owl:Class ;
+    rdfs:label "Internal Asset Exposed to Unsafe Debug Access Level or State" ;
+    rdfs:subClassOf :CWE-863 ;
+    :cwe-id "CWE-1244" .
+
+:CWE-1245 a owl:Class ;
+    rdfs:label "Improper Finite State Machines (FSMs) in Hardware Logic" ;
+    rdfs:subClassOf :CWE-684 ;
+    :cwe-id "CWE-1245" .
+
+:CWE-1246 a owl:Class ;
+    rdfs:label "Improper Write Handling in Limited-write Non-Volatile Memories" ;
+    rdfs:subClassOf :CWE-400 ;
+    :cwe-id "CWE-1246" .
+
+:CWE-1247 a owl:Class ;
+    rdfs:label "Improper Protection Against Voltage and Clock Glitches" ;
+    rdfs:subClassOf :CWE-1384 ;
+    :cwe-id "CWE-1247" .
+
+:CWE-1248 a owl:Class ;
+    rdfs:label "Semiconductor Defects in Hardware Logic with Security-Sensitive Implications" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1248" .
+
+:CWE-1249 a owl:Class ;
+    rdfs:label "Application-Level Admin Tool with Inconsistent View of Underlying Operating System" ;
+    rdfs:subClassOf :CWE-1250 ;
+    :cwe-id "CWE-1249" .
+
+:CWE-1250 a owl:Class ;
+    rdfs:label "Improper Preservation of Consistency Between Independent Representations of Shared State" ;
+    rdfs:subClassOf :CWE-664 ;
+    :cwe-id "CWE-1250" .
+
+:CWE-1251 a owl:Class ;
+    rdfs:label "Mirrored Regions with Different Values" ;
+    rdfs:subClassOf :CWE-1250 ;
+    :cwe-id "CWE-1251" .
+
+:CWE-1252 a owl:Class ;
+    rdfs:label "CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1252" .
+
+:CWE-1253 a owl:Class ;
+    rdfs:label "Incorrect Selection of Fuse Values" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1253" .
+
+:CWE-1254 a owl:Class ;
+    rdfs:label "Incorrect Comparison Logic Granularity" ;
+    rdfs:subClassOf :CWE-208,
+        :CWE-697 ;
+    :cwe-id "CWE-1254" .
+
+:CWE-1255 a owl:Class ;
+    rdfs:label "Comparison Logic is Vulnerable to Power Side-Channel Attacks" ;
+    rdfs:subClassOf :CWE-1300 ;
+    :cwe-id "CWE-1255" .
+
+:CWE-1256 a owl:Class ;
+    rdfs:label "Improper Restriction of Software Interfaces to Hardware Features" ;
+    rdfs:subClassOf :CWE-285 ;
+    :cwe-id "CWE-1256" .
+
+:CWE-1257 a owl:Class ;
+    rdfs:label "Improper Access Control Applied to Mirrored or Aliased Memory Regions" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1257" .
+
+:CWE-1258 a owl:Class ;
+    rdfs:label "Exposure of Sensitive System Information Due to Uncleared Debug Information" ;
+    rdfs:subClassOf :CWE-200,
+        :CWE-212 ;
+    :cwe-id "CWE-1258" .
+
+:CWE-1259 a owl:Class ;
+    rdfs:label "Improper Restriction of Security Token Assignment" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1259" .
+
+:CWE-1260 a owl:Class ;
+    rdfs:label "Improper Handling of Overlap Between Protected Memory Ranges" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1260" .
+
+:CWE-1261 a owl:Class ;
+    rdfs:label "Improper Handling of Single Event Upsets" ;
+    rdfs:subClassOf :CWE-1384 ;
+    :cwe-id "CWE-1261" .
+
+:CWE-1262 a owl:Class ;
+    rdfs:label "Improper Access Control for Register Interface" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1262" .
+
+:CWE-1263 a owl:Class ;
+    rdfs:label "Improper Physical Access Control" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1263" .
+
+:CWE-1264 a owl:Class ;
+    rdfs:label "Hardware Logic with Insecure De-Synchronization between Control and Data Channels" ;
+    rdfs:subClassOf :CWE-821 ;
+    :cwe-id "CWE-1264" .
+
+:CWE-1265 a owl:Class ;
+    rdfs:label "Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-1265" .
+
+:CWE-1266 a owl:Class ;
+    rdfs:label "Improper Scrubbing of Sensitive Data from Decommissioned Device" ;
+    rdfs:subClassOf :CWE-404 ;
+    :cwe-id "CWE-1266" .
+
+:CWE-1267 a owl:Class ;
+    rdfs:label "Policy Uses Obsolete Encoding" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1267" .
+
+:CWE-1268 a owl:Class ;
+    rdfs:label "Policy Privileges are not Assigned Consistently Between Control and Data Agents" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1268" .
+
+:CWE-1269 a owl:Class ;
+    rdfs:label "Product Released in Non-Release Configuration" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1269" .
+
+:CWE-1270 a owl:Class ;
+    rdfs:label "Generation of Incorrect Security Tokens" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1270" .
+
+:CWE-1271 a owl:Class ;
+    rdfs:label "Uninitialized Value on Reset for Registers Holding Security Settings" ;
+    rdfs:subClassOf :CWE-909 ;
+    :cwe-id "CWE-1271" .
+
+:CWE-1272 a owl:Class ;
+    rdfs:label "Sensitive Information Uncleared Before Debug/Power State Transition" ;
+    rdfs:subClassOf :CWE-226 ;
+    :cwe-id "CWE-1272" .
+
+:CWE-1273 a owl:Class ;
+    rdfs:label "Device Unlock Credential Sharing" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-1273" .
+
+:CWE-1274 a owl:Class ;
+    rdfs:label "Improper Access Control for Volatile Memory Containing Boot Code" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1274" .
+
+:CWE-1275 a owl:Class ;
+    rdfs:label "Sensitive Cookie with Improper SameSite Attribute" ;
+    rdfs:subClassOf :CWE-923 ;
+    :cwe-id "CWE-1275" .
+
+:CWE-1276 a owl:Class ;
+    rdfs:label "Hardware Child Block Incorrectly Connected to Parent System" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1276" .
+
+:CWE-1277 a owl:Class ;
+    rdfs:label "Firmware Not Updateable" ;
+    rdfs:subClassOf :CWE-1329 ;
+    :cwe-id "CWE-1277" .
+
+:CWE-1278 a owl:Class ;
+    rdfs:label "Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1278" .
+
+:CWE-1279 a owl:Class ;
+    rdfs:label "Cryptographic Operations are run Before Supporting Units are Ready" ;
+    rdfs:subClassOf :CWE-665 ;
+    :cwe-id "CWE-1279" .
+
+:CWE-1280 a owl:Class ;
+    rdfs:label "Access Control Check Implemented After Asset is Accessed" ;
+    rdfs:subClassOf :CWE-284,
+        :CWE-696 ;
+    :cwe-id "CWE-1280" .
+
+:CWE-1281 a owl:Class ;
+    rdfs:label "Sequence of Processor Instructions Leads to Unexpected Behavior" ;
+    rdfs:subClassOf :CWE-691 ;
+    :cwe-id "CWE-1281" .
+
+:CWE-1282 a owl:Class ;
+    rdfs:label "Assumed-Immutable Data is Stored in Writable Memory" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-1282" .
+
+:CWE-1283 a owl:Class ;
+    rdfs:label "Mutable Attestation or Measurement Reporting Data" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1283" .
+
+:CWE-1284 a owl:Class ;
+    rdfs:label "Improper Validation of Specified Quantity in Input" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-1284" .
+
+:CWE-1285 a owl:Class ;
+    rdfs:label "Improper Validation of Specified Index, Position, or Offset in Input" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-1285" .
+
+:CWE-1286 a owl:Class ;
+    rdfs:label "Improper Validation of Syntactic Correctness of Input" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-1286" .
+
+:CWE-1287 a owl:Class ;
+    rdfs:label "Improper Validation of Specified Type of Input" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-1287" .
+
+:CWE-1288 a owl:Class ;
+    rdfs:label "Improper Validation of Consistency within Input" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-1288" .
+
+:CWE-1289 a owl:Class ;
+    rdfs:label "Improper Validation of Unsafe Equivalence in Input" ;
+    rdfs:subClassOf :CWE-20 ;
+    :cwe-id "CWE-1289" .
+
+:CWE-1290 a owl:Class ;
+    rdfs:label "Incorrect Decoding of Security Identifiers " ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1290" .
+
+:CWE-1291 a owl:Class ;
+    rdfs:label "Public Key Re-Use for Signing both Debug and Production Code" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1291" .
+
+:CWE-1292 a owl:Class ;
+    rdfs:label "Incorrect Conversion of Security Identifiers" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1292" .
+
+:CWE-1293 a owl:Class ;
+    rdfs:label "Missing Source Correlation of Multiple Independent Data" ;
+    rdfs:subClassOf :CWE-345 ;
+    :cwe-id "CWE-1293" .
+
+:CWE-1294 a owl:Class ;
+    rdfs:label "Insecure Security Identifier Mechanism" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1294" .
+
+:CWE-1295 a owl:Class ;
+    rdfs:label "Debug Messages Revealing Unnecessary Information" ;
+    rdfs:subClassOf :CWE-200 ;
+    :cwe-id "CWE-1295" .
+
+:CWE-1296 a owl:Class ;
+    rdfs:label "Incorrect Chaining or Granularity of Debug Components" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1296" .
+
+:CWE-1297 a owl:Class ;
+    rdfs:label "Unprotected Confidential Information on Device is Accessible by OSAT Vendors" ;
+    rdfs:subClassOf :CWE-285 ;
+    :cwe-id "CWE-1297" .
+
+:CWE-1298 a owl:Class ;
+    rdfs:label "Hardware Logic Contains Race Conditions" ;
+    rdfs:subClassOf :CWE-362 ;
+    :cwe-id "CWE-1298" .
+
+:CWE-1299 a owl:Class ;
+    rdfs:label "Missing Protection Mechanism for Alternate Hardware Interface" ;
+    rdfs:subClassOf :CWE-288,
+        :CWE-420 ;
+    :cwe-id "CWE-1299" .
+
+:CWE-1300 a owl:Class ;
+    rdfs:label "Improper Protection of Physical Side Channels" ;
+    rdfs:subClassOf :CWE-203 ;
+    :cwe-id "CWE-1300" .
+
+:CWE-1301 a owl:Class ;
+    rdfs:label "Insufficient or Incomplete Data Removal within Hardware Component" ;
+    rdfs:subClassOf :CWE-226 ;
+    :cwe-id "CWE-1301" .
+
+:CWE-1302 a owl:Class ;
+    rdfs:label "Missing Security Identifier" ;
+    rdfs:subClassOf :CWE-1294 ;
+    :cwe-id "CWE-1302" .
+
+:CWE-1303 a owl:Class ;
+    rdfs:label "Non-Transparent Sharing of Microarchitectural Resources" ;
+    rdfs:subClassOf :CWE-203,
+        :CWE-1189 ;
+    :cwe-id "CWE-1303" .
+
+:CWE-1304 a owl:Class ;
+    rdfs:label "Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1304" .
+
+:CWE-1310 a owl:Class ;
+    rdfs:label "Missing Ability to Patch ROM Code" ;
+    rdfs:subClassOf :CWE-1329 ;
+    :cwe-id "CWE-1310" .
+
+:CWE-1311 a owl:Class ;
+    rdfs:label "Improper Translation of Security Attributes by Fabric Bridge" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1311" .
+
+:CWE-1312 a owl:Class ;
+    rdfs:label "Missing Protection for Mirrored Regions in On-Chip Fabric Firewall" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1312" .
+
+:CWE-1313 a owl:Class ;
+    rdfs:label "Hardware Allows Activation of Test or Debug Logic at Runtime" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1313" .
+
+:CWE-1314 a owl:Class ;
+    rdfs:label "Missing Write Protection for Parametric Data Values" ;
+    rdfs:subClassOf :CWE-862 ;
+    :cwe-id "CWE-1314" .
+
+:CWE-1315 a owl:Class ;
+    rdfs:label "Improper Setting of Bus Controlling Capability in Fabric End-point" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1315" .
+
+:CWE-1316 a owl:Class ;
+    rdfs:label "Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1316" .
+
+:CWE-1317 a owl:Class ;
+    rdfs:label "Improper Access Control in Fabric Bridge" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1317" .
+
+:CWE-1318 a owl:Class ;
+    rdfs:label "Missing Support for Security Features in On-chip Fabrics or Buses" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1318" .
+
+:CWE-1319 a owl:Class ;
+    rdfs:label "Improper Protection against Electromagnetic Fault Injection (EM-FI)" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1319" .
+
+:CWE-1320 a owl:Class ;
+    rdfs:label "Improper Protection for Outbound Error Messages and Alert Signals" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1320" .
+
+:CWE-1321 a owl:Class ;
+    rdfs:label "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')" ;
+    rdfs:subClassOf :CWE-915 ;
+    :cwe-id "CWE-1321" .
+
+:CWE-1322 a owl:Class ;
+    rdfs:label "Use of Blocking Code in Single-threaded, Non-blocking Context" ;
+    rdfs:subClassOf :CWE-834 ;
+    :cwe-id "CWE-1322" .
+
+:CWE-1323 a owl:Class ;
+    rdfs:label "Improper Management of Sensitive Trace Data" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1323" .
+
+:CWE-1325 a owl:Class ;
+    rdfs:label "Improperly Controlled Sequential Memory Allocation" ;
+    rdfs:subClassOf :CWE-770 ;
+    :cwe-id "CWE-1325" .
+
+:CWE-1326 a owl:Class ;
+    rdfs:label "Missing Immutable Root of Trust in Hardware" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1326" .
+
+:CWE-1327 a owl:Class ;
+    rdfs:label "Binding to an Unrestricted IP Address" ;
+    rdfs:subClassOf :CWE-668 ;
+    :cwe-id "CWE-1327" .
+
+:CWE-1328 a owl:Class ;
+    rdfs:label "Security Version Number Mutable to Older Versions" ;
+    rdfs:subClassOf :CWE-285 ;
+    :cwe-id "CWE-1328" .
+
+:CWE-1329 a owl:Class ;
+    rdfs:label "Reliance on Component That is Not Updateable" ;
+    rdfs:subClassOf :CWE-664,
+        :CWE-1357 ;
+    :cwe-id "CWE-1329" .
+
+:CWE-1330 a owl:Class ;
+    rdfs:label "Remanent Data Readable after Memory Erase" ;
+    rdfs:subClassOf :CWE-1301 ;
+    :cwe-id "CWE-1330" .
+
+:CWE-1331 a owl:Class ;
+    rdfs:label "Improper Isolation of Shared Resources in Network On Chip (NoC)" ;
+    rdfs:subClassOf :CWE-653,
+        :CWE-668 ;
+    :cwe-id "CWE-1331" .
+
+:CWE-1332 a owl:Class ;
+    rdfs:label "Improper Handling of Faults that Lead to Instruction Skips" ;
+    rdfs:subClassOf :CWE-1384 ;
+    :cwe-id "CWE-1332" .
+
+:CWE-1333 a owl:Class ;
+    rdfs:label "Inefficient Regular Expression Complexity" ;
+    rdfs:subClassOf :CWE-407 ;
+    :cwe-id "CWE-1333" .
+
+:CWE-1334 a owl:Class ;
+    rdfs:label "Unauthorized Error Injection Can Degrade Hardware Redundancy" ;
+    rdfs:subClassOf :CWE-284 ;
+    :cwe-id "CWE-1334" .
+
+:CWE-1335 a owl:Class ;
+    rdfs:label "Incorrect Bitwise Shift of Integer" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-1335" .
+
+:CWE-1336 a owl:Class ;
+    rdfs:label "Improper Neutralization of Special Elements Used in a Template Engine" ;
+    rdfs:subClassOf :CWE-94 ;
+    :cwe-id "CWE-1336" .
+
+:CWE-1338 a owl:Class ;
+    rdfs:label "Improper Protections Against Hardware Overheating" ;
+    rdfs:subClassOf :CWE-693 ;
+    :cwe-id "CWE-1338" .
+
+:CWE-1339 a owl:Class ;
+    rdfs:label "Insufficient Precision or Accuracy of a Real Number" ;
+    rdfs:subClassOf :CWE-682 ;
+    :cwe-id "CWE-1339" .
+
+:CWE-1341 a owl:Class ;
+    rdfs:label "Multiple Releases of Same Resource or Handle" ;
+    rdfs:subClassOf :CWE-675 ;
+    :cwe-id "CWE-1341" .
+
+:CWE-1342 a owl:Class ;
+    rdfs:label "Information Exposure through Microarchitectural State after Transient Execution" ;
+    rdfs:subClassOf :CWE-226 ;
+    :cwe-id "CWE-1342" .
+
+:CWE-1351 a owl:Class ;
+    rdfs:label "Improper Handling of Hardware Behavior in Exceptionally Cold Environments" ;
+    rdfs:subClassOf :CWE-1384 ;
+    :cwe-id "CWE-1351" .
+
+:CWE-1357 a owl:Class ;
+    rdfs:label "Reliance on Insufficiently Trustworthy Component" ;
+    rdfs:subClassOf :CWE-710 ;
+    :cwe-id "CWE-1357" .
+
+:CWE-1384 a owl:Class ;
+    rdfs:label "Improper Handling of Physical or Environmental Conditions" ;
+    rdfs:subClassOf :CWE-703 ;
+    :cwe-id "CWE-1384" .
+
+:CWE-1385 a owl:Class ;
+    rdfs:label "Missing Origin Validation in WebSockets" ;
+    rdfs:subClassOf :CWE-346 ;
+    :cwe-id "CWE-1385" .
+
+:CWE-1386 a owl:Class ;
+    rdfs:label "Insecure Operation on Windows Junction / Mount Point" ;
+    rdfs:subClassOf :CWE-59 ;
+    :cwe-id "CWE-1386" .
+
+:CWE-1389 a owl:Class ;
+    rdfs:label "Incorrect Parsing of Numbers with Different Radices" ;
+    rdfs:subClassOf :CWE-704 ;
+    :cwe-id "CWE-1389" .
+
+:CWE-1390 a owl:Class ;
+    rdfs:label "Weak Authentication" ;
+    rdfs:subClassOf :CWE-287 ;
+    :cwe-id "CWE-1390" .
+
+:CWE-1391 a owl:Class ;
+    rdfs:label "Use of Weak Credentials" ;
+    rdfs:subClassOf :CWE-1390 ;
+    :cwe-id "CWE-1391" .
+
+:CWE-1392 a owl:Class ;
+    rdfs:label "Use of Default Credentials" ;
+    rdfs:subClassOf :CWE-1391 ;
+    :cwe-id "CWE-1392" .
+
+:CWE-1393 a owl:Class ;
+    rdfs:label "Use of Default Password" ;
+    rdfs:subClassOf :CWE-1392 ;
+    :cwe-id "CWE-1393" .
+
+:CWE-1394 a owl:Class ;
+    rdfs:label "Use of Default Cryptographic Key" ;
+    rdfs:subClassOf :CWE-1392 ;
+    :cwe-id "CWE-1394" .
+
+:CWE-1395 a owl:Class ;
+    rdfs:label "Dependency on Vulnerable Third-Party Component" ;
+    rdfs:subClassOf :CWE-657 ;
+    :cwe-id "CWE-1395" .
 
 :D3FENDCatalogThing a owl:Class ;
     rdfs:label "D3FEND Catalog Thing" ;


### PR DESCRIPTION
Chose to implement the Research Concepts View/Graph as the initial take on the D3FEND taxonomy of CWE weaknesses.  Folded in with existing knowledge.  Used YARRRML->RML for extraction from XML and translation to ontology triples.  Documented in README.md.  Checks in newly transformed d3fend-protege.ttl with all the classes merged.'  Added cwe/ dir to extensions/ to hold code used for CWE->D3FEND transformation and possible future transformations.