### PR TITLE
[Correction] Typo in resriction for Resource Development Techniques

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -176,8 +176,8 @@
     rdfs:subPropertyOf :associated-with,
         :may-contain ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02639021-v> ;
-    :comment """d3fend uses 'contains' for the more ontologically traditional term 'has-part' and thus is transitive.  The concept of containment in other ontologies (e.g., SUMO and OBO's RO) may refer the containment of an object within a space or object defining a space, or may express the containment of subintervals or subsequences of intervals or sequences, respectively.\r
-\r
+    :comment """d3fend uses 'contains' for the more ontologically traditional term 'has-part' and thus is transitive.  The concept of containment in other ontologies (e.g., SUMO and OBO's RO) may refer the containment of an object within a space or object defining a space, or may express the containment of subintervals or subsequences of intervals or sequences, respectively.
+
 Moving forward different distinctions of kinds of has-part (contains) relationships may prove useful or even necessary.  Deferred for future releases""" ;
     :definition "x contains y: A core relation that holds between a whole x and its part y.  Equivalent to relational concept 'has part' and thus transitive." .
 
@@ -1657,20 +1657,20 @@ skos:altLabel a owl:AnnotationProperty ;
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-AL" ;
     :definition "The process of temporarily disabling user accounts on a system or domain." ;
-    :kb-article """## How it works\r
-Management servers with enterprise policies for account management provide the ability to enable and disable account for given rules. The rules may include specific periods of time (eg. weekend, plant shutdown, leave periods), specific user types or groups, or individual users.\r
-\r
-## Considerations\r
-* Local accounts caches vs centralized account management\r
-* Single Sign-on\r
-* Role based vs Attribute based systems\r
-\r
-## Examples of account configuration stores\r
-* Directory Services\r
-* Active Directory\r
-* RADIUS\r
-* LDAP\r
-* Oracle User Account Management\r
+    :kb-article """## How it works
+Management servers with enterprise policies for account management provide the ability to enable and disable account for given rules. The rules may include specific periods of time (eg. weekend, plant shutdown, leave periods), specific user types or groups, or individual users.
+
+## Considerations
+* Local accounts caches vs centralized account management
+* Single Sign-on
+* Role based vs Attribute based systems
+
+## Examples of account configuration stores
+* Directory Services
+* Active Directory
+* RADIUS
+* LDAP
+* Oracle User Account Management
 * JumpCloud""" ;
     :kb-reference :Reference-AccountMonitoring_ForescoutTechnologies,
         :Reference-FrameworkForNotifyingADirectoryServiceOfAuthenticationEventsProcessedOutsideTheDirectoryService_OracleInternationalCorp .
@@ -1684,26 +1684,26 @@ Management servers with enterprise policies for account management provide the a
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-ACA" ;
     :definition "Actively collecting PKI certificates by connecting to the server and downloading its server certificates for analysis." ;
-    :kb-article """## How it works\r
-Analysis of server certificates using active methods to detect if certificates have been misconfigured or spoofed by using elements of the certificate, certificate authorities and signatures.\r
-\r
-### Certificate validity analysis\r
-This can be accomplished by verifying the digital signature on certificate.\r
-\r
-### Certificate path analysis\r
-The client's browser can perform path verification to ensure that the server's certificate contains a valid trust anchor.\r
-\r
-### Certificate configuration analysis\r
-Some browsers can be configured to implement the key-usage extensions contained certificates. This can help to prevent a certificate from being misused.\r
-\r
-### Certificate revocation status analysis\r
-Using either Certificate Revocation Lists (CRLs) or Online Certificate Status Protocol (OCSP) to determine the revocation status. OCSP Stapling, binding the status with the certificate, helps to mitigate potential delay in status verifications.\r
-\r
-## Considerations\r
-* Management of the PKI across the enterprise typically requires automation to maintain scalability and flexibility\r
-* If the certificate authority, issuing the certificate, is compromised then all of the certificates issued by the CA are suspect\r
-* There may be delays associated with updates to certificates\r
-* Revoked certificates give the appearance of valid certificates until they are published to a trusted revocation service (OCSP or CRL)\r
+    :kb-article """## How it works
+Analysis of server certificates using active methods to detect if certificates have been misconfigured or spoofed by using elements of the certificate, certificate authorities and signatures.
+
+### Certificate validity analysis
+This can be accomplished by verifying the digital signature on certificate.
+
+### Certificate path analysis
+The client's browser can perform path verification to ensure that the server's certificate contains a valid trust anchor.
+
+### Certificate configuration analysis
+Some browsers can be configured to implement the key-usage extensions contained certificates. This can help to prevent a certificate from being misused.
+
+### Certificate revocation status analysis
+Using either Certificate Revocation Lists (CRLs) or Online Certificate Status Protocol (OCSP) to determine the revocation status. OCSP Stapling, binding the status with the certificate, helps to mitigate potential delay in status verifications.
+
+## Considerations
+* Management of the PKI across the enterprise typically requires automation to maintain scalability and flexibility
+* If the certificate authority, issuing the certificate, is compromised then all of the certificates issued by the CA are suspect
+* There may be delays associated with updates to certificates
+* Revoked certificates give the appearance of valid certificates until they are published to a trusted revocation service (OCSP or CRL)
 * The revocation service (OCSP or CRL) may be down during our connection and a browser will need to make a decision will need to be made about trusting the connection""" ;
     :kb-reference :Reference-SecuringWebTransactions .
 
@@ -1713,14 +1713,14 @@ Using either Certificate Revocation Lists (CRLs) or Online Certificate Status Pr
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-AL" ;
     :definition "Active learning aims to improve learning efficiency by allowing the learning algorithm to select which data to learn from." ;
-    :kb-article """## How it works\r
-Traditional supervised learning often requires a large number of labeled instances, which can be costly or time-consuming to obtain. Active learning addresses this labeling bottleneck by asking an oracle (e.g., a human annotator) to label selected unlabeled instances. The goal is to achieve high accuracy with minimal labeling effort.\r
-\r
-## Considerations\r
-Active learning is particularly useful in scenarios where data is abundant but labeled instances are scarce or expensive. Examples include speech recognition, information extraction, and document classification.\r
-\r
-## References\r
-- Wikipedia article on Active Learning (machine learning) [Link](https://en.wikipedia.org/wiki/Active_learning_(machine_learning))\r
+    :kb-article """## How it works
+Traditional supervised learning often requires a large number of labeled instances, which can be costly or time-consuming to obtain. Active learning addresses this labeling bottleneck by asking an oracle (e.g., a human annotator) to label selected unlabeled instances. The goal is to achieve high accuracy with minimal labeling effort.
+
+## Considerations
+Active learning is particularly useful in scenarios where data is abundant but labeled instances are scarce or expensive. Examples include speech recognition, information extraction, and document classification.
+
+## References
+- Wikipedia article on Active Learning (machine learning) [Link](https://en.wikipedia.org/wiki/Active_learning_(machine_learning))
 - Settles, B. (2009). Active Learning Literature Survey. [Link](https://burrsettles.com/pub/settles.activelearning.pdf)""" .
 
 :ActiveLogicalLinkMapping a :LogicalLinkMapping,
@@ -1733,18 +1733,18 @@ Active learning is particularly useful in scenarios where data is abundant but l
             owl:someValuesFrom :CollectorAgent ] ;
     :d3fend-id "D3-ALLM" ;
     :definition "Active logical link mapping sends and receives network traffic as a means to map the whole data link layer, where the links represent logical data flows rather than physical connection" ;
-    :kb-article """## How it works\r
-\r
-Active logical link mapping establishes awareness of logical links in the network by sending data over the network to gather information about logical connections in the network.\r
-\r
-Typically this will be achieved through network telemetry coordinated for network management and monitoring and will use a link layer discovery protocol such as LLDP and the information gathered and aggregated a higher levels using an application protocol such as SNMP.  The information may be polled by network management softare or configured once and then pushed from network sensors (or agents.)\r
-\r
-Another means of establishing network connectivity is by means of sendingn traffic through the use of a tool such as traceroute, to determine the logical paths through the network architecture.\r
-\r
-## Considerations\r
-\r
-* Best practice is to encrypte network monitoring data and require authentication for queries or admin/management functions.\r
-* Push notifications reduce bandwidth necessary to capture and maintain information if reliable transport is used.\r
+    :kb-article """## How it works
+
+Active logical link mapping establishes awareness of logical links in the network by sending data over the network to gather information about logical connections in the network.
+
+Typically this will be achieved through network telemetry coordinated for network management and monitoring and will use a link layer discovery protocol such as LLDP and the information gathered and aggregated a higher levels using an application protocol such as SNMP.  The information may be polled by network management softare or configured once and then pushed from network sensors (or agents.)
+
+Another means of establishing network connectivity is by means of sendingn traffic through the use of a tool such as traceroute, to determine the logical paths through the network architecture.
+
+## Considerations
+
+* Best practice is to encrypte network monitoring data and require authentication for queries or admin/management functions.
+* Push notifications reduce bandwidth necessary to capture and maintain information if reliable transport is used.
 * Special consideration should be made before using of active scanning in OT networks and OT-safe options chosen where available.""" ;
     :kb-reference :Reference-IdentificationOfTracerouteNodesAndAssociatedDevices,
         :Reference-SNMPNetworkAutoDiscovery .
@@ -1785,7 +1785,7 @@ Another means of establishing network connectivity is by means of sendingn traff
         :TemporalDifferenceLearning ;
     :d3fend-id "D3A-AC" ;
     :definition "Actor-Critic is a Temporal Difference(TD) version of Policy gradient. It has two networks: Actor and Critic. The actor decided which action should be taken and critic inform the actor how good was the action and how it should adjust. The learning of the actor is based on policy gradient approach. In comparison, critics evaluate the action produced by the actor by computing the value function." ;
-    :kb-article """## References\r
+    :kb-article """## References
 The Actor-Critic Reinforcement Learning Algorithm. Medium. [Link](https://medium.com/intro-to-artificial-intelligence/the-actor-critic-reinforcement-learning-algorithm-c8095a655c14).""" ;
     :todo "The citation suggest (at a very brief glance) this may belong under temporal difference learning" .
 
@@ -1795,7 +1795,7 @@ The Actor-Critic Reinforcement Learning Algorithm. Medium. [Link](https://medium
     rdfs:subClassOf :ANN-basedClustering ;
     :d3fend-id "D3A-ARTC" ;
     :definition "Adaptive Resonance Theory (ART) Clustering is a  neural network algorithm used for clustering data and is open to new learning(i.e. adaptive) without discarding the previous or the old information(i.e. resonance)." ;
-    :kb-article """## References\r
+    :kb-article """## References
 GeeksforGeeks. (n.d.). Adaptive Resonance Theory (ART). [Link](https://www.geeksforgeeks.org/adaptive-resonance-theory-art/)""" .
 
 :AddressSpace a owl:Class ;
@@ -1840,11 +1840,11 @@ GeeksforGeeks. (n.d.). Adaptive Resonance Theory (ART). [Link](https://www.geeks
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-ANAA" ;
     :definition "Detection of unauthorized use of administrative network protocols by analyzing network activity against a baseline." ;
-    :kb-article """## How it works\r
-Network protocols such as RDP, IPMI, SSH, SNMP, VNC, MOSH, NX, TeamViewer, SPICE, PCoIP, and others are used by system administrators to remotely manage servers. Defenders monitor administrative network activity to determine if the use of remote protocols is malicious. Attackers can abuse administrative protocols and leverage them for initial access to various endpoints. For example, an attacker with valid credentials will remotely SSH or RDP into a server and attempt to blend in with existing traffic from system administrators. By monitoring the traffic activity, it is possible to detect when the protocols are behaving differently from a known baseline of system administration activity.\r
-\r
-## Considerations\r
-* Administrative traffic can be encrypted, making network protocol analysis a challenge\r
+    :kb-article """## How it works
+Network protocols such as RDP, IPMI, SSH, SNMP, VNC, MOSH, NX, TeamViewer, SPICE, PCoIP, and others are used by system administrators to remotely manage servers. Defenders monitor administrative network activity to determine if the use of remote protocols is malicious. Attackers can abuse administrative protocols and leverage them for initial access to various endpoints. For example, an attacker with valid credentials will remotely SSH or RDP into a server and attempt to blend in with existing traffic from system administrators. By monitoring the traffic activity, it is possible to detect when the protocols are behaving differently from a known baseline of system administration activity.
+
+## Considerations
+* Administrative traffic can be encrypted, making network protocol analysis a challenge
 * False alarms can be mitigated by integration with inventory management systems""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingSuspiciousAdministrativeActivity_VectraNetworksInc,
         :Reference-RemoteRegistry_MITRE,
@@ -1866,9 +1866,9 @@ Network protocols such as RDP, IPMI, SSH, SNMP, VNC, MOSH, NX, TeamViewer, SPICE
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-AC" ;
     :definition "Recursively merges pair of clusters of sample data; uses linkage distance." ;
-    :kb-article """## References\r
-scikit-learn. (n.d.). AgglomerativeClustering. [Link](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.\r
-Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)\r
+    :kb-article """## References
+scikit-learn. (n.d.). AgglomerativeClustering. [Link](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.
+Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)
 html)""" .
 
 :AlethicLogic a owl:Class,
@@ -1877,7 +1877,7 @@ html)""" .
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-AL" ;
     :definition "Alethic logic is a modal logic that addresses the modalities of necessity and possibility." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Alethic logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Alethic_logic)""" .
 
 :Alias a owl:Class ;
@@ -1923,9 +1923,9 @@ html)""" .
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-ABC" ;
     :definition "Combines the principles of Artificial Neural Networks (ANN) and clustering methods." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Artificial neural network. [Link](https://en.wikipedia.org/wiki/Artificial_neural_network)""" ;
-    :todo """have a gander at this paper for more clustering techniques ?\r
+    :todo """have a gander at this paper for more clustering techniques ?
 https://www.sciencedirect.com/science/article/pii/S089360800900207X?viewFullText=true#sec19""" .
 
 :AnswerSetProgramming a owl:Class,
@@ -1934,12 +1934,12 @@ https://www.sciencedirect.com/science/article/pii/S089360800900207X?viewFullText
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-ASP" ;
     :definition "Answer set programming is a form of declarative programming based on the stable model (answer set) semantics of logic programming." ;
-    :kb-article """## How it works\r
-Answer set programming (ASP) is oriented towards difficult (primarily NP-hard) search problems. The computational process employed in the design of many answer set solvers is an enhancement of the DPLL algorithm and, in principle, it always terminates (unlike Prolog query evaluation, which may lead to an infinite loop).\r
-\r
-In a more general sense, ASP includes all applications of answer sets to knowledge representation and the use of Prolog-style query evaluation for solving problems arising in these applications.\r
-\r
-## References\r
+    :kb-article """## How it works
+Answer set programming (ASP) is oriented towards difficult (primarily NP-hard) search problems. The computational process employed in the design of many answer set solvers is an enhancement of the DPLL algorithm and, in principle, it always terminates (unlike Prolog query evaluation, which may lead to an infinite loop).
+
+In a more general sense, ASP includes all applications of answer sets to knowledge representation and the use of Prolog-style query evaluation for solving problems arising in these applications.
+
+## References
 1. Answer set programming. (2023, April 27). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Answer_set_programming)""" ;
     :synonym "ASP" .
 
@@ -1995,9 +1995,9 @@ In a more general sense, ASP includes all applications of answer sets to knowled
             owl:someValuesFrom :ApplicationConfiguration ] ;
     :d3fend-id "D3-ACH" ;
     :definition "Modifying an application's configuration to reduce its attack surface." ;
-    :kb-article """## How it works\r
-Application configuration settings can be configured to limit the permissions on an application or disable certain vulnerable application features.\r
-\r
+    :kb-article """## How it works
+Application configuration settings can be configured to limit the permissions on an application or disable certain vulnerable application features.
+
 Hardening an application's configuration involves analyzing not only the application but also the environment in which the application is run in for potential vulnerabilities.""" ;
     :kb-reference :Reference-RedHatEnterpriseLinux8SecurityTechnicalImplementationGuide,
         :Reference-Windows10STIG .
@@ -2013,8 +2013,8 @@ Hardening an application's configuration involves analyzing not only the applica
     :d3fend-id "D3-AH" ;
     :definition "Application Hardening makes an executable application more resilient to a class of exploits which either introduce new code or execute unwanted existing code. These techniques may be applied at compile-time or on an application binary." ;
     :enables :Harden ;
-    :kb-article """## Technique Overview\r
-\r
+    :kb-article """## Technique Overview
+
 Exploits may, for example, rely on knowledge of addresses in a process's memory, they may alter memory contents, and they may cause a program to use instructions in a way that they were not intended.  By, for example, including code that dynamically changes the memory address of data or code on each run, introducing logic to validating the memory contents before certain potentially dangerous flows are executed, or monitoring a program for unusual sequence of instructions, this makes it harder for an attacker to craft a working exploit.""" ;
     :synonym "Process Hardening" .
 
@@ -2073,7 +2073,7 @@ Exploits may, for example, rely on knowledge of addresses in a process's memory,
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-ASM" ;
     :definition "Approximate string matching is a form of string matching that allows errrors." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Navarro, G. (2001). A guided tour to approximate string matching. _ACM Computing Surveys_, 33(1), 31-88. [Link](https://doi.org/10.1145/375360.375365)""" .
 
 :ArchiveFile a owl:Class ;
@@ -2088,7 +2088,7 @@ Exploits may, for example, rely on knowledge of addresses in a process's memory,
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3A-AM" ;
     :definition "An autoregressive integrated moving average (ARIMA) model is a generalization of an autoregressive moving average (ARMA) model." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Autoregressive integrated moving average. [Link](https://en.wikipedia.org/wiki/Autoregressive_integrated_moving_average)""" ;
     :synonym "Autoregressive Integrated Moving Average Model" .
 
@@ -2099,7 +2099,7 @@ Wikipedia. (n.d.). Autoregressive integrated moving average. [Link](https://en.w
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3-ARMA" ;
     :definition "Autoregressive-moving-average (ARMA) models provide a parsimonious description of a (weakly) stationary stochastic process in terms of two polynomials, one for the autoregression (AR) and the second for the moving average (MA)." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Autoregressive-moving-average model. [Link](https://en.wikipedia.org/wiki/Autoregressive%E2%80%93moving-average_model)""" ;
     :synonym "Autoregressive moving average model" .
 
@@ -2129,7 +2129,7 @@ Wikipedia. (n.d.). Autoregressive-moving-average model. [Link](https://en.wikipe
     rdfs:subClassOf :Classification ;
     :d3fend-annotation "Classification ANNs seek to classify an observation as belonging to some discrete class as a function of the inputs. The input features (independent variables) can be categorical or numeric types, however, we require a categorical feature as the dependent variable." ;
     :d3fend-id "D3A-ANNC" ;
-    :kb-article """## References\r
+    :kb-article """## References
 ANN Classification. [Link](http://uc-r.github.io/ann_classification).""" .
 
 :Assessment a owl:Class ;
@@ -2186,7 +2186,7 @@ ANN Classification. [Link](http://uc-r.github.io/ann_classification).""" .
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-ARL" ;
     :definition "Association rule learning is a rule-based machine learning method for discovering interesting relations between variables in large databases." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Association rule learning. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wiki/Association_rule_learning)""" .
 
 :AsymmetricFeature-basedTransferLearning a owl:Class,
@@ -2195,7 +2195,7 @@ Association rule learning. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wi
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-AFTL" ;
     :definition "Homogeneous (where the metrics are the same for both source and target) asymmetric transformation mapping transforms the source feature space to align with that of the target or the target to that of the source. This, in effect, bridges the feature space gap and reduces the problem into a homogeneous transfer problem when further distribution differences need to be corrected." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learning. Journal of Big Data, 4(1), 29. [Link](https://doi.org/10.1186/s40537-017-0089-0).""" ;
     :todo "Could use a better definition as this is a slightly modified version of the heterogeneous definition" .
 
@@ -2260,14 +2260,14 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-ANCI" ;
     :definition "Removing tokens or credentials from an authentication cache to prevent further user associated account accesses." ;
-    :kb-article """## How it works\r
-Applications can locally cache user authentication credentials for certain server connections. An application may attempt to use the cached credential for a connection. If the cached credentials exist then the user will not be typically prompted for new credentials.\r
-\r
-\r
-## Considerations\r
-Are these cached credentials only on the local host? Can they be persisted to the remote server?\r
-\r
-## Examples\r
+    :kb-article """## How it works
+Applications can locally cache user authentication credentials for certain server connections. An application may attempt to use the cached credential for a connection. If the cached credentials exist then the user will not be typically prompted for new credentials.
+
+
+## Considerations
+Are these cached credentials only on the local host? Can they be persisted to the remote server?
+
+## Examples
 Windows Credential Management API""" ;
     :kb-reference :Reference-SecureCachingOfServerCredentials_DellProductsLP,
         :Reference-SystemAndMethodForProvidingAnActivelyInvalidatedClient-sideNetworkResourceCache_IMVU .
@@ -2283,26 +2283,26 @@ Windows Credential Management API""" ;
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-ANET" ;
     :definition "Collecting authentication events, creating a baseline user profile, and determining whether authentication events are consistent with the baseline profile." ;
-    :kb-article """## How it works\r
-Authentication event data is collected (logon information such as device id, time of day, day of week, geo-location, etc.) to create an activity baseline. Then, a threshold is determined either through a manually specified configuration, or a statistical analysis of deviations in historical data. New authentication events are evaluated to determine if a threshold is exceeded. Thresholds can be static or dynamic.\r
-\r
-### Actions\r
-As a result of the analysis, actions taken could include:\r
-\r
-* [Account Locking](/technique/d3f:AccountLocking)\r
-* Raising an alert\r
-\r
-### Example data sources\r
- * Directory server logs\r
- * VPN Server logs\r
- * IDAM Capability logs\r
- * NAC logs\r
- * Authentication client logs\r
- * Kerberos network traffic\r
- * LDAP network traffic\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+Authentication event data is collected (logon information such as device id, time of day, day of week, geo-location, etc.) to create an activity baseline. Then, a threshold is determined either through a manually specified configuration, or a statistical analysis of deviations in historical data. New authentication events are evaluated to determine if a threshold is exceeded. Thresholds can be static or dynamic.
+
+### Actions
+As a result of the analysis, actions taken could include:
+
+* [Account Locking](/technique/d3f:AccountLocking)
+* Raising an alert
+
+### Example data sources
+ * Directory server logs
+ * VPN Server logs
+ * IDAM Capability logs
+ * NAC logs
+ * Authentication client logs
+ * Kerberos network traffic
+ * LDAP network traffic
+
+## Considerations
+
 This technique covers statistical outliers. Though depending on the complexity or dimensionality of the data considered, outliers may not be obvious to a human analyst reviewing events in simplistic analytic views. If the malicious activity is not statistically different from benign activity, an alert threshold will not be met.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC,
@@ -2361,12 +2361,12 @@ This technique covers statistical outliers. Though depending on the complexity o
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-AZET" ;
     :definition "Collecting authorization events, creating a baseline user profile, and determining whether authorization events are consistent with the baseline profile." ;
-    :kb-article """## How it works\r
-\r
-Authorization event data is collected to create a baseline user profile. Authorization events that deviate from the baseline and exceed a static or dynamic threshold are identified for further action. Authorization events can include successful and failed authorization attempts as well as events related to permissions including viewing, editing, deleting, creating files, databases etc.\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+
+Authorization event data is collected to create a baseline user profile. Authorization events that deviate from the baseline and exceed a static or dynamic threshold are identified for further action. Authorization events can include successful and failed authorization attempts as well as events related to permissions including viewing, editing, deleting, creating files, databases etc.
+
+## Considerations
+
 Depending on the complexity of the data considered, outliers may not be obvious to a human analyst reviewing events in simplistic analytic views. If malicious activity is not statistically different from benign activity, an alert threshold will not be met.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC,
@@ -2397,7 +2397,7 @@ Depending on the complexity of the data considered, outliers may not be obvious 
     rdfs:subClassOf :DimensionReduction ;
     :d3fend-id "D3A-AUT" ;
     :definition "Autoencoders are specific type of deep learning architecture used for learning representation of data, typically for the purpose of dimensionality reduction. This is achieved by designing deep learning architecture that aims that copying input layer at its output layer." ;
-    :kb-article """## References\r
+    :kb-article """## References
 SOCR. (n.d.). ABIDE Autoencoder. [Link](https://socr.umich.edu/HTML5/ABIDE_Autoencoder/#:~:text=In%20simple%20words%2C%20autoencoders%20are,layer%20at%20its%20output%20layer.)""" .
 
 :AutoregressiveModel a owl:Class,
@@ -2406,7 +2406,7 @@ SOCR. (n.d.). ABIDE Autoencoder. [Link](https://socr.umich.edu/HTML5/ABIDE_Autoe
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3A-AM" ;
     :definition "An autoregressive (AR) model is a representation of a type of random process; as such, it is used to describe certain time-varying processes in nature, economics, behavior, etc." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Autoregressive model. [Link](https://en.wikipedia.org/wiki/Autoregressive_model)""" ;
     :synonym "AR Model" .
 
@@ -2416,7 +2416,7 @@ Wikipedia. (n.d.). Autoregressive model. [Link](https://en.wikipedia.org/wiki/Au
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-AAD" ;
     :definition "The average absolute deviation (AAD) of a data set is the average of the absolute deviations from a central point." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/wiki/Average_absolute_deviation)""" .
 
 :BarcodeScannerInputDevice a owl:Class ;
@@ -2432,7 +2432,7 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :BayesianMethod ;
     :d3fend-id "D3A-BE" ;
     :definition "A Bayes estimator or a Bayes action is an estimator or decision rule that minimizes the posterior expected value of a loss function (i.e., the posterior expected loss)." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Bayes estimator. [Link](https://en.wikipedia.org/wiki/Bayes_estimator)""" .
 
 :BayesianHypothesisTesting a owl:Class,
@@ -2441,10 +2441,10 @@ Wikipedia. (n.d.). Bayes estimator. [Link](https://en.wikipedia.org/wiki/Bayes_e
     rdfs:subClassOf :BayesianMethod ;
     :d3fend-id "D3A-BHT" ;
     :definition "Bayesian hypothesis testing can be framed as a special case of model comparison where a model refers to a likelihood function and a prior distribution." ;
-    :kb-article """## How it works\r
-Given two competing hypotheses and some relevant data, Bayesian hypothesis testing begins by specifying separate prior distributions to quantitatively describe each hypothesis. The combination of the likelihood function for the observed data with each of the prior distributions yields hypothesis-specific models. For each of the hypothesis-specific models, averaging (ie, integrating) the likelihood with respect to the prior distribution across the entire parameter space yields the probability of the data under the model and, therefore, the corresponding hypothesis. This quantity is more commonly referred to as the marginal likelihood and represents the average fit of the model to the data. The ratio of the marginal likelihoods for both hypothesis-specific models is known as the Bayes factor.\r
-\r
-## References\r
+    :kb-article """## How it works
+Given two competing hypotheses and some relevant data, Bayesian hypothesis testing begins by specifying separate prior distributions to quantitatively describe each hypothesis. The combination of the likelihood function for the observed data with each of the prior distributions yields hypothesis-specific models. For each of the hypothesis-specific models, averaging (ie, integrating) the likelihood with respect to the prior distribution across the entire parameter space yields the probability of the data under the model and, therefore, the corresponding hypothesis. This quantity is more commonly referred to as the marginal likelihood and represents the average fit of the model to the data. The ratio of the marginal likelihoods for both hypothesis-specific models is known as the Bayes factor.
+
+## References
 Baig, S. A., PhD. (2020). Bayesian Inference: An Introduction to Hypothesis Testing Using Bayes Factors. Nicotine & Tobacco Research, 22(7), 1244-1246. [Link](https://academic.oup.com/ntr/article/22/7/1244/5613971)""" .
 
 :BayesianLinearRegression a owl:Class,
@@ -2453,7 +2453,7 @@ Baig, S. A., PhD. (2020). Bayesian Inference: An Introduction to Hypothesis Test
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-BLR" ;
     :definition "Bayesian linear regression is a type of conditional modeling in which the mean of one variable is described by a linear combination of other variables, with the goal of obtaining the posterior probability of the regression coefficients." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/wiki/Bayesian_linear_regression)""" .
 
 :BayesianLinearRegressionLearning a owl:Class,
@@ -2462,7 +2462,7 @@ Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-BLRL" ;
     :definition "A supervised learning method that builds a Bayesian linear regression model using training data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/wiki/Bayesian_linear_regression)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#BayesianLinearRegression" .
 
@@ -2472,7 +2472,7 @@ Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-BM" ;
     :definition "Bayesian analysis is a statistical procedure which endeavors to estimate parameters of an underlying distribution based on the observed distribution." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wolfram MathWorld. (n.d.). Bayesian Analysis. [Link](https://mathworld.wolfram.com/BayesianAnalysis.html)""" .
 
 :BayesianModelAveraging a owl:Class,
@@ -2481,9 +2481,9 @@ Wolfram MathWorld. (n.d.). Bayesian Analysis. [Link](https://mathworld.wolfram.c
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BMA" ;
     :definition "A parameter estimate (or a prediction of new observations) obtained by averaging the estimates (or predictions) of the different models under consideration, each weighted by its model probability." ;
-    :kb-article """## References\r
-Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).\r
-\r
+    :kb-article """## References
+Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).
+
 Bayesian model average: A parameter estimation approach to model agnostic ensemble learning. (2019). Journal of Machine Learning for Modeling and Computing, 1(2), 61-70.  [Link](https://journals.sagepub.com/doi/full/10.1177/2515245919898657#:~:text=Bayesian%20model%20average%3A%20A%20parameter,weighted%20by%20its%20model%20probability).""" .
 
 :BayesianModelCombination a owl:Class,
@@ -2492,9 +2492,9 @@ Bayesian model average: A parameter estimation approach to model agnostic ensemb
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BMC" ;
     :definition "Bayesian model combination (BMC) is an algorithmic correction to Bayesian model averaging (BMA). Instead of sampling each model in the ensemble individually, it samples from the space of possible ensembles (with model weights drawn randomly from a Dirichlet distribution having uniform parameters)" ;
-    :kb-article """## References\r
-Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).\r
-\r
+    :kb-article """## References
+Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).
+
 Shultz, K. M., & Peterson, L. E. (2011). Model-averaged confidence intervals for ensemble learning. In *International Joint Conference on Neural Networks* (pp. 2677-2684).  [Link](https://axon.cs.byu.edu/papers/Kristine.ijcnn2011.pdf).""" .
 
 :BayesOptimalClassifier a owl:Class,
@@ -2503,8 +2503,8 @@ Shultz, K. M., & Peterson, L. E. (2011). Model-averaged confidence intervals for
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BOC" ;
     :definition "A probabilistic model that makes the most probable prediction for a new example." ;
-    :kb-article """## References\r
-Bayes Optimal Classifier. Machine Learning Mastery.  [Link](https://machinelearningmastery.com/bayes-optimal-classifier/).\r
+    :kb-article """## References
+Bayes Optimal Classifier. Machine Learning Mastery.  [Link](https://machinelearningmastery.com/bayes-optimal-classifier/).
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :BERT a owl:Class,
@@ -2513,8 +2513,8 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :Transformer-basedLearning ;
     :d3fend-id "D3A-BER" ;
     :definition "Bidirectional Encoder Representations from Transformers (BERT) is based on a deep learning model in which every output element is connected to every input element, and the weightings between them are dynamically calculated based upon their connection." ;
-    :kb-article """## References\r
-BERT (language model). (n.d.). In TechTarget. [Link](https://www.techtarget.com/searchenterpriseai/definition/BERT-language-model)\r
+    :kb-article """## References
+BERT (language model). (n.d.). In TechTarget. [Link](https://www.techtarget.com/searchenterpriseai/definition/BERT-language-model)
 BERT (language model). (n.d.). In Wikipedia. [Link](https://en.wikipedia.org/wiki/BERT_(language_model))""" ;
     :synonym "Bidirectional Encoder Representations from Transformers" .
 
@@ -2573,8 +2573,8 @@ BERT (language model). (n.d.). In Wikipedia. [Link](https://en.wikipedia.org/wik
             owl:onProperty :may-contain ;
             owl:someValuesFrom :Volume ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Device_file#BLOCKDEV> ;
-    :definition """A block device (or block special file) provides buffered access to hardware devices, and provides some abstraction from their specifics.\r
-\r
+    :definition """A block device (or block special file) provides buffered access to hardware devices, and provides some abstraction from their specifics.
+
 IEEE Std 1003.1-2017: A file that refers to a device. A block special file is normally distinguished from a character special file by providing access to the device in a manner such that the hardware characteristics of the device are not visible.""" ;
     rdfs:seeAlso <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_79> .
 
@@ -2589,14 +2589,14 @@ IEEE Std 1003.1-2017: A file that refers to a device. A block special file is no
     rdfs:subClassOf :LogicalRules ;
     :d3fend-id "D3A-BEM" ;
     :definition "Boolean expression matching produces a Boolean truth value for a given boolean expression and assignment of values to variables in the expression." ;
-    :kb-article """## How it works\r
-A Boolean expression is an expression used in programming languages that produces a Boolean value when evaluated. A Boolean value is either true or false. A Boolean expression may be composed of a combination of the Boolean constants true or false, Boolean-typed variables, Boolean-valued operators, and Boolean-valued functions.\r
-\r
-Boolean expressions correspond to propositional formulas in logic and are a special case of Boolean circuits.\r
-\r
-## References\r
-1. Boolean expression. (2022, April 25). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Boolean_expression)\r
-2. Boolean algebra. (2022, May 19). In _Wikipedia_.\r
+    :kb-article """## How it works
+A Boolean expression is an expression used in programming languages that produces a Boolean value when evaluated. A Boolean value is either true or false. A Boolean expression may be composed of a combination of the Boolean constants true or false, Boolean-typed variables, Boolean-valued operators, and Boolean-valued functions.
+
+Boolean expressions correspond to propositional formulas in logic and are a special case of Boolean circuits.
+
+## References
+1. Boolean expression. (2022, April 25). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Boolean_expression)
+2. Boolean algebra. (2022, May 19). In _Wikipedia_.
 [Link](https://en.wikipedia.org/wiki/Boolean_expression)""" .
 
 :Boosting a owl:Class,
@@ -2605,21 +2605,21 @@ Boolean expressions correspond to propositional formulas in logic and are a spec
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BOO" ;
     :definition "Boosting is a sequential process where each subsequent model attempts to correct the errors of the previous model" ;
-    :kb-article """## How it works\r
-Boosting consists of using sequentially weak learners where each iteration’s training focuses on previously misclassified instances in order to improve on the previous iteration. This process is continued iteratively until the final prediction is made by aggregating the previous predictions.\r
-\r
-## Considerations\r
-Boosting can be computationally expensive, prone to overfitting, and slower to train compared to other ensemble methods.\r
-\r
-There are three main types of Boosting algorithms\r
- - Adaptive Boosting\r
-Adaptive Boosting (sometimes called AdaBoost) works by adding equal importance to each piece of a dataset and running it through the base learning algorithms. Every algorithm that errors, the boosting algorithm assigns a higher importance to. This continues until an acceptable level of confidence is reached.\r
- - Gradient Boosting\r
-Gradient Boosting starts by training multiple models simultaneously to gather a strong estimate of strength to build new base learning algorithms.\r
- - XGBoosting\r
-XGBoosting is a scalable tree boosting model. Using decision trees, weight is assigned to each variable and put into a decision tree. Outputs that are classified by the algorithm as wrong or weak are put into a second decision tree and the results form a stronger model.\r
-\r
-## References\r
+    :kb-article """## How it works
+Boosting consists of using sequentially weak learners where each iteration’s training focuses on previously misclassified instances in order to improve on the previous iteration. This process is continued iteratively until the final prediction is made by aggregating the previous predictions.
+
+## Considerations
+Boosting can be computationally expensive, prone to overfitting, and slower to train compared to other ensemble methods.
+
+There are three main types of Boosting algorithms
+ - Adaptive Boosting
+Adaptive Boosting (sometimes called AdaBoost) works by adding equal importance to each piece of a dataset and running it through the base learning algorithms. Every algorithm that errors, the boosting algorithm assigns a higher importance to. This continues until an acceptable level of confidence is reached.
+ - Gradient Boosting
+Gradient Boosting starts by training multiple models simultaneously to gather a strong estimate of strength to build new base learning algorithms.
+ - XGBoosting
+XGBoosting is a scalable tree boosting model. Using decision trees, weight is assigned to each variable and put into a decision tree. Outputs that are classified by the algorithm as wrong or weak are put into a second decision tree and the results form a stronger model.
+
+## References
 Sciencedirect. (n.d.). Semi-supervised learning: An overview. [Link](https://www.sciencedirect.com/science/article/pii/S1319157823000228)""" .
 
 :BootLoader a owl:Class ;
@@ -2659,7 +2659,7 @@ Sciencedirect. (n.d.). Semi-supervised learning: An overview. [Link](https://www
     rdfs:subClassOf :ResamplingEnsemble ;
     :d3fend-id "D3A-BA" ;
     :definition "Bootstrap aggregating, also called bagging (from bootstrap aggregating), is a machine learning ensemble meta-algorithm designed to improve the stability and accuracy of machine learning algorithms used in statistical classification and regression. It also reduces variance and helps to avoid overfitting. Although it is usually applied to decision tree methods, it can be used with any type of method. Bagging is a special case of the model averaging approach." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Bootstrap aggregating. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Bootstrap_aggregating).""" .
 
 :BroadcastDomainIsolation a :NetworkIsolation,
@@ -2672,12 +2672,12 @@ Bootstrap aggregating. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Bootstra
             owl:someValuesFrom :LocalAreaNetworkTraffic ] ;
     :d3fend-id "D3-BDI" ;
     :definition "Broadcast isolation restricts the number of computers a host can contact on their LAN." ;
-    :kb-article """## How it works\r
-Software Defined Networking, or other network encapsulation technologies intercept host broadcast traffic then route it to a specified destination per a configured policy.\r
-\r
-This can be implemented within hypervisors, networking hardware (WAPs, switches, routers), or virutal hardware.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Software Defined Networking, or other network encapsulation technologies intercept host broadcast traffic then route it to a specified destination per a configured policy.
+
+This can be implemented within hypervisors, networking hardware (WAPs, switches, routers), or virutal hardware.
+
+## Considerations
 This technique is highly dependent on network infrastructure and networking requirements.""" ;
     :kb-reference :Reference-BroadcastIsolationAndLevel3NetworkSwitch_HewlettPackardEnterpriseDevelopmentLP,
         :Reference-PrivateVirtualLocalAreaNetworkIsolation_CiscoTechnologyInc ;
@@ -2708,7 +2708,7 @@ This technique is highly dependent on network infrastructure and networking requ
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BOM" ;
     :definition "A \"bucket of models\" is an ensemble technique in which a model selection algorithm is used to choose the best model for each problem. When tested with only one problem, a bucket of models can produce no better results than the best model in the set, but when evaluated across many problems, it will typically produce much better results, on average, than any model in the set." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :BuildTool a owl:Class ;
@@ -2731,31 +2731,31 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :NetworkTrafficAnalysis ;
     :d3fend-id "D3-BSE" ;
     :definition "Analyzing sequences of bytes and determining if they likely represent malicious shellcode." ;
-    :kb-article """## How it works\r
-\r
-Bytes are analyzed as if they are machine code instructions, and such instructions that are a common component of known shellcode are noted, such as stack pivots, reads from a Memory Address Table, and system calls for functions that disable protections or execute code.  For example, the x86 instruction `b0 0b: mov $11, %ax`, with no further alterations to the `%ax` register, followed by `cd 80: syscall` executes the system call `execve()` in the Linux kernel, which replaces the current process with another one specified -- this is a common action in shellcode, so this sequence would be flagged.\r
-\r
-This technique detects shellcode despite whether or not it would cause a buffer overflow in the target binary.\r
-\r
-If the sequence of bytes contains a sequence similar to that used in malicious shellcode, the entire byte sequence is flagged and a follow-on technique may be invoked.\r
-\r
-## Considerations\r
-\r
-### False Negatives\r
-If the shellcode instructions are far apart, simple implementations might not detect the shellcode.\r
-\r
-Due to the nature of assembly instructions not having a defined start or end, implementations which do not process all start sequences (for example, when they a find byte sequence of interest, continue scanning forwards from the end of it) might not detect the shellcode.\r
-\r
-This technique might not detect more complex or obfuscated instructions.  For that purpose, Dynamic Analysis or Emulated File Analysis could assist by analyzing the actual instruction function.\r
-\r
-This technique may not detect self-modifying code.  To make it harder for a process to modify itself, Process Segment Execution Prevention should be used, while noting its considerations.\r
-\r
-This technique might not detect malicious shellcode which reuses instructions in the target binary for malicious effect, as memory references in the presumed assembly code are not dereferenced.  Dynamic Analysis and Emulated File Analysis, when set up properly to fork from the running target binary, might detect this.  Process Segment Execution Prevention combined with Segment Address Offset Randomization frequently makes introduction of shellcode through overwriting a saved return pointer more difficult.  Call stack depth analysis might detect excessive reuse of instructions in the target binary.  Shadow Stack Frames might detect that a stack frame's return address has changed and Stack Frame Canary Verification might detect that the stack frame's return address was overwritten.  Other heuristic methods might detect jump-oriented programming shellcode.\r
-\r
-With inserting code directly, that it is not a buffer overflow, and just some place where code is executed either to a file or a write-what-where, the buffer overflow mitigations do not help.  Behavioral analysis could detect this, or proper access control could mitigate this.\r
-\r
-### False Positives\r
-\r
+    :kb-article """## How it works
+
+Bytes are analyzed as if they are machine code instructions, and such instructions that are a common component of known shellcode are noted, such as stack pivots, reads from a Memory Address Table, and system calls for functions that disable protections or execute code.  For example, the x86 instruction `b0 0b: mov $11, %ax`, with no further alterations to the `%ax` register, followed by `cd 80: syscall` executes the system call `execve()` in the Linux kernel, which replaces the current process with another one specified -- this is a common action in shellcode, so this sequence would be flagged.
+
+This technique detects shellcode despite whether or not it would cause a buffer overflow in the target binary.
+
+If the sequence of bytes contains a sequence similar to that used in malicious shellcode, the entire byte sequence is flagged and a follow-on technique may be invoked.
+
+## Considerations
+
+### False Negatives
+If the shellcode instructions are far apart, simple implementations might not detect the shellcode.
+
+Due to the nature of assembly instructions not having a defined start or end, implementations which do not process all start sequences (for example, when they a find byte sequence of interest, continue scanning forwards from the end of it) might not detect the shellcode.
+
+This technique might not detect more complex or obfuscated instructions.  For that purpose, Dynamic Analysis or Emulated File Analysis could assist by analyzing the actual instruction function.
+
+This technique may not detect self-modifying code.  To make it harder for a process to modify itself, Process Segment Execution Prevention should be used, while noting its considerations.
+
+This technique might not detect malicious shellcode which reuses instructions in the target binary for malicious effect, as memory references in the presumed assembly code are not dereferenced.  Dynamic Analysis and Emulated File Analysis, when set up properly to fork from the running target binary, might detect this.  Process Segment Execution Prevention combined with Segment Address Offset Randomization frequently makes introduction of shellcode through overwriting a saved return pointer more difficult.  Call stack depth analysis might detect excessive reuse of instructions in the target binary.  Shadow Stack Frames might detect that a stack frame's return address has changed and Stack Frame Canary Verification might detect that the stack frame's return address was overwritten.  Other heuristic methods might detect jump-oriented programming shellcode.
+
+With inserting code directly, that it is not a buffer overflow, and just some place where code is executed either to a file or a write-what-where, the buffer overflow mitigations do not help.  Behavioral analysis could detect this, or proper access control could mitigate this.
+
+### False Positives
+
 Byte sequences containing code that is never used as machine code are still analyzed and flagged for anomalies, and [eventually](http://mathforum.org/library/drmath/view/55871.html), it is likely that an attack sequence will arise from the sheer volume of bytes transmitted.""" ;
     :kb-reference :Reference-Network-BasedBufferOverflowDetectionByExploitCodeAnalysis_InformationSecurityResearchCentre,
         :Reference-Network-levelPolymorphicShellcodeDetectionUsingEmulation ;
@@ -2767,7 +2767,7 @@ Byte sequences containing code that is never used as machine code are still anal
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-C4." ;
     :definition "C4.5 is an algorithm that is strongly based off ID3. It creates decision trees the same way as ID3. C4.5 improves on several aspects of ID3, including handling discreet variables, handling training data with missing values, and has the ability to automatically prune the decision trees it creates." ;
-    :kb-article """## References\r
+    :kb-article """## References
 C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).""" ;
     :todo "Review: Definition" .
 
@@ -2777,7 +2777,7 @@ C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-C5." ;
     :definition "C5.0 is the next version of C4.5, which in turn is the upgrade from ID3. The only difference between C5.0 and C4.5 is some improvements made to C5.0." ;
-    :kb-article """## References\r
+    :kb-article """## References
 C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).""" .
 
 :CACertificateFile a owl:Class ;
@@ -2818,7 +2818,7 @@ C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-CC" ;
     :definition "The canopy clustering algorithm is an unsupervised pre-clustering algorithm  often used as preprocessing step for the K-means algorithm or the Hierarchical clustering algorithm. It is intended to speed up clustering operations on large data sets." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Canopy clustering algorithm. [Link](https://en.wikipedia.org/wiki/Canopy_clustering_algorithm)""" .
 
 :Capability a owl:Class ;
@@ -2831,25 +2831,25 @@ Wikipedia. (n.d.). Canopy clustering algorithm. [Link](https://en.wikipedia.org/
             owl:onProperty :has-feature ;
             owl:someValuesFrom :CapabilityFeature ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Capability_(systems_engineering)> ;
-    :comment """Source Definitions for DoDAF-DM2 Term: "(JCIDS):  The ability to achieve a desired effect under specified standards and conditions through combinations of means and ways to perform a set of tasks.\r
-(DoDAF/CADM):  An ability to achieve an objective. (DDDS Counter (333/1)(A))\r
-(JC3IEDM):  The potential ability to do work, perform a function or mission, achieve an objective, or provide a service.\r
-(MODAF):  Capabilities in the MODAF sense are specifically not about equipment but are a high level specification of the enterprise’s ability. A capability is a classification of some ability - and can be specified regardless of whether the enterprise is currently able to achieve it. For example, one could define a capability “Manned Interplanetary Travel” which no-one can currently achieve, but which may be planned or aspired to. Capabilities in MODAF are not time-dependent - once defined they are persistent. It is only the Capability Requirement that changes.\r
-(NAF):  The ability of one or more resources to deliver a specified type of effect or a specified course of action. (GEN TERM)\r
-(NAF):  A high level specification of the enterprise's ability. (MM)\r
-(JCS 1-02):  The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)\r
-(Webster's):  1. The quality of being capable; ability.  2. A talent or ability that has potential for development or use.  3. The capacity to be used, treated, or developed for a specific purpose.\r
-(Merriam-Webster's Eleventh Collegiate Dictionary): A feature or factor capable of development: POTENTIALITY.    3. The facility or potential for an indicated use or deployment.\r
-(Joint Publication 1-02, Dictionary of Military and Associated Terms, 12 Apr 2001 (as amended trhough 30 May 2008) ): The ability to exercise a specified course of action (A capability may or may not be accompanied by an intention)\r
-(Dictionary.com): The quality of being capable; capacity; ability: His capability was unquestionable. The ability to undergo or be affected by a given treatment or action: the capability of glass in resisting heat. Usually, capabilities. qualities, abilities, features, etc., that can be used or developed; potential: Though dilapidated, the house has great capabilities\r
-(Wiktionary): The power or ability to generate an outcome\r
-(www.staffordshireprepared.gov.uk/glossary/): Originally a military term which includes the aspects of personnel, equipment, training, planning and operational doctrine. Now used to mean a demonstrable capacity or ability to respond to and recover from a particular threat or hazard."\r
-\r
-CJCS Guide 3401D: https://www.jcs.mil/Portals/36/Documents/Library/Handbooks/g3401.pdf?ver=2016-02-05-175742-457 : "capability. The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)"\r
-\r
-USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423 "capability - means to accomplish a mission, function, or objective." DHS, DHS Lexicon, Terms, Mar 17;\r
-\r
-USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423  "capability - Provides the means to accomplish a mission or function resulting from the performance of one or more critical tasks, under specified conditions, to target levels of performance. A capability may be delivered with any combination of properly planned, organized, equipped, trained, and exercised personnel that achieves the desired outcome."\r
+    :comment """Source Definitions for DoDAF-DM2 Term: "(JCIDS):  The ability to achieve a desired effect under specified standards and conditions through combinations of means and ways to perform a set of tasks.
+(DoDAF/CADM):  An ability to achieve an objective. (DDDS Counter (333/1)(A))
+(JC3IEDM):  The potential ability to do work, perform a function or mission, achieve an objective, or provide a service.
+(MODAF):  Capabilities in the MODAF sense are specifically not about equipment but are a high level specification of the enterprise’s ability. A capability is a classification of some ability - and can be specified regardless of whether the enterprise is currently able to achieve it. For example, one could define a capability “Manned Interplanetary Travel” which no-one can currently achieve, but which may be planned or aspired to. Capabilities in MODAF are not time-dependent - once defined they are persistent. It is only the Capability Requirement that changes.
+(NAF):  The ability of one or more resources to deliver a specified type of effect or a specified course of action. (GEN TERM)
+(NAF):  A high level specification of the enterprise's ability. (MM)
+(JCS 1-02):  The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)
+(Webster's):  1. The quality of being capable; ability.  2. A talent or ability that has potential for development or use.  3. The capacity to be used, treated, or developed for a specific purpose.
+(Merriam-Webster's Eleventh Collegiate Dictionary): A feature or factor capable of development: POTENTIALITY.    3. The facility or potential for an indicated use or deployment.
+(Joint Publication 1-02, Dictionary of Military and Associated Terms, 12 Apr 2001 (as amended trhough 30 May 2008) ): The ability to exercise a specified course of action (A capability may or may not be accompanied by an intention)
+(Dictionary.com): The quality of being capable; capacity; ability: His capability was unquestionable. The ability to undergo or be affected by a given treatment or action: the capability of glass in resisting heat. Usually, capabilities. qualities, abilities, features, etc., that can be used or developed; potential: Though dilapidated, the house has great capabilities
+(Wiktionary): The power or ability to generate an outcome
+(www.staffordshireprepared.gov.uk/glossary/): Originally a military term which includes the aspects of personnel, equipment, training, planning and operational doctrine. Now used to mean a demonstrable capacity or ability to respond to and recover from a particular threat or hazard."
+
+CJCS Guide 3401D: https://www.jcs.mil/Portals/36/Documents/Library/Handbooks/g3401.pdf?ver=2016-02-05-175742-457 : "capability. The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)"
+
+USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423 "capability - means to accomplish a mission, function, or objective." DHS, DHS Lexicon, Terms, Mar 17;
+
+USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423  "capability - Provides the means to accomplish a mission or function resulting from the performance of one or more critical tasks, under specified conditions, to target levels of performance. A capability may be delivered with any combination of properly planned, organized, equipped, trained, and exercised personnel that achieves the desired outcome."
 DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
     rdfs:seeAlso <https://web.archive.org/web/20081123014953/http://www.dtic.mil/doctrine/jel/new_pubs/jp1_02.pdf> .
 
@@ -2931,7 +2931,7 @@ DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-CAR" ;
     :definition "The CART algorithm is a type of classification algorithm that is required to build a decision tree on the basis of Gini’s impurity index." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Classification and Regression Tree (CART) Algorithm. Analytics Steps. [Link](https://www.analyticssteps.com/blogs/classification-and-regression-tree-cart-algorithm).""" .
 
 :Catalog a owl:Class ;
@@ -2980,9 +2980,9 @@ Classification and Regression Tree (CART) Algorithm. Analytics Steps. [Link](htt
     rdfs:subClassOf :DescriptiveStatistics ;
     :d3fend-id "D3A-CT" ;
     :definition "A measure of central tendency ) is a summary measure that attempts to describe a whole set of data with a single value that represents the middle or centre of its distribution." ;
-    :kb-article """## References\r
-Australian Bureau of Statistics. (n.d.). Measures of Central Tendency. [Link](https://www.abs.gov.au/statistics/understanding-statistics/statistical-terms-and-concepts/measures-central-tendency)\r
-\r
+    :kb-article """## References
+Australian Bureau of Statistics. (n.d.). Measures of Central Tendency. [Link](https://www.abs.gov.au/statistics/understanding-statistics/statistical-terms-and-concepts/measures-central-tendency)
+
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :Centroid-basedClustering a owl:Class,
@@ -2991,7 +2991,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-CBC" ;
     :definition "Centroid-based clustering organizes the data into non-hierarchical clusters, in contrast to hierarchical clustering defined below. K-means is the most widely-used centroid-based clustering algorithm. Centroid-based algorithms are efficient but sensitive to initial conditions and outliers." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Google Developers. (n.d.). Clustering Algorithms. [Link](https://developers.google.com/machine-learning/clustering/clustering-algorithms)""" .
 
 :Certificate a owl:Class ;
@@ -3029,9 +3029,9 @@ Google Developers. (n.d.). Clustering Algorithms. [Link](https://developers.goog
             owl:someValuesFrom :CertificateFile ] ;
     :d3fend-id "D3-CA" ;
     :definition "Analyzing Public Key Infrastructure certificates to detect if they have been misconfigured or spoofed using both network traffic, certificate fields and third-party logs." ;
-    :kb-article """## How it works\r
-Certificate Analysis ensures that the data elements of the certificate are current and anchored in a known trust model. Certificate authorities, revocation lists, and third-party secure logs are used in the analysis. Analysis includes detection of server impersonation, phishing domains, and forged certificates.\r
-\r
+    :kb-article """## How it works
+Certificate Analysis ensures that the data elements of the certificate are current and anchored in a known trust model. Certificate authorities, revocation lists, and third-party secure logs are used in the analysis. Analysis includes detection of server impersonation, phishing domains, and forged certificates.
+
 TLS certificates are designed to expire to ensure that the cryptographic keys are forced to be changed on a regular basis. The certificates in the trust path also expire and can cause a break in the trust chain. This means that even if a server certificate is updated correctly, intermediate certificates can expire and the trust chain is not maintained. This can cause services to become unavailable.""" ;
     :kb-reference :Reference-SecuringWebTransactions .
 
@@ -3054,25 +3054,25 @@ TLS certificates are designed to expire to ensure that the cryptographic keys ar
             owl:someValuesFrom :PublicKey ] ;
     :d3fend-id "D3-CP" ;
     :definition "Persisting either a server's X509 certificate or their public key and comparing that to server's presented identity to allow for greater client confidence in the remote server's identity for SSL connections." ;
-    :kb-article """## How it works\r
-Pinning allows for a trusted copy of a certificate or public key to be associated with a server and thus reducing the likelihood of frequently visited sites being subjected to man-in-the-middle attacks. Certificates or public keys can be pinned after a trusted connection has been established or the pinning can be preloaded in an application, which is the preferred method for mobile applications.\r
-\r
-Pinning can take the form of certificate pinning or public key pinning.\r
-\r
-## Forms of Pinning\r
-* Certificate Pinning\r
-Certificate Pinning (CP) allows for the client to verify the X509 certificate with a preloaded certificate. Typically, this is involves storing a hash of the certificate and using the stored hash for comparison to the hash of the certificate submitted during the SSL handshake.\r
-\r
-* Public Key Pinning\r
-Public Key Pinning (PKP) requires the extraction of a public key from server's certificate. The stored public key is compared to the server's presented public key. A public key is expected to rotate less frequently than an X509 certificate and is generally favored over certificate pinning.\r
-\r
-An extension of PKP is Subject Public Key Information Pinning (SPKI) includes public key pinning plus additional information for SSL connections. The additional information can include preferred algorithms.\r
-\r
-## Considerations\r
-\r
-* With pinned certificates whenever a server updates its certificate, the pinned certificates will also need to be updated\r
-* With pinned public keys the extracted key may be subject to key refresh policies but much less frequently\r
-* Servers can become unavailable if pinned objects are set and not updated with the rotated identities. This may require a pinning strategy to be developed.\r
+    :kb-article """## How it works
+Pinning allows for a trusted copy of a certificate or public key to be associated with a server and thus reducing the likelihood of frequently visited sites being subjected to man-in-the-middle attacks. Certificates or public keys can be pinned after a trusted connection has been established or the pinning can be preloaded in an application, which is the preferred method for mobile applications.
+
+Pinning can take the form of certificate pinning or public key pinning.
+
+## Forms of Pinning
+* Certificate Pinning
+Certificate Pinning (CP) allows for the client to verify the X509 certificate with a preloaded certificate. Typically, this is involves storing a hash of the certificate and using the stored hash for comparison to the hash of the certificate submitted during the SSL handshake.
+
+* Public Key Pinning
+Public Key Pinning (PKP) requires the extraction of a public key from server's certificate. The stored public key is compared to the server's presented public key. A public key is expected to rotate less frequently than an X509 certificate and is generally favored over certificate pinning.
+
+An extension of PKP is Subject Public Key Information Pinning (SPKI) includes public key pinning plus additional information for SSL connections. The additional information can include preferred algorithms.
+
+## Considerations
+
+* With pinned certificates whenever a server updates its certificate, the pinned certificates will also need to be updated
+* With pinned public keys the extracted key may be subject to key refresh policies but much less frequently
+* Servers can become unavailable if pinned objects are set and not updated with the rotated identities. This may require a pinning strategy to be developed.
 * The application of this technique within web browser applications has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning) by  popular web browser developers. They now favor certificate analysis via public certificate transparency logs, and the EXPECT-CT HTTP header.""" ;
     :kb-reference :Reference-CertificateAndPublicKeyPinning,
         :Reference-End-to-endCertificatePinning .
@@ -3107,13 +3107,13 @@ An extension of PKP is Subject Public Key Information Pinning (SPKI) includes pu
     rdfs:subClassOf :SupervisedLearning ;
     :d3fend-id "D3A-CLA" ;
     :definition "Classification uses an algorithm to accurately assign test data into specific categories." ;
-    :kb-article """## How it works\r
-Classification recognizes specific entities within the dataset and attempts to draw some conclusions on how those entities should be labeled or defined. Common classification algorithms are linear classifiers, support vector machines (SVM), decision trees, k-nearest neighbor, and random forest, which are described in more detail below.\r
-\r
-\r
-## References\r
-Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning).\r
-\r
+    :kb-article """## How it works
+Classification recognizes specific entities within the dataset and attempts to draw some conclusions on how those entities should be labeled or defined. Common classification algorithms are linear classifiers, support vector machines (SVM), decision trees, k-nearest neighbor, and random forest, which are described in more detail below.
+
+
+## References
+Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning).
+
 Types of Classification in Machine Learning. Machine Learning Mastery. [Link](https://machinelearningmastery.com/types-of-classification-in-machine-learning/).""" .
 
 :Classifying a owl:Class ;
@@ -3130,14 +3130,14 @@ Types of Classification in Machine Learning. Machine Learning Mastery. [Link](ht
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-CSPP" ;
     :definition "Comparing client-server request and response payloads to a baseline profile to identify outliers." ;
-    :kb-article """## How it works\r
-Profiling request and response payloads across multiple clients to a single server to develop a baseline of their characteristics. May take into account request/response sizes, entropy, frequency, and rhythm. Finally, identify outliers as they may indicate a malicious payload delivery and subsequent server exploitation.\r
-\r
-\r
-## Considerations\r
-* Collecting metrics to establish a profile can be challenging since user behavior can change easily.\r
-* Employees may work different hours or inconsistent schedules which will cause false positives.\r
-* Collection of network activity to generate metrics is a computationally intensive process.\r
+    :kb-article """## How it works
+Profiling request and response payloads across multiple clients to a single server to develop a baseline of their characteristics. May take into account request/response sizes, entropy, frequency, and rhythm. Finally, identify outliers as they may indicate a malicious payload delivery and subsequent server exploitation.
+
+
+## Considerations
+* Collecting metrics to establish a profile can be challenging since user behavior can change easily.
+* Employees may work different hours or inconsistent schedules which will cause false positives.
+* Collection of network activity to generate metrics is a computationally intensive process.
 * Users may log into different workstations which may cause false positives.""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingMaliciousPayloads_VectraNetworksInc .
 
@@ -3212,7 +3212,7 @@ Profiling request and response payloads across multiple clients to a single serv
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-CA" ;
     :definition "Cluster analysis or clustering is the task of grouping a set of objects in such a way that objects in the same group (called a cluster) are more similar (in some sense) to each other than to those in other groups (clusters)." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Cluster analysis. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wiki/Cluster_analysis)""" .
 
 :Clustering a owl:Class ;
@@ -3243,10 +3243,10 @@ Cluster analysis. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wiki/Cluste
     rdfs:label "Coefficient of Variation" ;
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-COV" ;
-    :definition """The coefficient of variation (CV), also known as relative standard deviation (RSD), is a standardized measure of dispersion of a probability distribution or frequency distribution.\r
-\r
+    :definition """The coefficient of variation (CV), also known as relative standard deviation (RSD), is a standardized measure of dispersion of a probability distribution or frequency distribution.
+
 The coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean .""" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Coefficient of variation. [Link](https://en.wikipedia.org/wiki/Coefficient_of_variation)""" ;
     :synonym "Relative Standard Deviation",
         "RSD" .
@@ -3387,8 +3387,8 @@ Wikipedia. (n.d.). Coefficient of variation. [Link](https://en.wikipedia.org/wik
             owl:someValuesFrom :ConfigurationResource ] ;
     :d3fend-id "D3-CI" ;
     :definition "Configuration inventory identifies and records the configuration of software and hardware and their components throughout the organization." ;
-    :kb-article """## How it works\r
-\r
+    :kb-article """## How it works
+
 The organization retrieves configuration information through means of SNMP (MIB records), WBEM (CIM records), other protocols, or custom scripts and captures that information in a repository, typically known as a Configuration Management Database (CMDB).\"""" ;
     :kb-reference :Reference-Web-BasedEnterpriseManagement,
         :Reference-Windows-Management-Infrastructure,
@@ -3418,10 +3418,10 @@ The organization retrieves configuration information through means of SNMP (MIB 
             owl:someValuesFrom :LocalAreaNetwork ] ;
     :d3fend-id "D3-CHN" ;
     :definition "A decoy service, system, or environment, that is connected to the enterprise network, and simulates or emulates certain functionality to the network, without exposing full access to a production system." ;
-    :kb-article """## How it works\r
-Decoy honeypots are deployed within the enterprise environment that emulate certain services or portions of an OS to attract attackers.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Decoy honeypots are deployed within the enterprise environment that emulate certain services or portions of an OS to attract attackers.
+
+## Considerations
 A connected honeynet provides a tradeoff between emulating certain functionality but not being as sophisticated as an integrated honeynet. The connected honeynet may not provide enough functionality to detect new attack patterns or zero day exploits but could provide enough functionality for specific known vulnerabilities.""" ;
     :kb-reference :Reference-ModificationOfAServerToMimicADeceptionMechanism_AcalvioTechnologiesInc .
 
@@ -3431,7 +3431,7 @@ A connected honeynet provides a tradeoff between emulating certain functionality
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-CBC" ;
     :definition "Connectivity-based clustering is based on connectivity between the elements Clusters are created by building a hierarchical tree-type structure." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Connectivity-Based Clustering. Sarang, P. (2023) in Thinking Data Science. The Springer Series in Applied Machine Learning. Springer, Cham. [Link](https://doi.org/10.1007/978-3-031-02363-7_10)""" ;
     :todo "Should this be connectivity based clustering ?" .
 
@@ -3445,19 +3445,19 @@ Connectivity-Based Clustering. Sarang, P. (2023) in Thinking Data Science. The S
             owl:someValuesFrom :IntranetNetworkTraffic ] ;
     :d3fend-id "D3-CAA" ;
     :definition "Analyzing failed connections in a network to detect unauthorized activity." ;
-    :kb-article """## How it works\r
-Connection Attempt Analysis in multiple ways.\r
-\r
-### Monitoring traffic to unallocated IP space\r
-One approach looks for failed connection attempts against unallocated IP space. First, network traffic is captured to map out the network to identify network assets as well as unallocated IP space. The map is then used to determine if connection attempts are being made to the unallocated IP space.\r
-\r
-### Monitoring for sequentially transmitted traffic\r
-Another approach passively inspects network traffic with application protocol analyzers observing network activity characteristics such as volume of packets sent/ received, TCP session attributes, and connection information between hosts (start time, source/destination host, services, etc.). Then using pattern matching to identify traffic which appears to be probing for network hosts.\r
-\r
-## Considerations\r
-\r
-* Implementations that rely on analysis of unallocated IP address space increase in their complexity with network size and decentralized network infrastructure.\r
-* Inventory of unallocated IP space should should be continuously updated to mitigate the risk of false positives.\r
+    :kb-article """## How it works
+Connection Attempt Analysis in multiple ways.
+
+### Monitoring traffic to unallocated IP space
+One approach looks for failed connection attempts against unallocated IP space. First, network traffic is captured to map out the network to identify network assets as well as unallocated IP space. The map is then used to determine if connection attempts are being made to the unallocated IP space.
+
+### Monitoring for sequentially transmitted traffic
+Another approach passively inspects network traffic with application protocol analyzers observing network activity characteristics such as volume of packets sent/ received, TCP session attributes, and connection information between hosts (start time, source/destination host, services, etc.). Then using pattern matching to identify traffic which appears to be probing for network hosts.
+
+## Considerations
+
+* Implementations that rely on analysis of unallocated IP address space increase in their complexity with network size and decentralized network infrastructure.
+* Inventory of unallocated IP space should should be continuously updated to mitigate the risk of false positives.
 * IPv6 also introduces challenges including IPv6 traffic bypassing IPv4 specific protection systems (ex. firewalls and IDS) and complexity in managing both IPv6 and IPv4 addresses.""" ;
     :kb-reference :Reference-DetectingNetworkReconnaissanceByTrackingIntranetDark-netCommunications_VECTRANETWORKSInc ;
     :synonym "Network Scan Detection" .
@@ -3486,8 +3486,8 @@ Another approach passively inspects network traffic with application protocol an
     rdfs:subClassOf :File,
         :SoftwarePackage ;
     rdfs:isDefinedBy <https://www.docker.com/resources/what-container> ;
-    :definition """A container is a standard unit of software that packages up code and all its dependencies so the application runs quickly and reliably from one computing environment to another. A Docker container image is a lightweight, standalone, executable package of software that includes everything needed to run an application: code, runtime, system tools, system libraries and settings.\r
-\r
+    :definition """A container is a standard unit of software that packages up code and all its dependencies so the application runs quickly and reliably from one computing environment to another. A Docker container image is a lightweight, standalone, executable package of software that includes everything needed to run an application: code, runtime, system tools, system libraries and settings.
+
 Container images become containers at runtime and in the case of Docker containers - images become containers when they run on Docker Engine. Available for both Linux and Windows-based applications, containerized software will always run the same, regardless of the infrastructure. Containers isolate software from its environment and ensure that it works uniformly despite differences for instance between development and staging.""" ;
     rdfs:seeAlso "https://schema.ocsf.io/objects/image" .
 
@@ -3548,7 +3548,7 @@ Container images become containers at runtime and in the case of Docker containe
     rdfs:subClassOf :DeepNeuralNetClassification ;
     :d3fend-id "D3A-CNN" ;
     :definition "A class of artificial neural network most commonly applied to analyze visual imagery.CNNs use a mathematical operation called convolution in place of general matrix multiplication in at least one of their layers." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Convolutional neural network. [Link](https://en.wikipedia.org/wiki/Convolutional_neural_network)""" .
 
 :CopyMemoryFunction a owl:Class ;
@@ -3582,7 +3582,7 @@ Wikipedia. (n.d.). Convolutional neural network. [Link](https://en.wikipedia.org
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-CC" ;
     :definition "Correlation clustering provides a method for clustering a set of objects into the optimum number of clusters without specifying that number in advance." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Correlation clustering. [Link](https://en.wikipedia.org/wiki/Correlation_clustering)""" .
 
 :CramersV a owl:Class,
@@ -3591,7 +3591,7 @@ Wikipedia. (n.d.). Correlation clustering. [Link](https://en.wikipedia.org/wiki/
     rdfs:subClassOf :Correlation ;
     :d3fend-id "D3A-CV" ;
     :definition "Cramér's V (sometimes referred to as Cramér's phi and denoted as φc) is a measure of association between two nominal variables, giving a value between 0 and +1 (inclusive) and is based on Pearson's chi-squared statistic." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Cramér's V. [Link](https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V)""" ;
     :synonym "Cramer's Phi" .
 
@@ -3677,34 +3677,34 @@ Wikipedia. (n.d.). Cramér's V. [Link](https://en.wikipedia.org/wiki/Cram%C3%A9r
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-CCSA" ;
     :definition "Determining which credentials may have been compromised by analyzing the user logon history of a particular system." ;
-    :kb-article """## How it works\r
-\r
-#### Memory\r
-Credentials may be stored in memory for a variety of reasons; on Windows, they may be stored in lsass.exe.  Once a credential dumper like mimikatz runs and dumps the memory of lsass.exe, the credentials of every account logged on since boot are potentially compromised.\r
-When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.\r
-\r
-\r
-#### Hard disk\r
-Operating System may cache a certain number of credentials onto the hard disk to use as a source of truth if it cannot contact the credential server.  In many versions of Microsoft Windows, the 10 most recent are cached by default; this setting can be changed in the Microsoft Management Console's Local Security Policy: ```Computer Configuration -> Windows Settings -> Local Policy -> Security Options -> Interactive Logon: Number of previous logons to cache -> 0```  Here we are not concerned with the alteration of the credentials but the fact that they might be read.  If the attacker has physical access to the machine they are unlikely to be stopped from reading files on the filesystem.\r
-"In the event that the domain controller is unavailable Windows will check the last password hashes that has been cached in order to authenticate the user with the system. These password hashes are cached in the following registry setting:\r
-HKEY_LOCAL_MACHINE\\SECURITY\\Cache\r
-Mimikatz can retrieve these hashes if the following command is executed:\r
-lsadump::cache" [1]\r
-\r
-The Registry Hive, HKEY_LOCAL_MACHINE\\SAM, which is stored in the supporting files %systemroot%\\System32\\Config\\{Sam,sam.log,sam.sav}, contains the SAM file.\r
-\r
-DC: This is stored in %systemroot%\\ntds\\ntds.dit. (https://www.ultimatewindowssecurity.com/blog/default.aspx?d=10/2017)\r
-\r
-Sometimes memory, which contains credentials, could get on the hard disk. Like with hiberfil.sys in Windows.  Equivalent on Linux\r
-\r
-\r
-In Linux, an attacker could read the /etc/shadow file.\r
-\r
-Reading from /proc directory: mimipenguin, many others.\r
-\r
-## Considerations\r
-Effective implementation requires identifying any location that could end up containing credentials, and detecting an method of potential access to a source of credential data.\r
-\r
+    :kb-article """## How it works
+
+#### Memory
+Credentials may be stored in memory for a variety of reasons; on Windows, they may be stored in lsass.exe.  Once a credential dumper like mimikatz runs and dumps the memory of lsass.exe, the credentials of every account logged on since boot are potentially compromised.
+When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.
+
+
+#### Hard disk
+Operating System may cache a certain number of credentials onto the hard disk to use as a source of truth if it cannot contact the credential server.  In many versions of Microsoft Windows, the 10 most recent are cached by default; this setting can be changed in the Microsoft Management Console's Local Security Policy: ```Computer Configuration -> Windows Settings -> Local Policy -> Security Options -> Interactive Logon: Number of previous logons to cache -> 0```  Here we are not concerned with the alteration of the credentials but the fact that they might be read.  If the attacker has physical access to the machine they are unlikely to be stopped from reading files on the filesystem.
+"In the event that the domain controller is unavailable Windows will check the last password hashes that has been cached in order to authenticate the user with the system. These password hashes are cached in the following registry setting:
+HKEY_LOCAL_MACHINE\\SECURITY\\Cache
+Mimikatz can retrieve these hashes if the following command is executed:
+lsadump::cache" [1]
+
+The Registry Hive, HKEY_LOCAL_MACHINE\\SAM, which is stored in the supporting files %systemroot%\\System32\\Config\\{Sam,sam.log,sam.sav}, contains the SAM file.
+
+DC: This is stored in %systemroot%\\ntds\\ntds.dit. (https://www.ultimatewindowssecurity.com/blog/default.aspx?d=10/2017)
+
+Sometimes memory, which contains credentials, could get on the hard disk. Like with hiberfil.sys in Windows.  Equivalent on Linux
+
+
+In Linux, an attacker could read the /etc/shadow file.
+
+Reading from /proc directory: mimipenguin, many others.
+
+## Considerations
+Effective implementation requires identifying any location that could end up containing credentials, and detecting an method of potential access to a source of credential data.
+
 1. https://medium.com/blue-team/preventing-mimikatz-attacks-ed283e7ebdd5""" ;
     :kb-reference :Reference-AllLoginsSinceLastBoot_MITRE,
         :Reference-SystemsAndMethodsForDetectingCredentialTheft_SymantecCorp .
@@ -3749,8 +3749,8 @@ Effective implementation requires identifying any location that could end up con
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-CR" ;
     :definition "Deleting a set of credentials permanently to prevent them from being used to authenticate." ;
-    :kb-article """## How it works\r
-\r
+    :kb-article """## How it works
+
 Management servers with enterprise policies for account management provide the ability remove permissions, accounts, or credentials. Compromised credentials should be revoked to prevent further malicious activity.""" ;
     :kb-reference :Reference-RevokingaPreviouslyIssuedVerifiableCredential-Microsoft .
 
@@ -3764,13 +3764,13 @@ Management servers with enterprise policies for account management provide the a
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-CRO" ;
     :definition "Expiring an existing set of credentials and reissuing a new valid set" ;
-    :kb-article """## How it works\r
-\r
-Management servers with enterprise policies for account management provide the ability to change or reset passwords for accounts. Some organizations rotate credentials periodically to limit the risk of stolen credentials.\r
-\r
-## Considerations\r
-\r
-- When responding to an incident, severity of compromise should be considered to determine what credentials to what accounts should be regenerated\r
+    :kb-article """## How it works
+
+Management servers with enterprise policies for account management provide the ability to change or reset passwords for accounts. Some organizations rotate credentials periodically to limit the risk of stolen credentials.
+
+## Considerations
+
+- When responding to an incident, severity of compromise should be considered to determine what credentials to what accounts should be regenerated
 - If proactively rotating credentials periodically, several factors should be considered to determine the frequency. Also introduces some risk including promoting the creation of weak passwords and poor storage practices for employees and presents challenges in proper tracking.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-EvictionGuidanceforNetworksAffectedbytheSolarWindsandActiveDirectory/M365Compromise-CISA>,
         :Reference-PasswordandKeyRotation-SSH .
@@ -8696,7 +8696,7 @@ Management servers with enterprise policies for account management provide the a
     rdfs:subClassOf :Image-to-ImageTranslationGAN ;
     :d3fend-id "D3A-CYC" ;
     :definition "The Cycle Generative Adversarial Network (CycleGAN) is an approach to training a deep convolutional neural network for image-to-image translation tasks by mapping between input and output images using unpaired dataset." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Esri. (n.d.). How CycleGAN Works. [Link](https://developers.arcgis.com/python/guide/how-cyclegan-works/)""" .
 
 :D3FENDCatalogThing a owl:Class ;
@@ -8760,15 +8760,15 @@ Esri. (n.d.). How CycleGAN Works. [Link](https://developers.arcgis.com/python/gu
             owl:someValuesFrom :DatabaseQuery ] ;
     :d3fend-id "D3-DQSA" ;
     :definition "Analyzing database queries to detect [SQL Injection](https://capec.mitre.org/data/definitions/66.html)." ;
-    :kb-article """## How it works\r
-\r
-Some implementations use software hooks to intercept function calls related to database query operations. Other implementations might intercept or collect network traffic. The database query string is then extracted and analyzed with various methods, for example:\r
-* Detecting specific administrative SQL commands\r
-* Anomalous sequences of commands when compared to a statistical baseline.\r
-* Anomalous commands for a given user role.\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+
+Some implementations use software hooks to intercept function calls related to database query operations. Other implementations might intercept or collect network traffic. The database query string is then extracted and analyzed with various methods, for example:
+* Detecting specific administrative SQL commands
+* Anomalous sequences of commands when compared to a statistical baseline.
+* Anomalous commands for a given user role.
+
+## Considerations
+
 Some capabilities sanitize queries before permitting them to be transmitted to the database. This incurs risks such altering data in an undesired way or breaking application functionality.""" ;
     :kb-reference :Reference-SystemAndMethodForInternetSecurity_CylanceInc .
 
@@ -8841,10 +8841,10 @@ Some capabilities sanitize queries before permitting them to be transmitted to t
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-DAT" ;
     :definition "Datalog is a declarative logic programming language that is a syntactically a subset of Prolog." ;
-    :kb-article """## How it works\r
-Datalog generally uses a bottom-up rather than top-down evaluation model. This difference yields significantly different behavior and properties from Prolog. It is often used as a query language for deductive databases. Datalog has been applied to problems in data integration, networking, program analysis, and more.\r
-\r
-## References\r
+    :kb-article """## How it works
+Datalog generally uses a bottom-up rather than top-down evaluation model. This difference yields significantly different behavior and properties from Prolog. It is often used as a query language for deductive databases. Datalog has been applied to problems in data integration, networking, program analysis, and more.
+
+## References
 1. Datalog. (2023, April 20). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Datalog)""" .
 
 :DBSCAN a owl:Class,
@@ -8853,7 +8853,7 @@ Datalog generally uses a bottom-up rather than top-down evaluation model. This d
     rdfs:subClassOf :Density-basedClustering ;
     :d3fend-id "D3A-DBS" ;
     :definition "A density-based clustering algorithm that works on the assumption that clusters are dense regions in space separated by regions of lower density." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Analytics Vidhya. (2020, September 15). How DBSCAN Clustering Works: A Comprehensive Guide with Implementations in Python. [Link](https://www.analyticsvidhya.com/blog/2020/09/how-dbscan-clustering-works/#:~:text=DBSCAN%20is%20a%20density%2Dbased,points%20into%20a%20single%20cluster.)""" ;
     :todo "Do we need HBDSCAN and OPTICS as well in density based clustering ?" .
 
@@ -8864,14 +8864,14 @@ Analytics Vidhya. (2020, September 15). How DBSCAN Clustering Works: A Comprehen
     rdfs:subClassOf :ApplicationHardening ;
     :d3fend-id "D3-DCE" ;
     :definition "Removing unreachable or \"dead code\" from compiled source code." ;
-    :kb-article """## How it works\r
-\r
-Dead code is code that is considered unreachable by normal program execution. Dead code can be created by adding code under a condition that never evaluates to true. Dead code should be removed since this type of code can produce unexpected results, if accidentally or maliciously forced to execute.\r
-\r
-Dead code identification is typically performed by algorithms that implement program flows analysis looking for unreachable code. The dead code is eliminated by instructing compilers to remove the code through compiler flags, i.e., '-fdce' is used for Dead Code Elimination.\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+
+Dead code is code that is considered unreachable by normal program execution. Dead code can be created by adding code under a condition that never evaluates to true. Dead code should be removed since this type of code can produce unexpected results, if accidentally or maliciously forced to execute.
+
+Dead code identification is typically performed by algorithms that implement program flows analysis looking for unreachable code. The dead code is eliminated by instructing compilers to remove the code through compiler flags, i.e., '-fdce' is used for Dead Code Elimination.
+
+## Considerations
+
 Code can also be deemed unreachable for certain run-time conditions. Different deployed systems and environments may contain some code that is unreachable for the given environment. This technique does not consider run-time conditions for unreachable code.""" ;
     :kb-reference :Reference-DeadCodeElimination .
 
@@ -8890,35 +8890,35 @@ Code can also be deemed unreachable for certain run-time conditions. Different d
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-DT" ;
     :definition "Decision tree learning is a supervised learning approach used in statistics, data mining, and machine learning. In this formalism, a classification or regression decision tree is used as a predictive model to draw conclusions about a set of observations." ;
-    :kb-article """## How it works\r
-A decision tree starts with a root node, which does not have any incoming branches. The outgoing branches from the root node then feed into the internal nodes, also known as decision nodes. Based on the available features, both node types conduct evaluations to form homogenous subsets, which are denoted by leaf nodes, or terminal nodes. The leaf nodes represent all the possible outcomes within the dataset.\r
-\r
-## Considerations\r
-\r
-While the basic underlying model is that of a decision tree, the decision tree node criteria, and the method for identifying splits varies significantly depending on the learning algorithm selected (e.g., CART, ID3, C4.5, C5.0, CHAID, MARS.)  Extensions like linear and logistic trees can add additional expressiveness as well.\r
-\r
-### Verification Approach\r
-- Use software libraries and tools built for ML where possible, so that the underlying code is verified by prior use.\r
-- Use standard ML measures for both verification (developmental test) and operational test stages (e.g., accuracy, precision, recall, F1, ROC, confusion matrices.)\r
-- Assay your data to determine if a decision tree learning method will be effective, and if additional steps or supplemental ML techniques should be incorporated into the solution:\r
-  - Missing values,\r
-  - Noise and/or error rates in input data for each feature, or\r
-  - Decision trees are ideal when decision boundaries can be found that lie along axes of features.\r
-  - Target class balance; decision tree learning algorithms are especially sensitive to unbalanced target classes.\r
-- Decision tree learning overfitting may require tuning algorithm hyperparameters such as tree depth, max features used, max leaf nodes, etc.\r
-- Pruning may result in a more robust model in real-word applications.\r
-\r
-### Validation Approach\r
-- Use operationally relevant data across the range of application's operating environment.\r
-  - Use a variety of data sets reflecting different operating and environment conditions.\r
-  - Apply cross-fold validation to see sensitivity to data variation and avoid overfitting operational models.\r
-- Use SMEs to investigate model errors for problem domain areas or conditions for which the model may underperform and suggest refinements.\r
-- Incorporate some kind of continuous validation to address concept drift and the need to retrain the model and/or check data quality.\r
-\r
-## References\r
-1. Decision tree learning. (2023, May 30). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Decision_tree_learning)\r
-2. Decision Trees. (n.d.). In _scikit-learn User Guide 1.2.2_. [Link](https://scikit-learn.org/stable/modules/tree.html)\r
-3. Concept drift. (2023, April 17). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Concept_drift)\r
+    :kb-article """## How it works
+A decision tree starts with a root node, which does not have any incoming branches. The outgoing branches from the root node then feed into the internal nodes, also known as decision nodes. Based on the available features, both node types conduct evaluations to form homogenous subsets, which are denoted by leaf nodes, or terminal nodes. The leaf nodes represent all the possible outcomes within the dataset.
+
+## Considerations
+
+While the basic underlying model is that of a decision tree, the decision tree node criteria, and the method for identifying splits varies significantly depending on the learning algorithm selected (e.g., CART, ID3, C4.5, C5.0, CHAID, MARS.)  Extensions like linear and logistic trees can add additional expressiveness as well.
+
+### Verification Approach
+- Use software libraries and tools built for ML where possible, so that the underlying code is verified by prior use.
+- Use standard ML measures for both verification (developmental test) and operational test stages (e.g., accuracy, precision, recall, F1, ROC, confusion matrices.)
+- Assay your data to determine if a decision tree learning method will be effective, and if additional steps or supplemental ML techniques should be incorporated into the solution:
+  - Missing values,
+  - Noise and/or error rates in input data for each feature, or
+  - Decision trees are ideal when decision boundaries can be found that lie along axes of features.
+  - Target class balance; decision tree learning algorithms are especially sensitive to unbalanced target classes.
+- Decision tree learning overfitting may require tuning algorithm hyperparameters such as tree depth, max features used, max leaf nodes, etc.
+- Pruning may result in a more robust model in real-word applications.
+
+### Validation Approach
+- Use operationally relevant data across the range of application's operating environment.
+  - Use a variety of data sets reflecting different operating and environment conditions.
+  - Apply cross-fold validation to see sensitivity to data variation and avoid overfitting operational models.
+- Use SMEs to investigate model errors for problem domain areas or conditions for which the model may underperform and suggest refinements.
+- Incorporate some kind of continuous validation to address concept drift and the need to retrain the model and/or check data quality.
+
+## References
+1. Decision tree learning. (2023, May 30). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Decision_tree_learning)
+2. Decision Trees. (n.d.). In _scikit-learn User Guide 1.2.2_. [Link](https://scikit-learn.org/stable/modules/tree.html)
+3. Concept drift. (2023, April 17). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Concept_drift)
 4. 8 Concept Drift Detection Methods. (n.d.). In _Aporia Learning Center_. [Link](https://www.aporia.com/learn/data-drift/concept-drift-detection-methods/)""" .
 
 :DecisionTreeRegression a owl:Class,
@@ -8927,7 +8927,7 @@ While the basic underlying model is that of a decision tree, the decision tree n
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-DTR" ;
     :definition "Decision Trees Regression is asupervised learning method with the goal  to create a model that predicts the value of a target variable by learning simple decision rules inferred from the data features" ;
-    :kb-article """## References\r
+    :kb-article """## References
 scikit-learn. (n.d.). Decision Trees. [Link](https://scikit-learn.org/stable/modules/tree.html#tree)""" .
 
 :DecoyArtifact a owl:Class ;
@@ -8959,8 +8959,8 @@ scikit-learn. (n.d.). Decision Trees. [Link](https://scikit-learn.org/stable/mod
     :d3fend-id "D3-DE" ;
     :definition "A Decoy Environment comprises hosts and networks for the purposes of deceiving an attacker." ;
     :enables :Deceive ;
-    :kb-article """## Technique Overview\r
-\r
+    :kb-article """## Technique Overview
+
 Systems in a decoy environment are typically configured so that some detectable means of communication does not have any legitimate business purpose.  Any communication via these means should be logged and analyzed to find potential indicators of compromise for a possible past or future attack against other systems.""" ;
     :synonym "Honeypot" .
 
@@ -8974,14 +8974,14 @@ Systems in a decoy environment are typically configured so that some detectable 
             owl:someValuesFrom :File ] ;
     :d3fend-id "D3-DF" ;
     :definition "A file created for the purposes of deceiving an adversary." ;
-    :kb-article """## How it works\r
-The decoy file is made available as a local or network resource. Accesses to the file may be monitored. The files may be configurations, documents, executables, or other file types.\r
-\r
-\r
-## Considerations\r
-Properties of the file such as cryptographic checksums, file creation date, file modified date, file size, file owner etc may be modified to improve the credibility of the file.\r
-\r
-## Example\r
+    :kb-article """## How it works
+The decoy file is made available as a local or network resource. Accesses to the file may be monitored. The files may be configurations, documents, executables, or other file types.
+
+
+## Considerations
+Properties of the file such as cryptographic checksums, file creation date, file modified date, file size, file owner etc may be modified to improve the credibility of the file.
+
+## Example
 * A CSV file with decoy user credentials is placed on a system. The system or network is then monitored to detect any accesses to the decoy files.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-SupplyChainCyber-deception_Cymmetria,Inc.>,
         :Reference-OpenSourceIntelligenceDeceptions_IllusiveNetworksLtd,
@@ -8998,19 +8998,19 @@ Properties of the file such as cryptographic checksums, file creation date, file
             owl:someValuesFrom :NetworkResource ] ;
     :d3fend-id "D3-DNR" ;
     :definition "Deploying a network resource for the purposes of deceiving an adversary." ;
-    :kb-article """## How it works\r
-Decoy network resources are deployed to web application servers, network file shares, or other network based sharing services.\r
-\r
-A "honeypot" may serve a variety of decoy network resources.\r
-\r
-## Considerations\r
-\r
-* Developing a deployment and placement strategy for the decoy network resource.\r
-* Personnel responsible for creation of decoy networks should consider the potential for resource exhaustion through denial of service attacks.\r
-\r
-## Examples\r
-* Honeypots are typically used to mimic a known system with fake vulnerabilities. This may attract attackers to the honeypot.\r
-* Decoy accounts are also used to scan for attempted logins. The decoy accounts can provide security analysts with the attacker's potential intents and strategies.\r
+    :kb-article """## How it works
+Decoy network resources are deployed to web application servers, network file shares, or other network based sharing services.
+
+A "honeypot" may serve a variety of decoy network resources.
+
+## Considerations
+
+* Developing a deployment and placement strategy for the decoy network resource.
+* Personnel responsible for creation of decoy networks should consider the potential for resource exhaustion through denial of service attacks.
+
+## Examples
+* Honeypots are typically used to mimic a known system with fake vulnerabilities. This may attract attackers to the honeypot.
+* Decoy accounts are also used to scan for attempted logins. The decoy accounts can provide security analysts with the attacker's potential intents and strategies.
 * Tarpits are used to monitor unallocated IP space for unauthorized network activity.""" ;
     :kb-reference :Reference-AutomaticallyGeneratingNetworkResourceGroupsAndAssigningCustomizedDecoyPoliciesThereto_IllusiveNetworksLtd,
         :Reference-Deception-BasedResponsesToSecurityAttacks_CrowdstrikeInc,
@@ -9028,7 +9028,7 @@ A "honeypot" may serve a variety of decoy network resources.\r
     :d3fend-id "D3-DO" ;
     :definition "A Decoy Object is created and deployed for the purposes of deceiving attackers." ;
     :enables :Deceive ;
-    :kb-article """## Technique Overview\r
+    :kb-article """## Technique Overview
 Decoy objects are typically configured with detectable means of communication but do not have any legitimate business purpose. Any communication via or to these objects should be logged and analyzed to find potential indicators of compromise for a possible past or future attack against other systems.""" ;
     :synonym "Lure" .
 
@@ -9042,11 +9042,11 @@ Decoy objects are typically configured with detectable means of communication bu
             owl:someValuesFrom :User ] ;
     :d3fend-id "D3-DP" ;
     :definition "Establishing a fake online identity to misdirect, deceive, and or interact with adversaries." ;
-    :kb-article """## How it works\r
-A false online identity is created for the purposes of interacting with adversaries in a direct or indirect manner. This includes the associated email addresses, social media accounts, and other online communication profiles.\r
-\r
-## Considerations\r
-* Include phone numbers and online social profiles as well as automatically or manually responding to contact made to the persona to improve realism.\r
+    :kb-article """## How it works
+A false online identity is created for the purposes of interacting with adversaries in a direct or indirect manner. This includes the associated email addresses, social media accounts, and other online communication profiles.
+
+## Considerations
+* Include phone numbers and online social profiles as well as automatically or manually responding to contact made to the persona to improve realism.
 * Continuous updating and managing the decoy personas and online activity streams to ensure personas do not become stale and outdated.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-DecoyAndDeceptiveDataObjectTechnology_Cymmetria,Inc.>,
         :Reference-DecoyPersonasForSafeguardingOnlineIdentityUsingDeception_ .
@@ -9058,12 +9058,12 @@ A false online identity is created for the purposes of interacting with adversar
     rdfs:subClassOf :DecoyObject ;
     :d3fend-id "D3-DPR" ;
     :definition "Issuing publicly released media to deceive adversaries." ;
-    :kb-article """## How it works\r
-Publicly released media includes press release, videos, or other marketing collateral. The media may include URLs, points of contact, or other identifiers to entice interaction from adversaries.\r
-\r
-## Considerations\r
-* Information used in decoy public released media must contain enough realism to deceive and provide interaction from adversaries.\r
-* Continuous development, creation, and distribution of media and identifiers are needed to ensure adversary interaction continues over time.\r
+    :kb-article """## How it works
+Publicly released media includes press release, videos, or other marketing collateral. The media may include URLs, points of contact, or other identifiers to entice interaction from adversaries.
+
+## Considerations
+* Information used in decoy public released media must contain enough realism to deceive and provide interaction from adversaries.
+* Continuous development, creation, and distribution of media and identifiers are needed to ensure adversary interaction continues over time.
 * Decoy public releases could be placed on platforms with different degrees of ownership, including entirely enterprise-owned infrastructure, IaaS, and SaaS (including social applications). Platforms that are not entirely enterprise-owned may be more likely to gather information""" ;
     :kb-reference :Reference-MockAttackCybersecurityTrainingSystemAndMethods_WOMBATSECURITYTECHNOLOGIESInc .
 
@@ -9077,12 +9077,12 @@ Publicly released media includes press release, videos, or other marketing colla
             owl:someValuesFrom :AccessToken ] ;
     :d3fend-id "D3-DST" ;
     :definition "An authentication token created for the purposes of deceiving an adversary." ;
-    :kb-article """## How it works\r
-Usage of decoy session tokens may be monitored to track attacker behavior or otherwise control the beliefs of the attacker.\r
-\r
-## Considerations\r
-* Interaction and activity with the decoy session token must be constantly monitored and analyzed to detect unauthorized activity.\r
-* Session tokens are typically short-lived and therefore the decoy must be continuously updated to provide the appearance of it being used in the production environment.\r
+    :kb-article """## How it works
+Usage of decoy session tokens may be monitored to track attacker behavior or otherwise control the beliefs of the attacker.
+
+## Considerations
+* Interaction and activity with the decoy session token must be constantly monitored and analyzed to detect unauthorized activity.
+* Session tokens are typically short-lived and therefore the decoy must be continuously updated to provide the appearance of it being used in the production environment.
 * Automated tools can assist with maintenance and updates by automatically adjusting the decoy session token and environment to mimic the production environment.""" ;
     :kb-reference :Reference-DecoyAndDeceptiveDataObjectTechnology_CymmetriaInc .
 
@@ -9096,15 +9096,15 @@ Usage of decoy session tokens may be monitored to track attacker behavior or oth
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-DUC" ;
     :definition "A Credential created for the purpose of deceiving an adversary." ;
-    :kb-article """## How it works\r
-A detection analytic is developed to determine when a user uses decoy credentials. Subsequent actions by that user may be monitored or controlled by the defender.\r
-\r
-A credential may be:\r
- * Domain username and password\r
- * Local system username and password\r
-\r
-## Considerations\r
-* Decoy credentials should be integrated with a larger decoy environment to ensure that when decoy credentials are compromised, the credentials are used to interact with a decoy asset that is being monitored.\r
+    :kb-article """## How it works
+A detection analytic is developed to determine when a user uses decoy credentials. Subsequent actions by that user may be monitored or controlled by the defender.
+
+A credential may be:
+ * Domain username and password
+ * Local system username and password
+
+## Considerations
+* Decoy credentials should be integrated with a larger decoy environment to ensure that when decoy credentials are compromised, the credentials are used to interact with a decoy asset that is being monitored.
 * Continuous maintenance and updates are needed to ensure the legitimacy of the larger decoy environment and specifically the assets that utilize the decoy credentials.""" ;
     :kb-reference :Reference-DecoyAndDeceptiveDataObjectTechnology_CymmetriaInc,
         :Reference-DecoyNetwork-BasedServiceForDeceivingAttackers-AmazonTechnologies,
@@ -9116,7 +9116,7 @@ A credential may be:\r
     rdfs:subClassOf :ImageSynthesisGAN ;
     :d3fend-id "D3A-DCG" ;
     :definition "Deep Convolutional GAN (DCGAN) uses convolutional and convolutional-transpose layers in the generator and discriminator, respectively." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Analytics Vidhya. (2021). Deep Convolutional Generative Adversarial Network (DCGAN) for Beginners. [Link](https://www.analyticsvidhya.com/blog/2021/07/deep-convolutional-generative-adversarial-network-dcgan-for-beginners/)""" ;
     :synonym "DCGAN" .
 
@@ -9126,7 +9126,7 @@ Analytics Vidhya. (2021). Deep Convolutional Generative Adversarial Network (DCG
     rdfs:subClassOf :ArtificialNeuralNetClassification ;
     :d3fend-id "D3A-DNNC" ;
     :definition "A deep neural network (DNN) is an artificial neural network (ANN) with multiple layers between the input and output layers. There are different types of neural networks but they always consist of the same components: neurons, synapses, weights, biases, and functions. These components as a whole function similarly to a human brain, and can be trained like any other ML algorithm" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Deep learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Deep_learning).""" .
 
 :DeepQ-learning a owl:Class,
@@ -9135,7 +9135,7 @@ Deep learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Deep_learning).""
     rdfs:subClassOf :Q-Learning ;
     :d3fend-id "D3A-DQL" ;
     :definition "Uses a deep convolutional neural network, with layers of tiled convolutional filters to mimic the effects of receptive fields." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Q-learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Q-learning#Deep_Q-learning).""" .
 
 :DefaultUserAccount a owl:Class ;
@@ -9257,7 +9257,7 @@ Q-learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Q-learning#Deep_Q-l
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-DBC" ;
     :definition "Density-based clustering connects areas of high example density into clusters. This allows for arbitrary-shaped distributions as long as dense areas can be connected." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Google Developers. (n.d.). Clustering algorithms. [Link](https://developers.google.com/machine-learning/clustering/clustering-algorithms)""" .
 
 :Density-weightedMethod a owl:Class,
@@ -9266,7 +9266,7 @@ Google Developers. (n.d.). Clustering algorithms. [Link](https://developers.goog
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-DWM" ;
     :definition "An Actvie Learning technique that uses a density estimate meta-parameter to avoid sampling sparsely populated regions of the feature space and can be based parametrically or from a parameter free model." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :DeonticLogic a owl:Class,
@@ -9275,7 +9275,7 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-DL" ;
     :definition "Deontic logic addresses the modality of obligations and norms; i.e., the modality of morality." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Deontic logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Deontic_logic)""" .
 
 :Dependency a owl:Class ;
@@ -9297,12 +9297,12 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-DL" ;
     :definition "A description logic (DL) is a form of logic usually more expressive than propositional logic but less expressive than first-order logic." ;
-    :kb-article """## How it works\r
-The core reasoning problems for description logics (DLs) are (usually) decidable, and efficient decision procedures have been designed and implemented for these problems. There are general, spatial, temporal, spatiotemporal, and fuzzy description logics, and each description logic features a different balance between expressive power and reasoning complexity by supporting different sets of mathematical constructors.\r
-\r
-DLs are used in artificial intelligence to describe and reason about the relevant concepts of an application domain (known as terminological knowledge). It is of particular importance in providing a logical formalism for ontologies and the Semantic Web: the Web Ontology Language (OWL) and its profiles are based on DLs.\r
-\r
-## References\r
+    :kb-article """## How it works
+The core reasoning problems for description logics (DLs) are (usually) decidable, and efficient decision procedures have been designed and implemented for these problems. There are general, spatial, temporal, spatiotemporal, and fuzzy description logics, and each description logic features a different balance between expressive power and reasoning complexity by supporting different sets of mathematical constructors.
+
+DLs are used in artificial intelligence to describe and reason about the relevant concepts of an application domain (known as terminological knowledge). It is of particular importance in providing a logical formalism for ontologies and the Semantic Web: the Web Ontology Language (OWL) and its profiles are based on DLs.
+
+## References
 1. Description logic. (2023, April 16). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Description_logic)""" .
 
 :DescriptiveStatistics a owl:Class,
@@ -9311,7 +9311,7 @@ DLs are used in artificial intelligence to describe and reason about the relevan
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-DS" ;
     :definition "Descriptive statistics provide simple summaries about the sample and about the observations that have been made." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/Descriptive_statistics)""" .
 
 :DeserializationFunction a owl:Class ;
@@ -9401,7 +9401,7 @@ Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-DR" ;
     :definition "Dimensionality reduction is a key technique within unsupervised learning. It compresses the data by finding a smaller, different set of variables that capture what matters most in the original features, while minimizing the loss of information." ;
-    :kb-article """## References\r
+    :kb-article """## References
 O'Reilly Media. (n.d.). Chapter 7. Machine Learning and Security: Protecting Systems with Data and Algorithms. [Link](https://www.oreilly.com/library/view/machine-learning-and/9781492073048/ch07.html)""" .
 
 :Directory a owl:Class ;
@@ -9439,7 +9439,7 @@ O'Reilly Media. (n.d.). Chapter 7. Machine Learning and Security: Protecting Sys
     rdfs:subClassOf :MultivariateAnalysis ;
     :d3fend-id "D3A-DA" ;
     :definition "Discriminant analysis attempts to establish whether a set of variables can be used to distinguish between two or more groups of cases." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki/Multivariate_statistics)""" .
 
 :DiskEncryption a owl:Class,
@@ -9486,7 +9486,7 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-DBC" ;
     :definition "Distribution-based clustering creates and groups data points based on their likely hood of belonging to the same probability distribution (Gaussian, Binomial, etc.) in the data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 AnalytixLabs. (n.d.). Types of Clustering Algorithms. [Link](https://www.analytixlabs.co.in/blog/types-of-clustering-algorithms/#:~:text=Distribution-Based)""" .
 
 :DistributionProperties a owl:Class,
@@ -9495,7 +9495,7 @@ AnalytixLabs. (n.d.). Types of Clustering Algorithms. [Link](https://www.analyti
     rdfs:subClassOf :DescriptiveStatistics ;
     :d3fend-id "D3A-DP" ;
     :definition "The properties derived from a probability distribution." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wiki/Probability_distribution)""" ;
     :todo "Might be lots more to add in this tree" .
 
@@ -9505,7 +9505,7 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
     rdfs:subClassOf :ANN-basedClustering ;
     :d3fend-id "D3A-DBC" ;
     :definition "DNNs serve for clustering as mappings to better representations. The features of these representations can be drawn from different layers of the network or even from several layers." ;
-    :kb-article """## References\r
+    :kb-article """## References
 OpenReview. (n.d.). Unsupervised Clustering using Pseudo Ensemble Models. [Link](https://openreview.net/pdf?id=B1eT9VMgOX)""" .
 
 :DNSAllowlisting a :NetworkIsolation,
@@ -9531,22 +9531,22 @@ OpenReview. (n.d.). Unsupervised Clustering using Pseudo Ensemble Models. [Link]
             owl:someValuesFrom :DNSNetworkTraffic ] ;
     :d3fend-id "D3-DNSDL" ;
     :definition "Blocking DNS Network Traffic based on criteria such as IP address, domain name, or DNS query type." ;
-    :kb-article """## How it works\r
-Rules are implemented that filter DNS queries using criteria such as:\r
-- Client subnet\r
-- Type of network protocol used in query\r
-- Fully qualified domain name (FQDN) of record in the query\r
-- DNS Server IP address that received the DNS request\r
-- Type of DNS record being queried\r
-- Time of day the query is received\r
-- Size of the response\r
-\r
-For example, a DNS policy can be created for blocking DNS queries for FQDNs that have been identified as unauthorized.\r
-\r
-## Considerations\r
-- Implementation considerations for DNS filtering policies to avoid over-blocking or under-blocking domains.\r
-- Continuous maintenance of unauthorized domain lists is needed to keep up to date with possible site content changes.\r
-- File sharing or content delivery networks may require other filtering techniques that are more fine-grained (URL blocking).\r
+    :kb-article """## How it works
+Rules are implemented that filter DNS queries using criteria such as:
+- Client subnet
+- Type of network protocol used in query
+- Fully qualified domain name (FQDN) of record in the query
+- DNS Server IP address that received the DNS request
+- Type of DNS record being queried
+- Time of day the query is received
+- Size of the response
+
+For example, a DNS policy can be created for blocking DNS queries for FQDNs that have been identified as unauthorized.
+
+## Considerations
+- Implementation considerations for DNS filtering policies to avoid over-blocking or under-blocking domains.
+- Continuous maintenance of unauthorized domain lists is needed to keep up to date with possible site content changes.
+- File sharing or content delivery networks may require other filtering techniques that are more fine-grained (URL blocking).
 - Access to malicious websites or other network resources directly by IP instead of by DNS record, or after alteration of local DNS hosts file, may not result in DNS network traffic.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "DNS Blacklisting" .
@@ -9576,8 +9576,8 @@ For example, a DNS policy can be created for blocking DNS queries for FQDNs that
     rdfs:label "DNS Server" ;
     rdfs:subClassOf :Server ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Name_server> ;
-    :definition """A Domain Name System (DNS) name server is a kind of name server.  Domain names are one of the two principal namespaces of the Internet. The most important function of DNS servers is the translation (resolution) of human-memorable domain names and hostnames into the corresponding numeric Internet Protocol (IP) addresses, the second principal name space of the Internet which is used to identify and locate computer systems and resources on the Internet. (en).\r
-\r
+    :definition """A Domain Name System (DNS) name server is a kind of name server.  Domain names are one of the two principal namespaces of the Internet. The most important function of DNS servers is the translation (resolution) of human-memorable domain names and hostnames into the corresponding numeric Internet Protocol (IP) addresses, the second principal name space of the Internet which is used to identify and locate computer systems and resources on the Internet. (en).
+
 More generally, a name server is a computer application that implements a network service for providing responses to queries against a directory service. It translates an often humanly meaningful, text-based identifier to a system-internal, often numeric identification or addressing component. This service is performed by the server in response to a service protocol request.""" .
 
 :DNSTrafficAnalysis a :NetworkTrafficAnalysis,
@@ -9593,18 +9593,18 @@ More generally, a name server is a computer application that implements a networ
             owl:someValuesFrom :DNSLookup ] ;
     :d3fend-id "D3-DNSTA" ;
     :definition "Analysis of domain name metadata, including name and DNS records, to determine whether the domain is likely to resolve to an undesirable host." ;
-    :kb-article """## How it works\r
-This technique can be accomplished in a number of ways.\r
-\r
-* One example analytic determines whether or not a domain name was generated with an algorithm. Domain generation algorithms (DGAs) are sometimes used to create a domain name automatically  that will resolve to C2 infrastructure, without directly coding the domains in question into the malicious code.\r
-* Another method analyzes information about domains that have been visited, including whether a domain name is longer than a common length,  if a dynamic DNS domain was visited, if a fast-flux domain was visited, and if a recently created domain was visited. These factors are used to develop a score and if that score is over a certain threshold, an alert is generated.\r
-* Collected malware samples can be executed in a virtual environment to identify network domains that are connected to during execution. The network domains are then generated into signatures to identity bad domains for other hosts.\r
-\r
-This technique does not check for content hosted at the domain.\r
-\r
-## Considerations\r
-\r
-* DNS produces a large amount of traffic which can be resource-intensive to analyze in real time.\r
+    :kb-article """## How it works
+This technique can be accomplished in a number of ways.
+
+* One example analytic determines whether or not a domain name was generated with an algorithm. Domain generation algorithms (DGAs) are sometimes used to create a domain name automatically  that will resolve to C2 infrastructure, without directly coding the domains in question into the malicious code.
+* Another method analyzes information about domains that have been visited, including whether a domain name is longer than a common length,  if a dynamic DNS domain was visited, if a fast-flux domain was visited, and if a recently created domain was visited. These factors are used to develop a score and if that score is over a certain threshold, an alert is generated.
+* Collected malware samples can be executed in a virtual environment to identify network domains that are connected to during execution. The network domains are then generated into signatures to identity bad domains for other hosts.
+
+This technique does not check for content hosted at the domain.
+
+## Considerations
+
+* DNS produces a large amount of traffic which can be resource-intensive to analyze in real time.
 * If a server is compromised, for example, as part of a watering hole attack, but the DNS information pointing to that server is not altered, this technique would not catch such an incident.""" ;
     :kb-reference :Reference-DomainAgeRegistrationAlert_IncRapid7IncRAPID7Inc,
         :Reference-HeuristicBotnetDetection_PaloAltoNetworksInc,
@@ -9702,22 +9702,22 @@ This technique does not check for content hosted at the domain.\r
             owl:someValuesFrom :HardwareDriver ] ;
     :d3fend-id "D3-DLIC" ;
     :definition "Ensuring the integrity of drivers loaded during initialization of the operating system." ;
-    :kb-article """## How it works\r
-This technique can be accomplished in a number of ways:\r
-\r
-* A kernel level security agent installed on a host machine ensures that the driver associated with the agent is first in the initialization order. A dependent DLL associated with the driver is configured to be processed before other dependent DLLs and executes a number of operations to ensure the driver associated with the security agent is initialized first.\r
-\r
-* Kernel components can be signed by a certificate obtained by a third party to verify the source of the component and whether it has been modified. When signed, the component will include a signature block implemented as a hash value of the component header and can also include a certificate chain. The signature and certificate data are typically added before the kernel component is distributed to the public.\r
-\r
-\r
-## Considerations\r
-\r
-* The private keys to sign certificates as reputable companies have been stolen in the past -- in cases such as where certificates from Adobe, Realtek, and JMicron have been used to sign malicious executables. (Source: https://resources.infosecinstitute.com/cybercrime-exploits-digital-certificates/#gref)\r
-\r
-* Trusted Root Certificate Authorities have been compromised, yielding the ability to use the compromised keys to generate certificates with an arbitrary company name.\r
-\r
-* It may not be difficult for an attacker to start an organization which can obtain a signed certificate.\r
-\r
+    :kb-article """## How it works
+This technique can be accomplished in a number of ways:
+
+* A kernel level security agent installed on a host machine ensures that the driver associated with the agent is first in the initialization order. A dependent DLL associated with the driver is configured to be processed before other dependent DLLs and executes a number of operations to ensure the driver associated with the security agent is initialized first.
+
+* Kernel components can be signed by a certificate obtained by a third party to verify the source of the component and whether it has been modified. When signed, the component will include a signature block implemented as a hash value of the component header and can also include a certificate chain. The signature and certificate data are typically added before the kernel component is distributed to the public.
+
+
+## Considerations
+
+* The private keys to sign certificates as reputable companies have been stolen in the past -- in cases such as where certificates from Adobe, Realtek, and JMicron have been used to sign malicious executables. (Source: https://resources.infosecinstitute.com/cybercrime-exploits-digital-certificates/#gref)
+
+* Trusted Root Certificate Authorities have been compromised, yielding the ability to use the compromised keys to generate certificates with an arbitrary company name.
+
+* It may not be difficult for an attacker to start an organization which can obtain a signed certificate.
+
 * A root certificate authority (CA) whose certificate is trusted in the verification logic could generate incorrect certificates, if they are lax or have ulterior motives.""" ;
     :kb-reference :Reference-IntegrityAssuranceThroughEarlyLoadingInTheBootPhase_CrowdstrikeInc,
         :Reference-ProtectedComputingEnvironment_MicrosoftTechnologyLicensingLLC .
@@ -9728,7 +9728,7 @@ This technique can be accomplished in a number of ways:\r
     rdfs:subClassOf :Model-basedReinforcementLearning ;
     :d3fend-id "D3A-DQ" ;
     :definition "A Dyna-Q agent combines acting, learning, and planning." ;
-    :kb-article """## References\r
+    :kb-article """## References
 CompNeuro Neuromatch Academy Tutorials. [Link](https://compneuro.neuromatch.io/tutorials/W3D4_ReinforcementLearning/student/W3D4_Tutorial4.html)""" .
 
 :DynamicAnalysis a :FileAnalysis,
@@ -9744,16 +9744,16 @@ CompNeuro Neuromatch Academy Tutorials. [Link](https://compneuro.neuromatch.io/t
             owl:someValuesFrom :ExecutableFile ] ;
     :d3fend-id "D3-DA" ;
     :definition "Executing or opening a file in a synthetic \"sandbox\" environment to determine if the file is a malicious program or if the file exploits another program such as a document reader." ;
-    :kb-article """## How it works\r
-Analyzing the interaction of a piece of code with a system while the code is being executed in a controlled environment such as a sandbox, virtual machine, or simulator. This exposes the natural behavior of the piece of code without requiring the code to be disassembled.\r
-\r
-## Considerations\r
- * Malware often detects a fake environment, then changes its behavior accordingly. For example, it could detect that the system clock is being sped up in an effort to get it to execute commands that it would normally only execute at a later time, or that the hardware manufacturer of the machine is a virtualization provider.\r
- * Malware can attempt to determine if it is being debugged, and change its behavior accordingly.\r
- * For maximum fidelity, the simulated and real environments should be as similar as possible because the malware could perform differently in different environments.\r
- * Sometimes the malware behavior is triggered only under certain conditions (on a specific system date, after a certain time, or after it is sent a specific command) and can't be detected through a short execution in a virtual environment.\r
-\r
-## Implementations\r
+    :kb-article """## How it works
+Analyzing the interaction of a piece of code with a system while the code is being executed in a controlled environment such as a sandbox, virtual machine, or simulator. This exposes the natural behavior of the piece of code without requiring the code to be disassembled.
+
+## Considerations
+ * Malware often detects a fake environment, then changes its behavior accordingly. For example, it could detect that the system clock is being sped up in an effort to get it to execute commands that it would normally only execute at a later time, or that the hardware manufacturer of the machine is a virtualization provider.
+ * Malware can attempt to determine if it is being debugged, and change its behavior accordingly.
+ * For maximum fidelity, the simulated and real environments should be as similar as possible because the malware could perform differently in different environments.
+ * Sometimes the malware behavior is triggered only under certain conditions (on a specific system date, after a certain time, or after it is sent a specific command) and can't be detected through a short execution in a virtual environment.
+
+## Implementations
 * [Cuckoo Sandbox](https://cuckoosandbox.org)""" ;
     :kb-reference :Reference-MalwareAnalysisSystem_PaloAltoNetworksInc,
         :Reference-UseOfAnApplicationControllerToMonitorAndControlSoftwareFileAndApplicationEnvironments_SophosLtd ;
@@ -9799,13 +9799,13 @@ Analyzing the interaction of a piece of code with a system while the code is bei
             owl:someValuesFrom :Email ] ;
     :d3fend-id "D3-EF" ;
     :definition "Filtering incoming email traffic based on specific criteria." ;
-    :kb-article """## How it works\r
-\r
-Mail filters can be implemented to scan inbound email messages at the initial SMTP connection stage to detect and reject email containing spam and malware.\r
-\r
-This technique is distinct from d3f:EmailDeletion because it prevents an email from reaching an user's inbox. This technique can also be used for outbound email traffic.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+
+Mail filters can be implemented to scan inbound email messages at the initial SMTP connection stage to detect and reject email containing spam and malware.
+
+This technique is distinct from d3f:EmailDeletion because it prevents an email from reaching an user's inbox. This technique can also be used for outbound email traffic.
+
+## Considerations
 * The effectiveness of mail filters depend on the completeness of the filter policies""" ;
     :kb-reference :Reference-SystemAndMethodForProvidingAnonymousRemailingAndFilteringOfElectronicMail_Nokia .
 
@@ -9822,16 +9822,16 @@ This technique is distinct from d3f:EmailDeletion because it prevents an email f
             owl:someValuesFrom :MailServer ] ;
     :d3fend-id "D3-ER" ;
     :definition "The email removal technique deletes email files from system storage." ;
-    :kb-article """## How it works\r
-\r
-Email removal is a technique that can be used to prevent a user from executing malware or responding to phishing attempts. Security software or users themselves may detect malicious or suspicious email in a local or remote mail folder email and then employ this technique.\r
-\r
-## Considerations\r
-\r
-For email that needs to be removed, an infosec organization may choose to take additional follow-up actions (such as blocking the sources or notifying providers), rather than only relying on email deletion.\r
-\r
-For the case where users detect likely suspicious email files, the organization should consider implementing a means for reporting these emails to their infosec organization.\r
-\r
+    :kb-article """## How it works
+
+Email removal is a technique that can be used to prevent a user from executing malware or responding to phishing attempts. Security software or users themselves may detect malicious or suspicious email in a local or remote mail folder email and then employ this technique.
+
+## Considerations
+
+For email that needs to be removed, an infosec organization may choose to take additional follow-up actions (such as blocking the sources or notifying providers), rather than only relying on email deletion.
+
+For the case where users detect likely suspicious email files, the organization should consider implementing a means for reporting these emails to their infosec organization.
+
 Email files may propagate through many storage systems across the an organization's systems over time, so early detection and blocking helps avoid residual, latent stores of malicous email content in the enterprise.""" ;
     :kb-reference :Reference-SystemAndMethodForScanningRemoteServicesToLocateStoredObjectsWithMalware ;
     :synonym "Email Deletion" .
@@ -9905,13 +9905,13 @@ Email files may propagate through many storage systems across the an organizatio
             owl:someValuesFrom :NetworkNode ] ;
     :d3fend-id "D3-EHB" ;
     :definition "Monitoring the security status of an endpoint by sending periodic messages with health status, where absence of a response may indicate that the endpoint has been compromised." ;
-    :kb-article """## How it works\r
-Endpoints are configured to periodically generate and transmit a secure heartbeat that is delivered on a configured schedule and provides endpoint status information. Status information can include software details (version, configuration, etc), endpoint identification (MAC, IP address, machine ID) or other hardware/software configuration information. Interruption of the heartbeat can signal that the endpoint has been compromised.\r
-\r
-## Considerations\r
-* Security of heartbeat messages to ensure message integrity\r
-* Disappearance of the heartbeat could simply mean that the endpoint is powered off or intentionally disconnected from the network. Therefore other criteria may need to be used to accurately detect endpoint compromise.\r
-* Attacker presence on the machine may leave the heartbeat intact.\r
+    :kb-article """## How it works
+Endpoints are configured to periodically generate and transmit a secure heartbeat that is delivered on a configured schedule and provides endpoint status information. Status information can include software details (version, configuration, etc), endpoint identification (MAC, IP address, machine ID) or other hardware/software configuration information. Interruption of the heartbeat can signal that the endpoint has been compromised.
+
+## Considerations
+* Security of heartbeat messages to ensure message integrity
+* Disappearance of the heartbeat could simply mean that the endpoint is powered off or intentionally disconnected from the network. Therefore other criteria may need to be used to accurately detect endpoint compromise.
+* Attacker presence on the machine may leave the heartbeat intact.
 * An attacker may determine the format of the heartbeat and continue to send it even after the machine is compromised.""" ;
     :kb-reference :Reference-IntrusionDetectionUsingAHeartbeat_SophosLtd ;
     :synonym "Endpoint Health Telemetry" .
@@ -9928,7 +9928,7 @@ Endpoints are configured to periodically generate and transmit a secure heartbea
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-EL" ;
     :definition "In statistics and machine learning, ensemble methods use multiple learning algorithms to obtain better predictive performance than could be obtained from any of the constituent learning algorithms alone" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :EpistemicLogic a owl:Class,
@@ -9937,7 +9937,7 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-EL" ;
     :definition "Epistemic logic addresses modalities of knowledge; i.e., the certainty of sentences." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Epistemic logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Epistemic_logic)""" ;
     :synonym "Epistemic Modal Logic" .
 
@@ -9947,16 +9947,16 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :LogicalRules ;
     :d3fend-id "D3A-EM" ;
     :definition "Equivalence matching is matching two values, which may be bound to variables, to see if they are equivalent." ;
-    :kb-article """## How it works\r
-Equality is a relationship between two quantities or, more generally two mathematical expressions, asserting that the quantities have the same value, or that the expressions represent the same mathematical object.\r
-\r
-Programming languages can have multiple senses of equality that may include, but are not limited to:\r
-\r
-- Identity: The objects are identical; often indicated by having values indicating the same logical address.\r
-- Equality: The values of the expessions and properties are equivalent when evaluated; they do not need to have the same logical address.\r
-\r
-## References\r
-1. Equality (mathematics). (2023, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Equality_(mathematics)]\r
+    :kb-article """## How it works
+Equality is a relationship between two quantities or, more generally two mathematical expressions, asserting that the quantities have the same value, or that the expressions represent the same mathematical object.
+
+Programming languages can have multiple senses of equality that may include, but are not limited to:
+
+- Identity: The objects are identical; often indicated by having values indicating the same logical address.
+- Equality: The values of the expessions and properties are equivalent when evaluated; they do not need to have the same logical address.
+
+## References
+1. Equality (mathematics). (2023, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Equality_(mathematics)]
 2. Types of Equality. (2007, March 2). In _WikiWikiWeb_. [Link](https://wiki.c2.com/?TypesOfEquality)""" .
 
 :Estimation a owl:Class,
@@ -9965,7 +9965,7 @@ Programming languages can have multiple senses of equality that may include, but
     rdfs:subClassOf :InferentialStatistics ;
     :d3fend-id "D3A-EST" ;
     :definition "Estimation represents ways or a process of learning and determining the population parameter based on the model fitted to the data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Link](https://online.stat.psu.edu/stat504/lesson/statistical-inference-and-estimation)""" ;
     :todo "Seems like there should be more than just interval and pont estimation in here." .
 
@@ -10003,7 +10003,7 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
         :NumericPatternMatching ;
     :d3fend-id "D3A-EM" ;
     :definition "Exact matching for numeric types is just the simple test for mathematical equivalence of the values being matched." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Equality (mathematics). (2023, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Equality_(mathematics)]""" ;
     :synonym "Numeric Equivalence Matching" .
 
@@ -10023,29 +10023,29 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
             owl:someValuesFrom :Pointer ] ;
     :d3fend-id "D3-EHPV" ;
     :definition "Validates that a referenced exception handler pointer is a valid exception handler." ;
-    :kb-article """## How It Works\r
-When a process encounters an exception, it calls an exception handler to deal with the exception.  The method by which this exception handler is determined varies by the operating system.  The exception handler is called, even if it is the default exception handler to terminate the program and display a message that the program stopped working.  In the case that no valid exception handler is found, the program would fail to proceed as normal and could be programmed to terminate.\r
-\r
-In Windows, the address of the exception registration record is stored at the very start of the the Thread Information Block; the GS register points to this structure.\r
-\r
-The exception registration record contains two pointers: a pointer to the next exception registration record should this handler fail to handle the exception, and a pointer to the handler.\r
-\r
-A buffer overflow can overwrite the saved return pointer with an invalid location to execute memory; this often triggers the exception handler chain, which could also be corrupted by the buffer overflow.  Although Process Exception Handler Validation does not make sure that the exception handler pointer or the code at the exception handler was unaltered, or that the exception handler code is secure, this technique does ensure that the pointer is at least an exception handler that could be called by the program.\r
-\r
-With Process Exception Handler Validation, before the handler is called, it checks the exception handler against a source of valid exception handlers.  If the requested handler is not in this list, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.\r
-\r
-### Runtime valid exception handler source generation\r
-The source of valid exception handlers could be generated at runtime, with the risk of the information that is used to determine the validity of exception handlers being compromised.\r
-\r
-### Compile-time\r
-The source of valid exception handlers could also be generated at compile time or as a binary patch.  Given the source code, it would be rather straightforward to find the exceptions, as they are pointed in the catch statement of a try-catch clause and the compiler must already generate the code to call exceptions from this.\r
-\r
-## Considerations\r
-If the program file can be altered by the attacker, then the security could be bypassed by replacing it with any desired program, without even bypassing SEH.\r
-\r
-If the attacker was already able to overwrite the code for a valid exception handler via other functionality in the program, this defense would not prevent arbitrary code execution.\r
-If an exception handler recognized as valid is vulnerable, it would be executed anyway.\r
-\r
+    :kb-article """## How It Works
+When a process encounters an exception, it calls an exception handler to deal with the exception.  The method by which this exception handler is determined varies by the operating system.  The exception handler is called, even if it is the default exception handler to terminate the program and display a message that the program stopped working.  In the case that no valid exception handler is found, the program would fail to proceed as normal and could be programmed to terminate.
+
+In Windows, the address of the exception registration record is stored at the very start of the the Thread Information Block; the GS register points to this structure.
+
+The exception registration record contains two pointers: a pointer to the next exception registration record should this handler fail to handle the exception, and a pointer to the handler.
+
+A buffer overflow can overwrite the saved return pointer with an invalid location to execute memory; this often triggers the exception handler chain, which could also be corrupted by the buffer overflow.  Although Process Exception Handler Validation does not make sure that the exception handler pointer or the code at the exception handler was unaltered, or that the exception handler code is secure, this technique does ensure that the pointer is at least an exception handler that could be called by the program.
+
+With Process Exception Handler Validation, before the handler is called, it checks the exception handler against a source of valid exception handlers.  If the requested handler is not in this list, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.
+
+### Runtime valid exception handler source generation
+The source of valid exception handlers could be generated at runtime, with the risk of the information that is used to determine the validity of exception handlers being compromised.
+
+### Compile-time
+The source of valid exception handlers could also be generated at compile time or as a binary patch.  Given the source code, it would be rather straightforward to find the exceptions, as they are pointed in the catch statement of a try-catch clause and the compiler must already generate the code to call exceptions from this.
+
+## Considerations
+If the program file can be altered by the attacker, then the security could be bypassed by replacing it with any desired program, without even bypassing SEH.
+
+If the attacker was already able to overwrite the code for a valid exception handler via other functionality in the program, this defense would not prevent arbitrary code execution.
+If an exception handler recognized as valid is vulnerable, it would be executed anyway.
+
 SafeSEH might be applied only to some executable files or modules, allowing an attacker to call any piece of code as an exception handler in the unprotected modules.""" ;
     :kb-reference :Reference-SAFESEH_ImageHasSafeExceptionHandlers_MicrosoftDocs ;
     :synonym "Exception Handler Validation" .
@@ -10063,15 +10063,15 @@ SafeSEH might be applied only to some executable files or modules, allowing an a
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-EAL" ;
     :definition "Using a digital signature to authenticate a file before opening." ;
-    :kb-article """## How it works\r
-\r
-This technique is generic and there are numerous ways to compute and authenticate digital signatures.\r
-A digital certificate is generated from a private/public key pair issued by a certificate authority (CA). A hash of the file is encrypted using the private key. When the file is downloaded by another user, the user's system uses the public key to decrypt the hash and a new hash is created of the downloaded file. The hash decrypted by the public key is compared to the new hash and if there is a mismatch, further techniques, such as file deletion, file quarantine, or **Executable Blacklisting** may be invoked.\r
-\r
-This technique may be invoked when deciding whether to execute a file.\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+
+This technique is generic and there are numerous ways to compute and authenticate digital signatures.
+A digital certificate is generated from a private/public key pair issued by a certificate authority (CA). A hash of the file is encrypted using the private key. When the file is downloaded by another user, the user's system uses the public key to decrypt the hash and a new hash is created of the downloaded file. The hash decrypted by the public key is compared to the new hash and if there is a mismatch, further techniques, such as file deletion, file quarantine, or **Executable Blacklisting** may be invoked.
+
+This technique may be invoked when deciding whether to execute a file.
+
+## Considerations
+
 Organizations which download or create high volumes of software make management complex, in particular engineering or scientific organizations.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ComputingApparatusWithAutomaticIntegrityReferenceGenerationAndMaintenance_Tripwire,Inc.>,
         :Reference-EnhancingNetworkSecurityByPreventingUser-InitiatedMalwareExecution_ ;
@@ -10105,45 +10105,45 @@ Organizations which download or create high volumes of software make management 
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-EDL" ;
     :definition "Blocking the execution of files on a host in accordance with defined application policy rules." ;
-    :kb-article """## How it works\r
-\r
-#### Criteria\r
-\r
-A policy-enforcing application can register an application for denylisting based on conditions including the following:\r
-\r
-* File attributes\r
-    * file name\r
-    * file path\r
-    * file hash\r
-    * file publisher, as obtained from the digital signature\r
-    * permissions of the file\r
-* File malware scan (eg. Windows SmartScreen)\r
-* User-File combination\r
-\r
-This may be done to prevent execution of applications which are:\r
-\r
-* an old version with known vulnerabilities\r
-* without a valid license, which could cause legal issues\r
-* in a directory that is accessible to low-privileged users, that could be accessed by a malware dropper\r
-* known trojan horse programs\r
-* too open in their permissions, possibly set to run as a user other than the originator or allowing execution when they should not be\r
-* a match to the hash of other known malware\r
-* are detected as undesirable based on a file scan runtime behavior\r
-\r
-System administrators will customize the rules for the given environment.\r
-\r
-#### Backend\r
-\r
-The policy-enforcing program may work by running in kernel mode, and [intercepting] [system calls which execute a process].\r
-\r
-## Considerations\r
-\r
-* If denylisting is done by filename, filepath, or hash, these mechanisms may be a worthy first line of defense and detection, but could still be evaded by an attacker.\r
-* Continuous management is needed to keep the denylist up to date, whether it is based on hash, publisher, behavior, or any other digital artifact.\r
-* Although denylists based on attributes such as file path and virus scan could defend against some threats which they have not been explicitly coded to block, denylists may not provide protection from new, unknown, or zero day attacks.\r
-\r
-\r
-## Examples\r
+    :kb-article """## How it works
+
+#### Criteria
+
+A policy-enforcing application can register an application for denylisting based on conditions including the following:
+
+* File attributes
+    * file name
+    * file path
+    * file hash
+    * file publisher, as obtained from the digital signature
+    * permissions of the file
+* File malware scan (eg. Windows SmartScreen)
+* User-File combination
+
+This may be done to prevent execution of applications which are:
+
+* an old version with known vulnerabilities
+* without a valid license, which could cause legal issues
+* in a directory that is accessible to low-privileged users, that could be accessed by a malware dropper
+* known trojan horse programs
+* too open in their permissions, possibly set to run as a user other than the originator or allowing execution when they should not be
+* a match to the hash of other known malware
+* are detected as undesirable based on a file scan runtime behavior
+
+System administrators will customize the rules for the given environment.
+
+#### Backend
+
+The policy-enforcing program may work by running in kernel mode, and [intercepting] [system calls which execute a process].
+
+## Considerations
+
+* If denylisting is done by filename, filepath, or hash, these mechanisms may be a worthy first line of defense and detection, but could still be evaded by an attacker.
+* Continuous management is needed to keep the denylist up to date, whether it is based on hash, publisher, behavior, or any other digital artifact.
+* Although denylists based on attributes such as file path and virus scan could defend against some threats which they have not been explicitly coded to block, denylists may not provide protection from new, unknown, or zero day attacks.
+
+
+## Examples
 On a Windows machine the Windows Defender Application Control (WDAC) policy enforcement is run in the kernel and allows for restricting applications.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ContentExtractorAndAnalysisSystem_Bit9Inc,CarbonBlackInc>,
         :Reference-MethodAndApparatusForIncreasingTheSpeedAtWhichComputerVirusesAreDetected_McAfeeLLC ;
@@ -10222,7 +10222,7 @@ On a Windows machine the Windows Defender Application Control (WDAC) policy enfo
     rdfs:subClassOf :Distribution-basedClustering ;
     :d3fend-id "D3A-EMC" ;
     :definition "An unsupervised clustering algorithm and extends to NLP applications like Latent Dirichlet Allocation, the Baum-Welch algorithm for Hidden Markov Models, and medical imaging." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Towards Data Science. (n.d.). Expectation Maximization Explained. [Link](https://towardsdatascience.com/expectation-maximization-explained-c82f5ed438e5#:~:text=Expectation%20Maximization%20(EM)%20is%20a,Markov%20Models%2C%20and%20medical%20imaging.)""" .
 
 :ExpectedErrorReduction a owl:Class,
@@ -10231,7 +10231,7 @@ Towards Data Science. (n.d.). Expectation Maximization Explained. [Link](https:/
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-EER" ;
     :definition "Expected Error Reduction (EER) follows similar ideas as EMC, but again looks at the model output instead of the model itself and also takes the other data into account. In particular, a sample x is considered useful, if we can expect that knowing the label will reduce the future error on unseen samples" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :ExpectedModelChange a owl:Class,
@@ -10240,9 +10240,9 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-EMC" ;
     :definition "Supervised learning establishes a relationship between the known input and output variables to conduct a predictive analysis." ;
-    :kb-article """nal Consiterations\r
-\r
-## References\r
+    :kb-article """nal Consiterations
+
+## References
 Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :ExternalContentInclusionFunction a owl:Class ;
@@ -10306,10 +10306,10 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
             owl:someValuesFrom :LocalResourceAccess ] ;
     :d3fend-id "D3-FAPA" ;
     :definition "Analyzing the files accessed by a process to identify unauthorized activity." ;
-    :kb-article """## How it works\r
-File modifying malware such as wipers and ransomware are detected by identifying file access patterns that are associated with a malicious process. Examples of file access patterns include accessing a large number of files, accessing multiple file types, files being accessed located in multiple locations in a directory, and copying a file and encrypting the contents of that file into a copy.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+File modifying malware such as wipers and ransomware are detected by identifying file access patterns that are associated with a malicious process. Examples of file access patterns include accessing a large number of files, accessing multiple file types, files being accessed located in multiple locations in a directory, and copying a file and encrypting the contents of that file into a copy.
+
+## Considerations
 Certain file access actions may not be statistically different from authorized activity.""" ;
     :kb-reference :Reference-File-modifyingMalwareDetection_CrowdstrikeInc .
 
@@ -10327,7 +10327,7 @@ Certain file access actions may not be statistically different from authorized a
     :d3fend-id "D3-FA" ;
     :definition "File Analysis is an analytic process to determine a file's status. For example: virus, trojan, benign, malicious, trusted, unauthorized, sensitive, etc." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview\r
+    :kb-article """## Technique Overview
 Some techniques use file signatures or file metadata to compare against historical collections of malware. Files may also be compared against a source of ground truth such as cryptographic signatures. Examining files for potential malware using pattern matching against file contents/file behavior. Binary code may be dissembled and analyzed for predictive malware behavior, such as API call signatures. Analysis might occur within a protected environment such as a sandbox or live system.""" .
 
 :FileCarving a :NetworkTrafficAnalysis,
@@ -10340,11 +10340,11 @@ Some techniques use file signatures or file metadata to compare against historic
             owl:someValuesFrom :FileTransferNetworkTraffic ] ;
     :d3fend-id "D3-FC" ;
     :definition "Identifying and extracting files from network application protocols through the use of network stream reassembly software." ;
-    :kb-article """## How it works\r
-Protocol stream reassembly software recreates a directional byte stream by analyzing captured network packets. Once the stream is reassembled pattern matching is applied to determine if it contains a file of interest. Files of interest range from executable, archive, or document file formats. Once the file is captured, it is then processed with standard File Analysis Techniques. Example network protocols include HTTP, SMTP, FTP, HTTP/2, and TLS/HTTP/Dropbox.\r
-\r
-## Considerations\r
-- This is an error prone process due to the intricacies of network protocols and network packet capture.  For example reassembly may be done in real-time or streaming fashion, or packets may be written to disk, then bulk processed.  The packets may arrive out of order, with fragmentation, duplicates, or re-transmissions.  The reassembly software must compensate for the imperfect packet stream in order to recreate the well formed file which was transmitted.\r
+    :kb-article """## How it works
+Protocol stream reassembly software recreates a directional byte stream by analyzing captured network packets. Once the stream is reassembled pattern matching is applied to determine if it contains a file of interest. Files of interest range from executable, archive, or document file formats. Once the file is captured, it is then processed with standard File Analysis Techniques. Example network protocols include HTTP, SMTP, FTP, HTTP/2, and TLS/HTTP/Dropbox.
+
+## Considerations
+- This is an error prone process due to the intricacies of network protocols and network packet capture.  For example reassembly may be done in real-time or streaming fashion, or packets may be written to disk, then bulk processed.  The packets may arrive out of order, with fragmentation, duplicates, or re-transmissions.  The reassembly software must compensate for the imperfect packet stream in order to recreate the well formed file which was transmitted.
 - File type identification can be a difficult process which can be exploited by adversaries.""" ;
     :kb-reference :Reference-ComputerWormDefenseSystemAndMethod_FireEyeInc .
 
@@ -10355,20 +10355,20 @@ Protocol stream reassembly software recreates a directional byte stream by analy
     rdfs:subClassOf :FileAnalysis ;
     :d3fend-id "D3-FCR" ;
     :definition "Employing a pattern matching rule language to analyze files." ;
-    :kb-article """## How it works\r
-Rules, often called signatures, are used for both generic and targeted malware detection. The rules are usually expressed in a domain specific language (DSL), then deployed to software that scans files for matches. The rules are developed and broadly distributed by commercial vendors, or they are developed and deployed by enterprise security teams to address highly targeted or custom malware. Conceptually, there are public and private rule sets. Both leverage the same technology, but they are intended to detect different types of cyber adversaries.\r
-\r
-## Considerations\r
-* Patterns expressed in the DSLs range in their complexity. Some scanning engines support file parsing and normalization for high fidelity matching, others support only simple regular expression matching against raw file data. Engineers must make a trade-off in terms of:\r
-     * The fidelity of the matching capabilities in order to balance high recall with avoiding false positives,\r
-     * The computational load for scanning, and\r
-     * The resilience of the engine to deal with adversarial content presented in different forms-- content which in some cases is designed to exploit or defeat the scanning engines.\r
- * Signature libraries can become large over time and impact scanning performance.\r
- * Some vendors who sell signatures have to delete old signatures over time.\r
- * Simple signatures against raw content cannot match against encoded, encrypted, or sufficiently obfuscated content.\r
-\r
-## Implementations\r
- * YARA\r
+    :kb-article """## How it works
+Rules, often called signatures, are used for both generic and targeted malware detection. The rules are usually expressed in a domain specific language (DSL), then deployed to software that scans files for matches. The rules are developed and broadly distributed by commercial vendors, or they are developed and deployed by enterprise security teams to address highly targeted or custom malware. Conceptually, there are public and private rule sets. Both leverage the same technology, but they are intended to detect different types of cyber adversaries.
+
+## Considerations
+* Patterns expressed in the DSLs range in their complexity. Some scanning engines support file parsing and normalization for high fidelity matching, others support only simple regular expression matching against raw file data. Engineers must make a trade-off in terms of:
+     * The fidelity of the matching capabilities in order to balance high recall with avoiding false positives,
+     * The computational load for scanning, and
+     * The resilience of the engine to deal with adversarial content presented in different forms-- content which in some cases is designed to exploit or defeat the scanning engines.
+ * Signature libraries can become large over time and impact scanning performance.
+ * Some vendors who sell signatures have to delete old signatures over time.
+ * Simple signatures against raw content cannot match against encoded, encrypted, or sufficiently obfuscated content.
+
+## Implementations
+ * YARA
  * ClamAV""" ;
     :kb-reference :Reference-ComputationalModelingAndClassificationOfDataStreams_CrowdstrikeInc,
         :Reference-DetectingScript-basedMalware_CrowdstrikeInc,
@@ -10400,17 +10400,17 @@ Rules, often called signatures, are used for both generic and targeted malware d
             owl:someValuesFrom :File ] ;
     :d3fend-id "D3-FE" ;
     :definition "Encrypting a file using a cryptographic key." ;
-    :kb-article """## How it Works\r
-Files are encrypted using either a single key for both encryption and decryption or separate keys. Single key encryption is symmetric encryption and using two key distinct keys is asymmetric encryption.\r
-\r
-### Symmetric Cryptography\r
-Symmetric encryption uses the same cryptographic key for both the encryption and decryption a file. Managing keys at scale sometimes uses asymmetric key exchange protocols such as Diffie-Hellman can be used to share the symmetric cryptographic key with the others.\r
-\r
-### Asymmetric Cryptography\r
-Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. Files are encrypted using the public key and decrypted using their private key. Asymmetric encryption is typically slower than symmetric encryption and not widely used for large file encryption, but is popular for key wrapping, key exchanges, and digital signatures.\r
-\r
-## Considerations\r
-- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.\r
+    :kb-article """## How it Works
+Files are encrypted using either a single key for both encryption and decryption or separate keys. Single key encryption is symmetric encryption and using two key distinct keys is asymmetric encryption.
+
+### Symmetric Cryptography
+Symmetric encryption uses the same cryptographic key for both the encryption and decryption a file. Managing keys at scale sometimes uses asymmetric key exchange protocols such as Diffie-Hellman can be used to share the symmetric cryptographic key with the others.
+
+### Asymmetric Cryptography
+Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. Files are encrypted using the public key and decrypted using their private key. Asymmetric encryption is typically slower than symmetric encryption and not widely used for large file encryption, but is popular for key wrapping, key exchanges, and digital signatures.
+
+## Considerations
+- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
 - Secure transfer of private keys between multiple devices.""" ;
     :kb-reference :Reference-MethodForFileEncryption .
 
@@ -10439,10 +10439,10 @@ Asymmetric encryption is typically accomplished using public and private key cer
     rdfs:subClassOf :FileAnalysis ;
     :d3fend-id "D3-FH" ;
     :definition "Employing file hash comparisons to detect known malware." ;
-    :kb-article """## How it works\r
-This technique requires a list of hashes to compare a file against.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+This technique requires a list of hashes to compare a file against.
+
+## Considerations
 Performance on large files or very large numbers of files.""" ;
     :kb-reference :Reference-Munin .
 
@@ -10468,14 +10468,14 @@ Performance on large files or very large numbers of files.""" ;
             owl:someValuesFrom :File ] ;
     :d3fend-id "D3-FIM" ;
     :definition "Detecting any suspicious changes to files in a computer system." ;
-    :kb-article """## How it Works\r
-There are a number of tools in Windows and Unix that can monitor specific files in a system and generate alerts if any artifacts have been created, modified, or removed. They accomplish this by comparing the current artifacts to a previous snapshot.\r
-\r
-Unix - Unix systems have a file integrity checker tool called tripwire. Tripwire first initializes a database that serves as a basis for comparison and can then scan the system to compare the state of the current file system against the initial baseline database. Additionally, users can define policies that specify potential violations.\r
-\r
-Windows - In Microsoft Azure, file integrity monitoring can be enabled which can track file and registry key creation, removals, and modifications of specific files.\r
-\r
-## Considerations\r
+    :kb-article """## How it Works
+There are a number of tools in Windows and Unix that can monitor specific files in a system and generate alerts if any artifacts have been created, modified, or removed. They accomplish this by comparing the current artifacts to a previous snapshot.
+
+Unix - Unix systems have a file integrity checker tool called tripwire. Tripwire first initializes a database that serves as a basis for comparison and can then scan the system to compare the state of the current file system against the initial baseline database. Additionally, users can define policies that specify potential violations.
+
+Windows - In Microsoft Azure, file integrity monitoring can be enabled which can track file and registry key creation, removals, and modifications of specific files.
+
+## Considerations
 Files can change constantly due to the non-static nature of a computer system. File Integrity Monitoring works best when pointed at a narrow scope of critical files to limit the number of unneccessary files that may be modified over the course of normal use. The accuracy and precision of defined policies also affect the efficacy of this technique.""" ;
     :kb-reference :Reference-FileIntegrityMonitoringinMicrosoftDefenderforCloud-Microsoft,
         :Reference-Tripwire .
@@ -10504,16 +10504,16 @@ Files can change constantly due to the non-static nature of a computer system. F
             owl:someValuesFrom :FileServer ] ;
     :d3fend-id "D3-FR" ;
     :definition "The file removal technique deletes malicious artifacts or programs from a computer system." ;
-    :kb-article """## How it works\r
-\r
-Adversaries may place files or programs into a computer's file system to perform malicious actions. As part of the eviction process, these files and programs should be removed to prevent further compromise or reinfection. Examples of malicious types of files are malware which is directly harmful and content files with the intent to deceive users (e.g., phishing.)\r
-\r
-On Windows systems, antivirus (AV) software should be used to safely and permanently remove malicious files. AV software may first quarantine a suspected malicious file, which is the process of moving a file from its original location to a new location and makes changes so that it cannot be executed. Users can then verify that the file is not benign and then permanently delete it.\r
-\r
-## Considerations\r
-\r
-When it is determined that a file should be removed for security purposes, the organization--or systems implementing an organization's policies--may determine that the file should not simply be deleted from the enterprise's mission systems, but be quarantined to a secure system by an approved mechanism, so as to allow follow-up investigation by security staff.\r
-\r
+    :kb-article """## How it works
+
+Adversaries may place files or programs into a computer's file system to perform malicious actions. As part of the eviction process, these files and programs should be removed to prevent further compromise or reinfection. Examples of malicious types of files are malware which is directly harmful and content files with the intent to deceive users (e.g., phishing.)
+
+On Windows systems, antivirus (AV) software should be used to safely and permanently remove malicious files. AV software may first quarantine a suspected malicious file, which is the process of moving a file from its original location to a new location and makes changes so that it cannot be executed. Users can then verify that the file is not benign and then permanently delete it.
+
+## Considerations
+
+When it is determined that a file should be removed for security purposes, the organization--or systems implementing an organization's policies--may determine that the file should not simply be deleted from the enterprise's mission systems, but be quarantined to a secure system by an approved mechanism, so as to allow follow-up investigation by security staff.
+
 On Windows systems, deleting a file in File Explorer does not permanently delete a file - it sends it to the Recycle Bin instead. The Recycle Bin must be emptied, or alternative steps must be performed to remove files completely. Even then, in some cases the data may persist in disk, so data shredder tools may be needed to completely wipe a file. Thus, AV tools are recommended.""" ;
     :kb-reference :Reference-HowDoesAntivirusQuarantineWork-SafetyDetectives ;
     :synonym "File Deletion" .
@@ -10610,20 +10610,20 @@ On Windows systems, deleting a file in File Explorer does not permanently delete
             owl:someValuesFrom :Firmware ] ;
     :d3fend-id "D3-FBA" ;
     :definition "Analyzing the behavior of embedded code in firmware and looking for anomalous behavior and suspicious activity." ;
-    :kb-article """## How it works\r
-Firmware behavior analysis provides protections by ensuring that installed firmware has not been tampered with or modified. Firmware analysis applies to mutable firmware and immutable read-only memory (ROMs).\r
-\r
-Firmware in deployed network devices is typically not analyzed and monitored for vulnerabilities and thus is subject to potential attacks. This technique makes use of known and measured behavioral attributes, including timing attributes, of analyzed firmware on deployed devices.\r
-\r
-A behavioral method that employs known timing measurements may use the timing results from a challenge and response protocol to detect the presence of malware in embedded firmware. Firmware device timing measurements are made, specific to the installed device, and are used in the verifying function.\r
-\r
-The original firmware image is modified by injecting a monitoring software component into the embedded firmware code. The injected software components will allow for a software root of trust, the challenge and response protocol, to be implement in the firmware.\r
-\r
-A challenge-response is issued and includes a nonce so that replays are not allowed. The firmware will calculate a checksum over all of memory, including the nonce, and return the result. The verification system will compare the computed checksum and the time it took for the computation of the checksum to determine if the firmware has been modified.\r
-\r
-## Considerations\r
-* The firmware code will need to be modified to include the behavioral monitoring functionality.\r
-* This technique is sensitive to the device the embedded firmware is hosted on and it is expected that the devices and firmware will need to be profiled and analyzed to determine timing estimation.\r
+    :kb-article """## How it works
+Firmware behavior analysis provides protections by ensuring that installed firmware has not been tampered with or modified. Firmware analysis applies to mutable firmware and immutable read-only memory (ROMs).
+
+Firmware in deployed network devices is typically not analyzed and monitored for vulnerabilities and thus is subject to potential attacks. This technique makes use of known and measured behavioral attributes, including timing attributes, of analyzed firmware on deployed devices.
+
+A behavioral method that employs known timing measurements may use the timing results from a challenge and response protocol to detect the presence of malware in embedded firmware. Firmware device timing measurements are made, specific to the installed device, and are used in the verifying function.
+
+The original firmware image is modified by injecting a monitoring software component into the embedded firmware code. The injected software components will allow for a software root of trust, the challenge and response protocol, to be implement in the firmware.
+
+A challenge-response is issued and includes a nonce so that replays are not allowed. The firmware will calculate a checksum over all of memory, including the nonce, and return the result. The verification system will compare the computed checksum and the time it took for the computation of the checksum to determine if the firmware has been modified.
+
+## Considerations
+* The firmware code will need to be modified to include the behavioral monitoring functionality.
+* This technique is sensitive to the device the embedded firmware is hosted on and it is expected that the devices and firmware will need to be profiled and analyzed to determine timing estimation.
 * This technique is not expected to be one hundred percent correct as you would expect in a hardware root of trust solution and may require some tuning.""" ;
     :kb-reference :Reference-FirmwareBehaviorAnalysisConFirm,
         :Reference-FirmwareBehaviorAnalysisVIPER ;
@@ -10639,17 +10639,17 @@ A challenge-response is issued and includes a nonce so that replays are not allo
             owl:someValuesFrom :Firmware ] ;
     :d3fend-id "D3-FEMC" ;
     :definition "Monitoring code is injected into firmware for integrity monitoring of firmware and firmware data." ;
-    :kb-article """## How it works\r
-Firmware in deployed network devices is typically not monitored for malicious changes. This technique provides a method to embed a software security component into the deployed firmware which provides a near real-time monitoring hook. The exception handling code, in the firmware, is typically used to expose any detected vulnerabilities.\r
-\r
-The injected software components provide a feature similar to intrusion detection systems for the firmware by detecting unauthorized modifications of the embedded firmware. The integrity of static code and firmware data are monitored continuously in the hosted devices. Comparisons are made to monitored elements like firmware memory addresses and data segments. Memory pages are scanned and if a modification is detected the software component may lock the page. This will protect subsequent attempted modifications to the firmware. The software component may utilize the exception handling code and thus be able to disclose the exact address of the modified memory.\r
-\r
-The injected software components are inserted during the firmware imaging process. The injected software is assumed to have knowledge of both the embedded code and the current execution state of the host program. The injected software will monitor and alert, in near real-time, on potential suspicious activity. The injected code is run alongside of the embedded code in the host. The injected software operates as an independent entity and is not dependent on the host software.\r
-\r
-Finally, this technique may implement other countermeasure techniques as part of their analytical processes. These should be identified by referencing other countermeasure techniques directly as necessary.\r
-\r
-## Considerations\r
-* The firmware code will need to be modified and re-hosted on the device.\r
+    :kb-article """## How it works
+Firmware in deployed network devices is typically not monitored for malicious changes. This technique provides a method to embed a software security component into the deployed firmware which provides a near real-time monitoring hook. The exception handling code, in the firmware, is typically used to expose any detected vulnerabilities.
+
+The injected software components provide a feature similar to intrusion detection systems for the firmware by detecting unauthorized modifications of the embedded firmware. The integrity of static code and firmware data are monitored continuously in the hosted devices. Comparisons are made to monitored elements like firmware memory addresses and data segments. Memory pages are scanned and if a modification is detected the software component may lock the page. This will protect subsequent attempted modifications to the firmware. The software component may utilize the exception handling code and thus be able to disclose the exact address of the modified memory.
+
+The injected software components are inserted during the firmware imaging process. The injected software is assumed to have knowledge of both the embedded code and the current execution state of the host program. The injected software will monitor and alert, in near real-time, on potential suspicious activity. The injected code is run alongside of the embedded code in the host. The injected software operates as an independent entity and is not dependent on the host software.
+
+Finally, this technique may implement other countermeasure techniques as part of their analytical processes. These should be identified by referencing other countermeasure techniques directly as necessary.
+
+## Considerations
+* The firmware code will need to be modified and re-hosted on the device.
 * Exposing monitoring hooks to the injected code may introduce additional risk.""" ;
     :kb-reference :Reference-FirmwareEmbeddedMonitoringCodeRedBalloon,
         :Reference-FirmwareEmbeddedMonitoringCodeSymbiotes .
@@ -10672,11 +10672,11 @@ Finally, this technique may implement other countermeasure techniques as part of
             owl:someValuesFrom :Firmware ] ;
     :d3fend-id "D3-FV" ;
     :definition "Cryptographically verifying firmware integrity." ;
-    :kb-article """## How it works\r
-Cryptographic hash values are computed for system and peripheral firmware. The hash values are compared against precomputed hash values for the identified firmware. A hash value mismatch may indicate that the firmware may have been tampered with or updated with a non-current release indicating a misconfiguration for the system.\r
-\r
-## Considerations\r
-* Requires cryptographically computed hash values of firmware\r
+    :kb-article """## How it works
+Cryptographic hash values are computed for system and peripheral firmware. The hash values are compared against precomputed hash values for the identified firmware. A hash value mismatch may indicate that the firmware may have been tampered with or updated with a non-current release indicating a misconfiguration for the system.
+
+## Considerations
+* Requires cryptographically computed hash values of firmware
 * Requires storage of precomputed firmware hash values""" ;
     :kb-reference :Reference-FirmwareVerificationEclypsium,
         :Reference-FirmwareVerificationTrapezoid,
@@ -10688,45 +10688,45 @@ Cryptographic hash values are computed for system and peripheral firmware. The h
     rdfs:subClassOf :PredicateLogic ;
     :d3fend-id "D3A-FOL" ;
     :definition "First-order logic is a collection of formal systems used in mathematics, philosophy, linguistics, and computer science. First-order logic uses quantified variables over non-logical objects, and allows the use of sentences that contain variables." ;
-    :kb-article """## How it works\r
-\r
-For propositions such as "Socrates is a man", one can have expressions in the form "there exists x such that x is Socrates and x is a man", where "there exists" is a quantifier, while x is a variable. This distinguishes it from propositional logic, which does not use quantifiers or relations.\r
-\r
-The term "first-order" distinguishes first-order logic from higher-order logic, in which there are predicates having predicates or functions as arguments, or in which quantification over predicates, functions, or both, are permitted.\r
-\r
-## Considerations\r
-\r
-- Advantages:\r
--- First-order logic is more expressive than propositional logic; one can talk about objects and their properties, relations between objects.\r
--- First-order logic is able to make use of variables and quantifiers (e.g., "for all" and "exists".)\r
--- First-order logic supports power forms of reasoning, such as inferring the properties of an unknown object from the properties of known objects.\r
-\r
-- Disadvantages:\r
--- First-order logic is more difficult to learn and use than propositional logic, due to its greater complexity.\r
--- First-order logic is also less tractable than propositional logic in many cases; reasoning about quantifiers and variables adds complexity.\r
--- First-order logic can be difficult to apply in practice, due to the need to find appropriate axioms and rules for each application.\r
-\r
-### Verification Approach\r
-\r
-- Automated theorem provers can assist in formal verification, performing automated reasoning over system modeled in first-order logic and explore a complete space of system behaviors\r
-- First-order logic may be more expressive than necessary for many types of problems and may be more difficult to verify by SMEs.\r
-- Theorem provers based in FOL are capable of use in software verification tasks, but an SMT solver such as Z3 might be more appropriate.\r
-- Defining a set of competency questions (i.e., query use cases for a first-order logic ontology) can help scope the logic required for a complete solution.\r
-\r
-### Validation Approach\r
-\r
-- Domain SMEs should be identified to review the analytics results and compare them to expected results for a given input.\r
-- Where possible, an outside team of SMEs should inspect the formal logic specification of a system against its stated requirements and suitability to address its domain problem sets.\r
-- Defining a set of competency questions and the expected results provides one means of validation.\r
-\r
-## References\r
-\r
-1.  First-order logic. (2023, May 26). In _Wikipedia_.  [Link](https://en.wikipedia.org/wiki/First-order_logic)\r
-2. Shapiro, S. and Kissel, T. Classical Logic. (2022). Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-classical/)\r
-3. A.I. For Anyone. First-order Logic (n.d.). [Link](https://www.aiforanyone.org/glossary/first-order-logic)\r
-4. Smith, P. An Introduction to Formal Logic. (2020). [Link](https://doi.org/10.1017/9781108328999)\r
-5. Gruninger, M. and Fox, M. (1995). Methodology for the Design and Evaluation of Ontologies. [Link](https://www.researchgate.net/publication/2288533_Methodology_for_the_Design_and_Evaluation_of_Ontologies)\r
-6. Keet, C., Suarez-Figurosa, M., and Poveda-Villalon, M. (2014). Pitfalls in Ontologies and TIPS to Prevent Them. [Link](https://dl.acm.org/doi/10.4018/ijswis.2014040102)\r
+    :kb-article """## How it works
+
+For propositions such as "Socrates is a man", one can have expressions in the form "there exists x such that x is Socrates and x is a man", where "there exists" is a quantifier, while x is a variable. This distinguishes it from propositional logic, which does not use quantifiers or relations.
+
+The term "first-order" distinguishes first-order logic from higher-order logic, in which there are predicates having predicates or functions as arguments, or in which quantification over predicates, functions, or both, are permitted.
+
+## Considerations
+
+- Advantages:
+-- First-order logic is more expressive than propositional logic; one can talk about objects and their properties, relations between objects.
+-- First-order logic is able to make use of variables and quantifiers (e.g., "for all" and "exists".)
+-- First-order logic supports power forms of reasoning, such as inferring the properties of an unknown object from the properties of known objects.
+
+- Disadvantages:
+-- First-order logic is more difficult to learn and use than propositional logic, due to its greater complexity.
+-- First-order logic is also less tractable than propositional logic in many cases; reasoning about quantifiers and variables adds complexity.
+-- First-order logic can be difficult to apply in practice, due to the need to find appropriate axioms and rules for each application.
+
+### Verification Approach
+
+- Automated theorem provers can assist in formal verification, performing automated reasoning over system modeled in first-order logic and explore a complete space of system behaviors
+- First-order logic may be more expressive than necessary for many types of problems and may be more difficult to verify by SMEs.
+- Theorem provers based in FOL are capable of use in software verification tasks, but an SMT solver such as Z3 might be more appropriate.
+- Defining a set of competency questions (i.e., query use cases for a first-order logic ontology) can help scope the logic required for a complete solution.
+
+### Validation Approach
+
+- Domain SMEs should be identified to review the analytics results and compare them to expected results for a given input.
+- Where possible, an outside team of SMEs should inspect the formal logic specification of a system against its stated requirements and suitability to address its domain problem sets.
+- Defining a set of competency questions and the expected results provides one means of validation.
+
+## References
+
+1.  First-order logic. (2023, May 26). In _Wikipedia_.  [Link](https://en.wikipedia.org/wiki/First-order_logic)
+2. Shapiro, S. and Kissel, T. Classical Logic. (2022). Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-classical/)
+3. A.I. For Anyone. First-order Logic (n.d.). [Link](https://www.aiforanyone.org/glossary/first-order-logic)
+4. Smith, P. An Introduction to Formal Logic. (2020). [Link](https://doi.org/10.1017/9781108328999)
+5. Gruninger, M. and Fox, M. (1995). Methodology for the Design and Evaluation of Ontologies. [Link](https://www.researchgate.net/publication/2288533_Methodology_for_the_Design_and_Evaluation_of_Ontologies)
+6. Keet, C., Suarez-Figurosa, M., and Poveda-Villalon, M. (2014). Pitfalls in Ontologies and TIPS to Prevent Them. [Link](https://dl.acm.org/doi/10.4018/ijswis.2014040102)
 7. Bjorner, N. et al. The inner magic behind the Z3 theorem prover. (2019) [Link](https://www.microsoft.com/en-us/research/blog/the-inner-magic-behind-the-z3-theorem-prover/)""" ;
     :synonym "First-order Predicate Calculus",
         "FOL",
@@ -10763,12 +10763,12 @@ The term "first-order" distinguishes first-order logic from higher-order logic, 
             owl:someValuesFrom :OutboundInternetDNSLookupTraffic ] ;
     :d3fend-id "D3-FRDDL" ;
     :definition "Blocking a lookup based on the query's domain name value." ;
-    :kb-article """## How it works\r
-\r
-Policies are created that filter DNS queries using fully qualified domain name (FQDN) of record in the query. A DNS policy can be created for blocking DNS queries from FQDNs that have been identified as unauthorized.\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+
+Policies are created that filter DNS queries using fully qualified domain name (FQDN) of record in the query. A DNS policy can be created for blocking DNS queries from FQDNs that have been identified as unauthorized.
+
+## Considerations
+
 Continuous maintenance of unauthorized domain lists is needed to keep up to date as updates occur.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Forward Resolution Domain Blacklisting" .
@@ -10783,22 +10783,22 @@ Continuous maintenance of unauthorized domain lists is needed to keep up to date
             owl:someValuesFrom :InboundInternetDNSResponseTraffic ] ;
     :d3fend-id "D3-FRIDL" ;
     :definition "Blocking a DNS lookup's answer's IP address value." ;
-    :kb-article """## How it works\r
-\r
-This technique prevents a client from learning IP addresses deemed to be potentially malicious, which would have been delivered via forward resolution responses.\r
-\r
-Responses to forward resolution requests (that is, requests where a domain is sent and IP(s) are returned) are collected, and the IP address(es) included as a response are examined. If the IP address(es) are in a range included in the blacklist, then the response is dropped and not forwarded to the client.\r
-\r
-The DNS lookup can be blocked by either dropping the network traffic with an inline device, or modifying the value of the response sent by the DNS server. To transparently prevent client applications from hanging on a request, it is common practice to replace malicious values with addresses in the range 127.0.0.0/8 or the address of a honeypot maintained by the network administrators.\r
-\r
-## Considerations\r
-\r
-* This technique does not prevent the client from contacting the blacklisted IP, only from learning about this IP address via a nameserver lookup request.\r
-* DNS Response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer IP address value(s).\r
-  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.\r
-  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.\r
-* This technique must be implemented logically between the application that receives the response and the server which sent the response.\r
-  * DNS responses sent in an encrypted manner, such as those using DoH or DoT, will require interception of the TLS connections in order to determine the IP address(es) in the response.\r
+    :kb-article """## How it works
+
+This technique prevents a client from learning IP addresses deemed to be potentially malicious, which would have been delivered via forward resolution responses.
+
+Responses to forward resolution requests (that is, requests where a domain is sent and IP(s) are returned) are collected, and the IP address(es) included as a response are examined. If the IP address(es) are in a range included in the blacklist, then the response is dropped and not forwarded to the client.
+
+The DNS lookup can be blocked by either dropping the network traffic with an inline device, or modifying the value of the response sent by the DNS server. To transparently prevent client applications from hanging on a request, it is common practice to replace malicious values with addresses in the range 127.0.0.0/8 or the address of a honeypot maintained by the network administrators.
+
+## Considerations
+
+* This technique does not prevent the client from contacting the blacklisted IP, only from learning about this IP address via a nameserver lookup request.
+* DNS Response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer IP address value(s).
+  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.
+  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.
+* This technique must be implemented logically between the application that receives the response and the server which sent the response.
+  * DNS responses sent in an encrypted manner, such as those using DoH or DoT, will require interception of the TLS connections in order to determine the IP address(es) in the response.
 * Replacing the response is not effective in the case that the nameserver uses a technique to provide integrity of its responses, such as DNSSEC for DNS responses.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Forward Resolution IP Blacklisting" .
@@ -10816,10 +10816,10 @@ The DNS lookup can be blocked by either dropping the network traffic with an inl
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-FL" ;
     :definition "Fuzzy logic is a form of many-valued logic in which the truth value of variables may be any real number between 0 and 1." ;
-    :kb-article """## How it works\r
-It is employed to handle the concept of partial truth, where the truth value may range between completely true and completely false.[1] By contrast, in Boolean logic, the truth values of variables may only be the integer values 0 or 1.\r
-\r
-## References\r
+    :kb-article """## How it works
+It is employed to handle the concept of partial truth, where the truth value may range between completely true and completely false.[1] By contrast, in Boolean logic, the truth values of variables may only be the integer values 0 or 1.
+
+## References
 1. Fuzzy logic. (2023, May 28). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Fuzzy_logic)""" .
 
 :GatedRecurrentUnit a owl:Class,
@@ -10828,7 +10828,7 @@ It is employed to handle the concept of partial truth, where the truth value may
     rdfs:subClassOf :RecurrentNeuralNetwork ;
     :d3fend-id "D3A-GRU" ;
     :definition "The GRU is like a long short-term memory (LSTM) with a forget gate, but has fewer parameters than LSTM, as it lacks an output gate. GRU's performance on certain tasks of polyphonic music modeling, speech signal modeling and natural language processing was found to be similar to that of LSTM" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (2021, September 20). Gated Recurrent Unit. [Link](https://en.wikipedia.org/wiki/Gated_recurrent_unit)""" .
 
 :Generation a owl:Class ;
@@ -10841,7 +10841,7 @@ Wikipedia. (2021, September 20). Gated Recurrent Unit. [Link](https://en.wikiped
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-GAN" ;
     :definition "Generative Adversarial Networks (GAN) are an approach to generative modeling using deep learning methods, such as convolutional neural networks." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Brownlee, J. (2019). What Are Generative Adversarial Networks (GANs)? Machine Learning Mastery. [Link](https://machinelearningmastery.com/what-are-generative-adversarial-networks-gans/)""" ;
     :synonym "GAN" .
 
@@ -10851,7 +10851,7 @@ Brownlee, J. (2019). What Are Generative Adversarial Networks (GANs)? Machine Le
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-GM" ;
     :definition "The nth root of the product of the data values, where there are n of these. This measure is valid only for data that are measured absolutely on a strictly positive scale." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :GetOpenSockets a owl:Class ;
@@ -10904,8 +10904,8 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:isDefinedBy "https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html" ;
     :d3fend-id "D3A-GAKG" ;
     :definition "Goodman-Kruskal $\\\\gamma$ is a measure of rank correlation between x and y and is given by $(n_c -n_d) / (n_c + n_d)$, where $n_c$ is the number of concordant pairs of the observations and $n_d$ is the number of discordant pairs." ;
-    :kb-article """## References\r
-1. Wolfram Research. (2012). GoodmanKruskalGamma. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html)\r
+    :kb-article """## References
+1. Wolfram Research. (2012). GoodmanKruskalGamma. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html)
 1. Goodman and Kruskal's gamma. (2022, Nov 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Goodman_and_Kruskal%27s_gamma]""" .
 
 :GPT a owl:Class,
@@ -10914,7 +10914,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :Transformer-basedLearning ;
     :d3fend-id "D3A-GPT" ;
     :definition "Generative pre-trained transformers (GPT) are a type of large language model (LLM) and a prominent framework for generative artificial intelligence." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Generative pre-trained transformer. (n.d.). In Wikipedia. [Link](https://en.wikipedia.org/wiki/Generative_pre-trained_transformer)""" ;
     :synonym "Generative Pre-trained Transformer" .
 
@@ -10924,7 +10924,7 @@ Generative pre-trained transformer. (n.d.). In Wikipedia. [Link](https://en.wiki
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-GBC" ;
     :definition "Graph-based Clustering is a form of clustering where data is represented with graphs to identify clusters ." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Density-Based and Graph-Based Clustering. [Link](https://towardsdatascience.com/density-based-and-graph-based-clustering-a1f0d45ff5fb)""" .
 
 :Graph-basedSemi-supervisedLearning a owl:Class,
@@ -10933,7 +10933,7 @@ Density-Based and Graph-Based Clustering. [Link](https://towardsdatascience.com/
     rdfs:subClassOf :Semi-supervisedTransductiveLearning ;
     :d3fend-id "D3A-GBSSL" ;
     :definition "Graph-based Semi-Supervised Learning (GSSL) methods aim to classify unlabeled data by learning the graph structure and labeled data jointly." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Yang, S., Pan, L., & Cheng, J. (2021). Graph-based Semi-Supervised Learning Methods for Imbalanced Data Classification. [Link](https://www.sciencedirect.com/science/article/pii/S0031320321002132?viewFullText=true).""" .
 
 :GraphicalUserInterface a owl:Class ;
@@ -10961,7 +10961,7 @@ Yang, S., Pan, L., & Cheng, J. (2021). Graph-based Semi-Supervised Learning Meth
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-GBC" ;
     :definition "Divides the entire data space into a finite number of cells reducing the complexity of the data and focuses on the cells rather than the data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 TechVidvan. (n.d.). Clustering in Machine Learning Tutorial. [Link](https://techvidvan.com/tutorials/clustering-in-machine-learning/)""" .
 
 :Grid-CNN a owl:Class,
@@ -10970,7 +10970,7 @@ TechVidvan. (n.d.). Clustering in Machine Learning Tutorial. [Link](https://tech
     rdfs:subClassOf :ConvolutionalNeuralNetwork ;
     :d3fend-id "D3A-GC" ;
     :definition "A class of neural networks that specializes in processing data that has a grid-like topology, such as an image." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Talukdar, P. (2020, June 10). Convolutional Neural Networks Explained. Towards Data Science. [Link](https://towardsdatascience.com/convolutional-neural-networks-explained-9cc5188c4939)""" .
 
 :Grouping a owl:Class ;
@@ -11026,22 +11026,22 @@ Talukdar, P. (2020, June 10). Convolutional Neural Networks Explained. Towards D
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-HBPI" ;
     :definition "Preventing one process from writing to the memory space of another process through hardware based address manager implementations." ;
-    :kb-article """## How it works\r
-Process isolation, in this context, is address space separation controlled by a security function that limits the communication between processes so that one process cannot directly modify the executing code of another process. For example with virtual address space:\r
-\r
-* Process A address space is different from process B address space, which prevents process A from writing to process B\r
-\r
-Hardware process isolation is commonly implemented through Direct Memory Access (DMA) which collaborates with a Memory Management Unit (MMU), or Input-Output Memory Management Unit (IOMMU). These hardware controls are deployed directly on processors to aid hosts or enclaves in process isolation.\r
-\r
-* DMA - Direct memory access allows memory access to occur independently of the program currently run by the microprocessor. DMA allows for I/O devices to directly read from and write to memory, or it can be used to efficiently copy blocks of memory. During DMA transfers, the microprocessor can execute an unrelated program.\r
-* MMU - A memory management unit acts as an access control and is responsible for performing the translation of virtual memory addresses to physical memory addresses. The MMU allocates each process its own virtual memory space.\r
-* IOMMU - An input-output memory management unit is used to allocate each I/O device its own virtual address space to the underlying physical addresses. IOMMU allows devices that do not support long memory addresses to address the entire memory space.\r
-\r
-## Considerations\r
-* Private hosts may be vulnerable to DMA attack if they have a PCI or PCI Express port that connects attached devices directly to physical address space.\r
-\r
-## Implementations:\r
- * Intel Virtualization Technology for Directed I/O (Intel VT-d)\r
+    :kb-article """## How it works
+Process isolation, in this context, is address space separation controlled by a security function that limits the communication between processes so that one process cannot directly modify the executing code of another process. For example with virtual address space:
+
+* Process A address space is different from process B address space, which prevents process A from writing to process B
+
+Hardware process isolation is commonly implemented through Direct Memory Access (DMA) which collaborates with a Memory Management Unit (MMU), or Input-Output Memory Management Unit (IOMMU). These hardware controls are deployed directly on processors to aid hosts or enclaves in process isolation.
+
+* DMA - Direct memory access allows memory access to occur independently of the program currently run by the microprocessor. DMA allows for I/O devices to directly read from and write to memory, or it can be used to efficiently copy blocks of memory. During DMA transfers, the microprocessor can execute an unrelated program.
+* MMU - A memory management unit acts as an access control and is responsible for performing the translation of virtual memory addresses to physical memory addresses. The MMU allocates each process its own virtual memory space.
+* IOMMU - An input-output memory management unit is used to allocate each I/O device its own virtual address space to the underlying physical addresses. IOMMU allows devices that do not support long memory addresses to address the entire memory space.
+
+## Considerations
+* Private hosts may be vulnerable to DMA attack if they have a PCI or PCI Express port that connects attached devices directly to physical address space.
+
+## Implementations:
+ * Intel Virtualization Technology for Directed I/O (Intel VT-d)
  * Firecracker""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ApproachesForSecuringAnInternetEndpointUsingFine-grainedOperatingSystemVirtualization_Bromium,Inc.>,
         <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-IsolationOfApplicationsWithinAVirtualMachine_Bromium,Inc.>,
@@ -11058,20 +11058,20 @@ Hardware process isolation is commonly implemented through Direct Memory Access 
             owl:someValuesFrom :HardwareDevice ] ;
     :d3fend-id "D3-HCI" ;
     :definition "Hardware component inventorying identifies and records the hardware items in the organization's architecture." ;
-    :kb-article """## How it works\r
-Administrators collect information on hardware devices such as peripherals, NICs, processors, and memory devices that are components of the computers in their architecture using a variety of administrative and management tools that query for this information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through remote adminstration tools and system commands, either manually or using scripts.\r
-\r
-## Considerations\r
-* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.\r
-* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools\r
-\r
-## Examples\r
-* Bus discovery\r
-   * Admin-scripted PCI Bus inventory using ssh and pciutils\r
-* Application-layer discovery\r
-   * Simple Network Management Protocol (SNMP) collects MIB information\r
-   * Web-based Enterprise Management (WBEM) collects CIM information\r
-      * Windows Management Instrumentation (WMI)\r
+    :kb-article """## How it works
+Administrators collect information on hardware devices such as peripherals, NICs, processors, and memory devices that are components of the computers in their architecture using a variety of administrative and management tools that query for this information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through remote adminstration tools and system commands, either manually or using scripts.
+
+## Considerations
+* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.
+* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools
+
+## Examples
+* Bus discovery
+   * Admin-scripted PCI Bus inventory using ssh and pciutils
+* Application-layer discovery
+   * Simple Network Management Protocol (SNMP) collects MIB information
+   * Web-based Enterprise Management (WBEM) collects CIM information
+      * Windows Management Instrumentation (WMI)
       * Windows Management Infrastructure (MI)""" ;
     :kb-reference :Reference-AdvancedDeviceMatchingSystem ;
     :synonym "Hardware Component Discovery",
@@ -11101,7 +11101,7 @@ Administrators collect information on hardware devices such as peripherals, NICs
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-HM" ;
     :definition "The reciprocal of the arithmetic mean of the reciprocals of the data values. This measure too is valid only for data that are measured absolutely on a strictly positive scale." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :HeapSegment a owl:Class ;
@@ -11116,7 +11116,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :HeterogeneousTransferLearning ;
     :d3fend-id "D3A-HAFBTL" ;
     :definition "Asymmetric transformation mapping  transforms the source feature space to align with that of the target or the target to that of the source. This, in effect, bridges the feature space gap and reduces the problem into a homogeneous transfer problem when further distribution differences need to be corrected." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid optimization algorithm. Journal of Big Data, 4(1), 25. [Link](https://journalofbigdata.springeropen.com/articles/10.1186/s40537-017-0089-0).""" .
 
 :HeterogeneousFeature-basedTransferLearning a owl:Class,
@@ -11125,7 +11125,7 @@ Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid
     rdfs:subClassOf :HeterogeneousTransferLearning ;
     :d3fend-id "D3A-HFBTL" ;
     :definition "Symmetric transformation  takes both the source feature space Xs and target feature space Xt and learns feature transformations as to project each onto a common subspace Xc for adaptation purposes. This derived subspace becomes a domain-invariant feature subspace to associate cross-domain data, and in effect, reduces marginal distribution differences." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid optimization algorithm. Journal of Big Data, 4(1), 25. [Link](https://journalofbigdata.springeropen.com/articles/10.1186/s40537-017-0089-0).""" .
 
 :HeterogeneousTransferLearning a owl:Class,
@@ -11134,7 +11134,7 @@ Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid
     rdfs:subClassOf :TransferLearning ;
     :d3fend-id "D3A-HTL" ;
     :definition "Heterogeneous transfer learning is characterized by the source and target domains having differing feature spaces, but may also be combined with other issues such as differing data distributions and label spaces." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid optimization algorithm. Journal of Big Data, 4(1), 25. [Link](https://journalofbigdata.springeropen.com/articles/10.1186/s40537-017-0089-0).""" .
 
 :HierarchicalClustering a owl:Class,
@@ -11143,8 +11143,8 @@ Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-HC" ;
     :definition "Hierarchical clustering (also called hierarchical cluster analysis or HCA) is a method of cluster analysis that seeks to build a hierarchy of clusters." ;
-    :kb-article """## References\r
-Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)\r
+    :kb-article """## References
+Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)
 html)""" ;
     :todo "Consider Divisive clustering as per the wiki" .
 
@@ -11155,14 +11155,14 @@ html)""" ;
     rdfs:subClassOf :ForwardResolutionDomainDenylisting ;
     :d3fend-id "D3-HDDL" ;
     :definition "Blocking the resolution of any subdomain of a specified domain name." ;
-    :kb-article """## How it works\r
-This technique is used to block DNS queries from related domains and subdomains that are unauthorized.\r
-\r
-Hierarchical domain blacklisting considers the blacklisting of second level domains and additional sub-domains and specific hosts for a given query value. A denylist is maintained that contains DNS names and corresponding subdomains, including wildcards, that should be blocked for a given lookup.\r
-\r
-## Considerations\r
-* The denylist of domain names will have to be maintained and will need to be kept up to date\r
-* Other domains that resolve to the domain of interest for blocking (CNAME, etc).\r
+    :kb-article """## How it works
+This technique is used to block DNS queries from related domains and subdomains that are unauthorized.
+
+Hierarchical domain blacklisting considers the blacklisting of second level domains and additional sub-domains and specific hosts for a given query value. A denylist is maintained that contains DNS names and corresponding subdomains, including wildcards, that should be blocked for a given lookup.
+
+## Considerations
+* The denylist of domain names will have to be maintained and will need to be kept up to date
+* Other domains that resolve to the domain of interest for blocking (CNAME, etc).
 * Denylists should have identified maintenance cycles to ensure lists are not stale.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Hierarchical Domain Blacklisting" .
@@ -11173,7 +11173,7 @@ Hierarchical domain blacklisting considers the blacklisting of second level doma
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-HDC" ;
     :definition "The cluster analysis of data with anywhere from a few dozen to many thousands of dimensions." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Clustering high-dimensional data. [Link](https://en.wikipedia.org/wiki/Clustering_high-dimensional_data)""" .
 
 :Higher-orderLogic a owl:Class,
@@ -11182,7 +11182,7 @@ Wikipedia. (n.d.). Clustering high-dimensional data. [Link](https://en.wikipedia
     rdfs:subClassOf :PredicateLogic ;
     :d3fend-id "D3A-HOL" ;
     :definition "Higher-order logic is a form of predicate logic that is distinguished from first-order logic by additional quantifiers and, sometimes, stronger semantics. Higher-order logics with their standard semantics are more expressive, but their model-theoretic properties are less well-behaved than those of first-order logic." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Higher-order logic. (2023, May 13). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Higher-order_logic)""" ;
     :synonym "HOL" .
 
@@ -11196,7 +11196,7 @@ Wikipedia. (n.d.). Clustering high-dimensional data. [Link](https://en.wikipedia
     rdfs:subClassOf :TransferLearning ;
     :d3fend-id "D3A-HTL" ;
     :definition "In homogeneous transfer learning, the feature spaces of the source and target domains is of the same dimension (Ds = Dt) while the data of both domains is represented by the same attributes (Xs = Xt) and labels (Ys = Yt). Thus, homogeneous transfer learning aims to bridge the gap in the data distributions experienced during cross-domain transfer." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Khalil, K., Asgher, U., & Ayaz, Y. (2022). Novel fNIRS study on homogeneous symmetric feature-based transfer learning for brain-computer interface. Scientific Reports, 12, 3198. [Link](https://www.nature.com/articles/s41598-022-06805-4).""" .
 
 :HomoglyphDenylisting a :ForwardResolutionDomainDenylisting,
@@ -11206,14 +11206,14 @@ Khalil, K., Asgher, U., & Ayaz, Y. (2022). Novel fNIRS study on homogeneous symm
     rdfs:subClassOf :ForwardResolutionDomainDenylisting ;
     :d3fend-id "D3-HDL" ;
     :definition "Blocking DNS queries that are deceptively similar to legitimate domain names." ;
-    :kb-article """## How it works\r
-\r
-Homoglyph domain blacklisting considers the domain and subdomain structure of a lookup and compares the named components to blacklisted named components. The blacklisted named components are typically crafted modifications of known good domains, e.g., gooogle.com versus google.com. The blacklisted domains typically resemble trusted domains, but have been altered slightly to deceive users.\r
-\r
-The blacklisted named components also include consideration for fonts or Unicode characters that can make certain characters appear very similar (zero vs capital O and the letter l vs the number one). The blacklisted domains under certain fonts will appear to be a trusted domain.\r
-\r
-## Considerations\r
-* Maintaining the currency of the list can be a challenge especially with newly registered domain entries.\r
+    :kb-article """## How it works
+
+Homoglyph domain blacklisting considers the domain and subdomain structure of a lookup and compares the named components to blacklisted named components. The blacklisted named components are typically crafted modifications of known good domains, e.g., gooogle.com versus google.com. The blacklisted domains typically resemble trusted domains, but have been altered slightly to deceive users.
+
+The blacklisted named components also include consideration for fonts or Unicode characters that can make certain characters appear very similar (zero vs capital O and the letter l vs the number one). The blacklisted domains under certain fonts will appear to be a trusted domain.
+
+## Considerations
+* Maintaining the currency of the list can be a challenge especially with newly registered domain entries.
 * Blacklists should have identified maintenance cycles to ensure lists are not stale.""" ;
     :kb-reference :Reference-DetectionOfMaliciousIDNHomoglyphDomains ;
     :synonym "Homoglyph Blacklisting" .
@@ -11231,11 +11231,11 @@ The blacklisted named components also include consideration for fonts or Unicode
             owl:someValuesFrom :URL ] ;
     :d3fend-id "D3-HD" ;
     :definition "Comparing strings using a variety of techniques to determine if a deceptive or malicious string is being presented to a user." ;
-    :kb-article """## How it works\r
-A homoglyph, in this context, is a deceptive string or word which looks like a trusted word, but is composed of different characters, for example: goooogle.com versus google.com. This is commonly found in phishing and typo squatting attacks where a human exploiting through a social engineering campaign.\r
-\r
-## Considerations\r
-* In very large environments processing DNS queries can be computationally expensive due to the amount of traffic that is generated\r
+    :kb-article """## How it works
+A homoglyph, in this context, is a deceptive string or word which looks like a trusted word, but is composed of different characters, for example: goooogle.com versus google.com. This is commonly found in phishing and typo squatting attacks where a human exploiting through a social engineering campaign.
+
+## Considerations
+* In very large environments processing DNS queries can be computationally expensive due to the amount of traffic that is generated
 * Legitimate companies and products use non-dictionary words in their names that could result in many false positives""" ;
     :kb-reference :Reference-Computer-implementedMethodsAndSystemsForIdentifyingVisuallySimilarTextCharacterStrings_GreathornInc,
         :Reference-SystemAndMethodForDetectingHomoglyphAttacksWithASiameseConvolutionalNeuralNetwork_EndgameInc .
@@ -11313,7 +11313,7 @@ A homoglyph, in this context, is a deceptive string or word which looks like a t
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-HBTL" ;
     :definition "This method creates an asymmetric mapping from the target to the source and takes into account bias issues of cross-domain correspondences." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learning. Journal of Big Data, 4(1), 29. [Link](https://doi.org/10.1186/s40537-017-0089-0).""" .
 
 :HypothesisTesting a owl:Class,
@@ -11322,7 +11322,7 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
     rdfs:subClassOf :InferentialStatistics ;
     :d3fend-id "D3A-HT" ;
     :definition "A statistical hypothesis test is a method of statistical inference used to decide whether the data at hand sufficiently support a particular hypothesis. Hypothesis testing allows us to make probabilistic statements about population parameters." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Statistical hypothesis testing. [Link](https://en.wikipedia.org/wiki/Statistical_hypothesis_testing)""" .
 
 :ID3 a owl:Class,
@@ -11331,10 +11331,10 @@ Wikipedia. (n.d.). Statistical hypothesis testing. [Link](https://en.wikipedia.o
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-ID3" ;
     :definition "ID3 stands for Iterative Dichotomiser 3 and is named such because the algorithm iteratively (repeatedly) dichotomizes(divides) features into two or more groups at each step." ;
-    :kb-article """## Addtional Consiterations\r
-ID3 is the basis of C4.5, and is best used in natural language processing.\r
-\r
-## References\r
+    :kb-article """## Addtional Consiterations
+ID3 is the basis of C4.5, and is best used in natural language processing.
+
+## References
 Decision Trees for Classification: ID3 Algorithm Explained. Towards Data Science. [Link](https://towardsdatascience.com/decision-trees-for-classification-id3-algorithm-explained-89df76e72df1).""" .
 
 :Identifier a owl:Class ;
@@ -11351,21 +11351,21 @@ Decision Trees for Classification: ID3 Algorithm Explained. Towards Data Science
     rdfs:subClassOf :IdentifierAnalysis ;
     :d3fend-id "D3-IAA" ;
     :definition "Taking known malicious identifiers and determining if they are present in a system." ;
-    :kb-article """## How it works\r
-\r
-Identifier activity analysis is the process of taking identifiers--typically known malicious identifiers--and determining the artifacts that have interacted with those identifiers.\r
-\r
-There are many open and closed source repositories of identifiers that represent indicators of compromise. For example, VirusTotal contains hash signatures of malware and IP Addresses used by threat actors. Defenders can search for these indicators of compromise their own systems to gain context on activity around an identifier.\r
-\r
-## Considerations\r
-\r
-Indicator activity analysis is a good way to gain high precision analysis, but adversaries can modify their own signatures such as hashes quickly to evade detection. This is related to David Bianco’s Pyramid of Pain - Indicators on the lower level (hash values, IP addresses domain names) are easy for adversaries to change.\r
-\r
-Identifier activity data of interest for analysis with the identifier might include, but is not limited to:\r
-\r
-* network traffic activity where the identifier was used to identify communicating entities or referred to in the communication\r
-* process activity referencing the identifier, especially for resource access\r
-* file activity referencing the identifier\r
+    :kb-article """## How it works
+
+Identifier activity analysis is the process of taking identifiers--typically known malicious identifiers--and determining the artifacts that have interacted with those identifiers.
+
+There are many open and closed source repositories of identifiers that represent indicators of compromise. For example, VirusTotal contains hash signatures of malware and IP Addresses used by threat actors. Defenders can search for these indicators of compromise their own systems to gain context on activity around an identifier.
+
+## Considerations
+
+Indicator activity analysis is a good way to gain high precision analysis, but adversaries can modify their own signatures such as hashes quickly to evade detection. This is related to David Bianco’s Pyramid of Pain - Indicators on the lower level (hash values, IP addresses domain names) are easy for adversaries to change.
+
+Identifier activity data of interest for analysis with the identifier might include, but is not limited to:
+
+* network traffic activity where the identifier was used to identify communicating entities or referred to in the communication
+* process activity referencing the identifier, especially for resource access
+* file activity referencing the identifier
 * registry settings referencing the identifier""" ;
     :kb-reference :Reference-ThePyramidOfPain-DavidBianco .
 
@@ -11399,7 +11399,7 @@ Identifier activity data of interest for analysis with the identifier might incl
     rdfs:subClassOf :GenerativeAdversarialNetwork ;
     :d3fend-id "D3A-ITITG" ;
     :definition "Image-to-image translation is the task of transferring styles and characteristics from one image domain to another." ;
-    :kb-article """## References\r
+    :kb-article """## References
 MathWorks. (n.d.). Get Started with GANs for Image-to-Image Translation. [Link](https://www.mathworks.com/help/images/get-started-with-gans-for-image-to-image-translation.html)""" .
 
 :ImageCodeSegment a owl:Class ;
@@ -11440,8 +11440,8 @@ MathWorks. (n.d.). Get Started with GANs for Image-to-Image Translation. [Link](
     rdfs:subClassOf :GenerativeAdversarialNetwork ;
     :d3fend-id "D3A-ISG" ;
     :definition "Image synthesis thorugh the application of Generative Adversarial Networks." ;
-    :kb-article """## References\r
-\r
+    :kb-article """## References
+
 Zhang, Q., Wang, H., Lu, H., Won, D., & Yoon, S. W. (2018). Medical Image Synthesis with Generative Adversarial Networks for Tissue Recognition. 2018 IEEE International Conference on Healthcare Informatics (ICHI), 199-207. doi: 10.1109/ICHI.2018.00030. [Link](https://ieeexplore.ieee.org/document/8419363)""" .
 
 :Impact a :OffensiveTactic,
@@ -11518,10 +11518,10 @@ Zhang, Q., Wang, H., Lu, H., Won, D., & Yoon, S. W. (2018). Medical Image Synthe
             owl:someValuesFrom :InboundInternetNetworkTraffic ] ;
     :d3fend-id "D3-ISVA" ;
     :definition "Analyzing inbound network session or connection attempt volume." ;
-    :kb-article """## How it works\r
-Network appliances are configured to alert on certain packets that typically are involved in DoS attacks. Typical packets include ICMP packets and SYN requests that are commonly used to flood networks. A sampling period is used to define a time window in which collected counts of the identified packets can be measured. If the collected number of packets exceeds a predefined limit then an alert is generated.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Network appliances are configured to alert on certain packets that typically are involved in DoS attacks. Typical packets include ICMP packets and SYN requests that are commonly used to flood networks. A sampling period is used to define a time window in which collected counts of the identified packets can be measured. If the collected number of packets exceeds a predefined limit then an alert is generated.
+
+## Considerations
 Scalability as volume of attacks increase; single servers may not have the memory and storage resources to handle high volumes of network traffic.""" ;
     :kb-reference :Reference-DetectingDDoSAttackUsingSnort,
         <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-IdentifyingADenial-of-serviceAttackInACloud-basedProxyService-CloudfareInc.>,
@@ -11539,28 +11539,28 @@ Scalability as volume of attacks increase; single servers may not have the memor
             owl:someValuesFrom :InboundNetworkTraffic ] ;
     :d3fend-id "D3-ITF" ;
     :definition "Restricting network traffic originating from untrusted networks destined towards a private host or enclave." ;
-    :kb-article """## How it works\r
-Inbound Traffic, in this context, is network traffic originating from an untrusted network towards a private host or enclave.\r
-For example:\r
-\r
-* An untrusted network host connecting to a internal commercial portal, shopping.example.com\r
-* An external mail server connecting to an internal mail server, mail.example.com\r
-\r
-Filtering policies are developed by administrators to meet business requirements and limit connectivity. These policies are implemented on edge devices such as firewalls, routers, and intrusion prevention systems. Examples of filters:\r
-\r
-* Blocking incoming traffic from spoofed internally facing IP addresses\r
-* Blocking specific ports and services from establishing connections\r
-* Limiting specific IP ranges from connecting to the network\r
-* Dynamic inbound filtering (Hole punching, STUN, NAT-T)\r
-\r
-## Considerations\r
-* Business requirements typically drive the development of filtering rulesets\r
-* Protocols using non-standard ports may circumvent filtering technology, which does not detect application protocol based on traffic content\r
-\r
-## Implementations\r
-* OpenWRT (Embedded)\r
-* Netfilter (Linux)\r
-* Windows Firewall\r
+    :kb-article """## How it works
+Inbound Traffic, in this context, is network traffic originating from an untrusted network towards a private host or enclave.
+For example:
+
+* An untrusted network host connecting to a internal commercial portal, shopping.example.com
+* An external mail server connecting to an internal mail server, mail.example.com
+
+Filtering policies are developed by administrators to meet business requirements and limit connectivity. These policies are implemented on edge devices such as firewalls, routers, and intrusion prevention systems. Examples of filters:
+
+* Blocking incoming traffic from spoofed internally facing IP addresses
+* Blocking specific ports and services from establishing connections
+* Limiting specific IP ranges from connecting to the network
+* Dynamic inbound filtering (Hole punching, STUN, NAT-T)
+
+## Considerations
+* Business requirements typically drive the development of filtering rulesets
+* Protocols using non-standard ports may circumvent filtering technology, which does not detect application protocol based on traffic content
+
+## Implementations
+* OpenWRT (Embedded)
+* Netfilter (Linux)
+* Windows Firewall
 * pf(BSD)""" ;
     :kb-reference :Reference-ActiveFirewallSystemAndMethodology_McAfeeLLC,
         :Reference-AutomaticallyGeneratingRulesForConnectionSecurity_Microsoft,
@@ -11579,34 +11579,34 @@ Filtering policies are developed by administrators to meet business requirements
     rdfs:subClassOf :ProcessAnalysis ;
     :d3fend-id "D3-IBCA" ;
     :definition "Analyzing vendor specific branch call recording in order to detect ROP style attacks." ;
-    :kb-article """## How it works\r
-\r
-This technique is used to detect an attacker attempting to exploit and execute code on a target system's call stack using return-oriented programming (ROP). Modern processors that have the ability to maintain a list of the branching calls, e.g., Intel's Last Branch Recording (LBR), can be used to track and analyze indirect branching calls that are indicative of malicious activity.\r
-\r
-In order to reduce the number of indirect branch calls to analyze to a manageable set it is assumed that malicious ROP activity will involve the use of system calls.  The technique observes indirect branch calls that are part of paths that lead to system calls, all others are ignored. Branching calls chained together is often referred to as gadgets and gadgets are often used in ROP attacks. Indirect branch calls that involve a transfer from user-space to kernel-space are of interest for this technique.\r
-\r
-Identification of potential ROP exploit execution includes:\r
-\r
-- Inspecting the LBR when a system function call is made\r
-\r
-  - The LBR is configured to return only instruction of interest (ret, indirect jmp, indirect calls)\r
-\r
-\r
-- Behavior is analyzed for\r
-  - Ret instructions that appear to target areas not preceded by the call sites\r
-  - Sequences of small code fragments that appear to be chained through the indirect branching calls (gadgets)\r
-\r
-\r
-- Of interest are returns that appear to not render control back after calls\r
-  - Typical ret-call are paired\r
-  - gadgets will appear to have ret followed by instruction of next instruction of the following gadget\r
-\r
-\r
-## Considerations\r
-\r
-* May be operating system dependent since specific system calls are used to scope branching behavoir\r
-* Processors need to support access to a Last Branch Recording list feature\r
-* The size of the LBR stack can limit the expected size of the analyzed execution stack\r
+    :kb-article """## How it works
+
+This technique is used to detect an attacker attempting to exploit and execute code on a target system's call stack using return-oriented programming (ROP). Modern processors that have the ability to maintain a list of the branching calls, e.g., Intel's Last Branch Recording (LBR), can be used to track and analyze indirect branching calls that are indicative of malicious activity.
+
+In order to reduce the number of indirect branch calls to analyze to a manageable set it is assumed that malicious ROP activity will involve the use of system calls.  The technique observes indirect branch calls that are part of paths that lead to system calls, all others are ignored. Branching calls chained together is often referred to as gadgets and gadgets are often used in ROP attacks. Indirect branch calls that involve a transfer from user-space to kernel-space are of interest for this technique.
+
+Identification of potential ROP exploit execution includes:
+
+- Inspecting the LBR when a system function call is made
+
+  - The LBR is configured to return only instruction of interest (ret, indirect jmp, indirect calls)
+
+
+- Behavior is analyzed for
+  - Ret instructions that appear to target areas not preceded by the call sites
+  - Sequences of small code fragments that appear to be chained through the indirect branching calls (gadgets)
+
+
+- Of interest are returns that appear to not render control back after calls
+  - Typical ret-call are paired
+  - gadgets will appear to have ret followed by instruction of next instruction of the following gadget
+
+
+## Considerations
+
+* May be operating system dependent since specific system calls are used to scope branching behavoir
+* Processors need to support access to a Last Branch Recording list feature
+* The size of the LBR stack can limit the expected size of the analyzed execution stack
 * If processor does not support LBR then overhead costs for the analysis can be significant""" ;
     :kb-reference :Reference-IndirectBranchingCalls .
 
@@ -11616,7 +11616,7 @@ Identification of potential ROP exploit execution includes:\r
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-IS" ;
     :definition "Statistical inference is the process of using data analysis to infer properties of an underlying distribution of probability." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Statistical inference. [Link](https://en.wikipedia.org/wiki/Statistical_inference)""" .
 
 :InformationContentEntity a owl:Class ;
@@ -11666,53 +11666,53 @@ Wikipedia. (n.d.). Statistical inference. [Link](https://en.wikipedia.org/wiki/S
             owl:someValuesFrom :InputDevice ] ;
     :d3fend-id "D3-IDA" ;
     :definition "Operating system level mechanisms to prevent abusive input device exploitation." ;
-    :kb-article """## How it works\r
-\r
-Input Device Hardening techniques filter certain commands, or disable related operating system functionality.\r
-\r
-### Analytics\r
-\r
-All of these values can be analyzed and compared to a baseline:\r
-\r
-* Amount of input\r
-* Duration of a single input\r
-* Durations between inputs\r
-* Value of input\r
-\r
-Context can also include:\r
-\r
-* User which is logged in, to include attributes such as physical location of the user\r
-* Date and time\r
-* System which is processing the input\r
-* Source device of input, to include its properties (eg. manufacturer), configuration (eg. keyboard layout) and behavioral attributes of this device (eg. first use)\r
-* Source system of input (local or remote system)\r
-* Other hardware devices attached to the system\r
-\r
-\r
-### Actions\r
-\r
-Actions can include:\r
-\r
-* Disabling the source device\r
-* Sending an alert\r
-* Locking the current session (eg. system screen lock, or returning to an authentication screen in a web app) and requiring one or more methods of authentication to continue\r
-* Administratively disabling credentials for the account or the entire account -- the technique *Account Locking*\r
-\r
-\r
-### Examples\r
-A malicious input device sends many keystrokes with approximately the same delay between each.  This does not match the normal cadence of input, and the device is disabled.\r
-\r
-Input to type the session user's name takes abnormally longer for each keystroke.  The system is locked to the password prompt screen.\r
-\r
-A system receives key press events from two different devices -- one device sends keystrokes after the other has been idle for a long time.\r
-\r
-A system receives physical input in a user session, while that user has sent input from a device located out of the country in the past hour.\r
-\r
-Network traffic is suddenly routed through a new external device, and nearly the same volume of network traffic is subsequently sent out the previously existing interface.  The new external device is disabled, and an alert is raised to investigate the network configuration for a potential compromise.\r
-\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+
+Input Device Hardening techniques filter certain commands, or disable related operating system functionality.
+
+### Analytics
+
+All of these values can be analyzed and compared to a baseline:
+
+* Amount of input
+* Duration of a single input
+* Durations between inputs
+* Value of input
+
+Context can also include:
+
+* User which is logged in, to include attributes such as physical location of the user
+* Date and time
+* System which is processing the input
+* Source device of input, to include its properties (eg. manufacturer), configuration (eg. keyboard layout) and behavioral attributes of this device (eg. first use)
+* Source system of input (local or remote system)
+* Other hardware devices attached to the system
+
+
+### Actions
+
+Actions can include:
+
+* Disabling the source device
+* Sending an alert
+* Locking the current session (eg. system screen lock, or returning to an authentication screen in a web app) and requiring one or more methods of authentication to continue
+* Administratively disabling credentials for the account or the entire account -- the technique *Account Locking*
+
+
+### Examples
+A malicious input device sends many keystrokes with approximately the same delay between each.  This does not match the normal cadence of input, and the device is disabled.
+
+Input to type the session user's name takes abnormally longer for each keystroke.  The system is locked to the password prompt screen.
+
+A system receives key press events from two different devices -- one device sends keystrokes after the other has been idle for a long time.
+
+A system receives physical input in a user session, while that user has sent input from a device located out of the country in the past hour.
+
+Network traffic is suddenly routed through a new external device, and nearly the same volume of network traffic is subsequently sent out the previously existing interface.  The new external device is disabled, and an alert is raised to investigate the network configuration for a potential compromise.
+
+
+## Considerations
+
 Given some example of legitimate behavioral input patterns, attackers could mimic those input patterns, a technique which has been used in popular culture in the creation of Deepfake videos and [This Person Does Not Exist](https://thispersondoesnotexist.com).""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ContinuousAuthenticationByAnalysisOfKeyboardTypingCharacteristics_BradfordUniv.,UK>,
         :Reference-www.biometric-solutions.com_keystroke-dynamics .
@@ -11728,7 +11728,7 @@ Given some example of legitimate behavioral input patterns, attackers could mimi
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-IBTL" ;
     :definition "Instance-based transfer learning methods try to reweight the samples in the source domain in an attempt to correct for marginal distribution differences. These reweighted instances are then directly used in the target domain for training." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.com/georgian-impact-blog/transfer-learning-part-1-ed0c174ad6e7#:~:text=Homogeneous%20Transfer%20Learning-,1.,the%20target%20domain%20for%20training).""" .
 
 :InstantMessagingClient a owl:Class ;
@@ -11747,15 +11747,15 @@ Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.co
             owl:someValuesFrom :IntranetNetwork ] ;
     :d3fend-id "D3-IHN" ;
     :definition "The practice of setting decoys in a production environment to entice interaction from attackers." ;
-    :kb-article """## How it works\r
-Integrated honeynets use full production environments connected to the enterprise network, that utilize computing resources or software that attract attackers, and allow full interaction and access that provides a complete view of an attack.\r
-\r
-## Considerations\r
-An attacker with control of a system on an Integrated Honeynet could:\r
-* try to attack other connected hosts on the network, its IP range of internal hosts not properly configured to react to connections from machines on the integrated honeynet, or position behind the firewall.\r
-* exploit its position by eavesdropping on network traffic\r
-If an attacker manages to stop the processes used to log an attack without setting off any alarms. [1]\r
-\r
+    :kb-article """## How it works
+Integrated honeynets use full production environments connected to the enterprise network, that utilize computing resources or software that attract attackers, and allow full interaction and access that provides a complete view of an attack.
+
+## Considerations
+An attacker with control of a system on an Integrated Honeynet could:
+* try to attack other connected hosts on the network, its IP range of internal hosts not properly configured to react to connections from machines on the integrated honeynet, or position behind the firewall.
+* exploit its position by eavesdropping on network traffic
+If an attacker manages to stop the processes used to log an attack without setting off any alarms. [1]
+
 1. Honeypots for Windows, Roger Grimes, 2005""" ;
     :kb-reference :Reference-SynchronizingAHoneyNetworkConfigurationToReflectATargetNetworkEnvironment_PaloAltoNetworksInc .
 
@@ -11816,7 +11816,7 @@ If an attacker manages to stop the processes used to log an attack without setti
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-IR" ;
     :definition "The interquartile range (IQR) is a measure of statistical dispersion, which is the spread of the data and is defined as the difference between the 75th and 25th percentiles of the data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Interquartile range. [Link](https://en.wikipedia.org/wiki/Interquartile_range)""" ;
     :synonym "IQR" .
 
@@ -11826,7 +11826,7 @@ Wikipedia. (n.d.). Interquartile range. [Link](https://en.wikipedia.org/wiki/Int
     rdfs:subClassOf :Estimation ;
     :d3fend-id "D3A-IE" ;
     :definition "Interval estimation is the use of sample data to estimate an interval of possible values of a parameter of interest." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Interval estimation. [Link](https://en.wikipedia.org/wiki/Interval_estimation)""" .
 
 :IntranetAdministrativeNetworkTraffic a owl:Class ;
@@ -11904,7 +11904,7 @@ Wikipedia. (n.d.). Interval estimation. [Link](https://en.wikipedia.org/wiki/Int
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-ISSL" ;
     :definition "These methods directly optimize an objective function with components for labeled and unlabeled samples and do not rely on any intermediate steps or supervised base learners. Basically, these methods are extension of existing supervised methods to include the effect of unlabeled data samples in the objective function." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Beginner's Guide to Semi-Supervised Learning. Jashish Blog.  [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/).""" .
 
 :IntrusionDetectionSystem a owl:Class ;
@@ -11921,8 +11921,8 @@ Beginner's Guide to Semi-Supervised Learning. Jashish Blog.  [Link](http://jashi
         "IPS" ;
     rdfs:subClassOf :IntrusionDetectionSystem ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Intrusion_detection_system#Intrusion_prevention> ;
-    :definition """Intrusion prevention systems (IPS), also known as intrusion detection and prevention systems (IDPS), are network security appliances that monitor network or system activities for malicious activity. The main functions of intrusion prevention systems are to identify malicious activity, log information about this activity, report it and attempt to block or stop it.\r
-\r
+    :definition """Intrusion prevention systems (IPS), also known as intrusion detection and prevention systems (IDPS), are network security appliances that monitor network or system activities for malicious activity. The main functions of intrusion prevention systems are to identify malicious activity, log information about this activity, report it and attempt to block or stop it.
+
 Intrusion prevention systems are considered extensions of intrusion detection systems because they both monitor network traffic and/or system activities for malicious activity. The main differences are, unlike intrusion detection systems, intrusion prevention systems are placed in-line and are able to actively prevent or block intrusions that are detected. IPS can take such actions as sending an alarm, dropping detected malicious packets, resetting a connection or blocking traffic from the offending IP address. An IPS also can correct cyclic redundancy check (CRC) errors, defragment packet streams, mitigate TCP sequencing issues, and clean up unwanted transport and network layer options.""" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Intrusion_detection_system> .
 
@@ -11939,21 +11939,21 @@ Intrusion prevention systems are considered extensions of intrusion detection sy
             owl:someValuesFrom :RemovableMediaDevice ] ;
     :d3fend-id "D3-IOPR" ;
     :definition "Limiting access to computer input/output (IO) ports to restrict unauthorized devices." ;
-    :kb-article """## How It works\r
-\r
-Software-based restriction uses agent software installed on a computer system. The agent software monitors all IO port system traffic. The agent software is configurable to limit the use of certain devices connected to IO ports. The restriction software can also be configured to limit the access to files and applications on external storage devices connected to IO ports.\r
-\r
-Hardware-based restriction can also be employed to limit access to IO ports. For example, a hardware USB filter device that is placed between the host system and the external devices can filter IO port connections based on configurable rules. When new devices are connected to the USB filter the type of device is determined. Using an allow list a connection determination is made for the device.\r
-\r
-Some implementations detect when a device is connected in order to authorize the connection against a list of approved devices, in some cases by device type. For example, if the device is determined to be a storage device, then the contained files and executables are examined to more accurately identify the device type.\r
-\r
-Types of restrictions that may be applied:\r
-- Device connection\r
-- Device command filtering\r
-- Device file system read or write restrictions\r
-\r
-## Considerations\r
- * Agent software will need to be installed on host systems\r
+    :kb-article """## How It works
+
+Software-based restriction uses agent software installed on a computer system. The agent software monitors all IO port system traffic. The agent software is configurable to limit the use of certain devices connected to IO ports. The restriction software can also be configured to limit the access to files and applications on external storage devices connected to IO ports.
+
+Hardware-based restriction can also be employed to limit access to IO ports. For example, a hardware USB filter device that is placed between the host system and the external devices can filter IO port connections based on configurable rules. When new devices are connected to the USB filter the type of device is determined. Using an allow list a connection determination is made for the device.
+
+Some implementations detect when a device is connected in order to authorize the connection against a list of approved devices, in some cases by device type. For example, if the device is determined to be a storage device, then the contained files and executables are examined to more accurately identify the device type.
+
+Types of restrictions that may be applied:
+- Device connection
+- Device command filtering
+- Device file system read or write restrictions
+
+## Considerations
+ * Agent software will need to be installed on host systems
  * Configurations for allow/deny for devices and files will need to be maintained""" ;
     :kb-reference :Reference-ComputerMotherboardHavingPeripheralSecurityFunctions,
         :Reference-MethodAndSystemForControllingCommunicationPorts,
@@ -11983,17 +11983,17 @@ Types of restrictions that may be applied:\r
             owl:someValuesFrom :IntranetIPCNetworkTraffic ] ;
     :d3fend-id "D3-IPCTA" ;
     :definition "Analyzing standard inter process communication (IPC) protocols to detect deviations from normal protocol activity." ;
-    :kb-article """## How it works\r
-Inter process communication enables applications or threads to share data. This can involve one or more computers. Monitoring IPC in your environment can reveal abnormal or malicious activity.\r
-IPC can occur within a single computer or between multiple computers remotely through network protocols. Thus there are multiple ways to collect and monitor these exchanges between processes. A network protocol analyzer may monitor and parse SMB network traffic to record system activity. A host based monitoring agent may monitor IPC activity contained within a single host to look for deviations from standard usages.\r
-\r
-### Examples\r
- * SMB\r
- * Zeromq\r
- * Java RMI API\r
-\r
-## Considerations\r
-* IPC can generate substantial amounts of data, and it may not be feasible to collect all of it.\r
+    :kb-article """## How it works
+Inter process communication enables applications or threads to share data. This can involve one or more computers. Monitoring IPC in your environment can reveal abnormal or malicious activity.
+IPC can occur within a single computer or between multiple computers remotely through network protocols. Thus there are multiple ways to collect and monitor these exchanges between processes. A network protocol analyzer may monitor and parse SMB network traffic to record system activity. A host based monitoring agent may monitor IPC activity contained within a single host to look for deviations from standard usages.
+
+### Examples
+ * SMB
+ * Zeromq
+ * Java RMI API
+
+## Considerations
+* IPC can generate substantial amounts of data, and it may not be feasible to collect all of it.
 * IPC may occur over loopback interfaces or direct memory access granted by the operating system.""" ;
     :kb-reference :Reference-CAR-2015-04-001%3ARemotelyScheduledTasksViaAT_MITRE,
         :Reference-SecuritySystemWithMethodologyForInterprocessCommunicationControl_CheckPointSoftwareTechInc,
@@ -12057,10 +12057,10 @@ IPC can occur within a single computer or between multiple computers remotely th
             owl:someValuesFrom :Authorization ] ;
     :d3fend-id "D3-JFAPA" ;
     :definition "Detecting anomalies in user access patterns by comparing user access activity to behavioral profiles that categorize users by role such as job title, function, department." ;
-    :kb-article """## How it works\r
-Peer group analysis identifies functionally similar groups of actors (users or resources) based on categorizations such as job title, organizational hierarchy, or other attribute that indicates similarity of job function. Current user access activity is then compared to the appropriate peer group behavior profile to identify anomalies.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Peer group analysis identifies functionally similar groups of actors (users or resources) based on categorizations such as job title, organizational hierarchy, or other attribute that indicates similarity of job function. Current user access activity is then compared to the appropriate peer group behavior profile to identify anomalies.
+
+## Considerations
 Potential for false positives from anomalies that are not associated with malicious activity.""" ;
     :kb-reference :Reference-AnomalyDetectionUsingAdaptiveBehavioralProfiles_SecuronixInc .
 
@@ -12106,7 +12106,7 @@ Potential for false positives from anomalies that are not associated with malici
     rdfs:subClassOf :ResamplingEnsemble ;
     :d3fend-id "D3A-KFCV" ;
     :definition "Cross-validation is a resampling procedure used to evaluate machine learning models on a limited data sample. The procedure has a single parameter called k that refers to the number of groups that a given data sample is to be split into. As such, the procedure is often called k-fold cross-validation. When a specific value for k is chosen, it may be used in place of k in the reference to the model, such as k=10 becoming 10-fold cross-validation" ;
-    :kb-article """## References\r
+    :kb-article """## References
 K-Fold Cross-Validation. Machine Learning Mastery.  [Link](https://machinelearningmastery.com/k-fold-cross-validation/#:~:text=Cross%2Dvalidation%20is%20a%20resampling,k%2Dfold%20cross%2Dvalidation).""" .
 
 :K-meansClustering a owl:Class,
@@ -12115,7 +12115,7 @@ K-Fold Cross-Validation. Machine Learning Mastery.  [Link](https://machinelearni
     rdfs:subClassOf :Centroid-basedClustering ;
     :d3fend-id "D3A-KMC" ;
     :definition "K-means algorithm identifies k number of centroids, and then allocates every data point to the nearest cluster, while keeping the centroids as small as possible." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Towards Data Science. (n.d.). Understanding K-means Clustering in Machine Learning. [Link](https://towardsdatascience.com/understanding-k-means-clustering-in-machine-learning-6a6e67336aa1)""" .
 
 :K-NearestNeighbors a owl:Class,
@@ -12124,11 +12124,11 @@ Towards Data Science. (n.d.). Understanding K-means Clustering in Machine Learni
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-KNN" ;
     :definition "The k-nearest neighbors algorithm, also known as KNN or k-NN, is a non-parametric, supervised learning classifier, which uses proximity to make classifications or predictions about the grouping of an individual data point." ;
-    :kb-article """## How it works\r
-For classification problems, a class label is assigned on the basis of a majority vote-i.e. the label that is most frequently represented around a given data point is used. While this is technically considered “plurality voting”, the term, “majority vote” is more commonly used in literature. The distinction between these terminologies is that “majority voting” technically requires a majority of greater than 50%, which primarily works when there are only two categories. When you have multiple classes-e.g. four categories, you don’t necessarily need 50% of the vote to make a conclusion about a class; you could assign a class label with a vote of greater than 25%.\r
-\r
-\r
-## References\r
+    :kb-article """## How it works
+For classification problems, a class label is assigned on the basis of a majority vote-i.e. the label that is most frequently represented around a given data point is used. While this is technically considered “plurality voting”, the term, “majority vote” is more commonly used in literature. The distinction between these terminologies is that “majority voting” technically requires a majority of greater than 50%, which primarily works when there are only two categories. When you have multiple classes-e.g. four categories, you don’t necessarily need 50% of the vote to make a conclusion about a class; you could assign a class label with a vote of greater than 25%.
+
+
+## References
 K-Nearest Neighbors (k-NN). IBM. [Link](https://www.ibm.com/topics/knn?mhsrc=ibmsearch_a&mhq=k-nearest%20neighbors%20).""" .
 
 :KendallsRankCorrelationCoefficient a owl:Class,
@@ -12138,8 +12138,8 @@ K-Nearest Neighbors (k-NN). IBM. [Link](https://www.ibm.com/topics/knn?mhsrc=ibm
     rdfs:isDefinedBy "https://reference.wolfram.com/language/ref/KendallTau.html" ;
     :d3fend-id "D3A-KRCC" ;
     :definition "Kendall's $\\\\tau$ between and is given by $(n_c - n_d) / \\\\sqrt((n_c+n_d+n_x)(n_c+n_d+n_y)$, where is the number of concordant pairs of observations, is the number of discordant pairs, is the number of ties involving only the variable, and is the number of ties involving only the variable.\" ;" ;
-    :kb-article """## References\r
-1. Wolfram Research. (2012). KendallTau. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/KendallTau.html)\r
+    :kb-article """## References
+1. Wolfram Research. (2012). KendallTau. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/KendallTau.html)
 1. Kendall's Tau. (2023, May 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Kendall_rank_correlation_coefficient]\"\"\",""" ;
     :synonym "Kendall's Tau Coefficient" .
 
@@ -12209,8 +12209,8 @@ K-Nearest Neighbors (k-NN). IBM. [Link](https://www.ibm.com/topics/knn?mhsrc=ibm
         "Loadable Kernel Module" ;
     rdfs:subClassOf :ObjectFile ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Loadable_kernel_module> ;
-    :definition """A loadable kernel module (LKM) is an object file that contains code to extend the running kernel, or so-called base kernel, of an operating system. LKMs are typically used to add support for new hardware (as device drivers) and/or filesystems, or for adding system calls. When the functionality provided by a LKM is no longer required, it can be unloaded in order to free memory and other resources.\r
-\r
+    :definition """A loadable kernel module (LKM) is an object file that contains code to extend the running kernel, or so-called base kernel, of an operating system. LKMs are typically used to add support for new hardware (as device drivers) and/or filesystems, or for adding system calls. When the functionality provided by a LKM is no longer required, it can be unloaded in order to free memory and other resources.
+
 Most current Unix-like systems and Microsoft Windows support loadable kernel modules, although they might use a different name for them, such as kernel loadable module (kld) in FreeBSD, kernel extension (kext) in macOS,[1] kernel extension module in AIX, kernel-mode driver in Windows NT[2] and downloadable kernel module (DKM) in VxWorks. They are also known as kernel loadable modules (or KLM), and simply as kernel modules (KMOD).""" ;
     rdfs:seeAlso "https://schema.ocsf.io/objects/kernel_driver" .
 
@@ -12243,7 +12243,7 @@ Most current Unix-like systems and Microsoft Windows support loadable kernel mod
     rdfs:subClassOf :DistributionProperties ;
     :d3fend-id "D3A-KUR" ;
     :definition "The measure of the \"fatness\" of the tails of a pmf or pdf. The fourth standardized moment of the distribution." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wiki/Probability_distribution)""" .
 
 :LaptopComputer a owl:Class ;
@@ -12286,7 +12286,7 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
     rdfs:subClassOf :ApproximateStringMatching ;
     :d3fend-id "D3A-LM" ;
     :definition "The Levenshtein distance (LD) is a metric for measuring the differences between two sequences - or strings. Informally, the LD is the number of individual edits one would have to make to turn one sequence into another." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Navarro, G. (2001). A guided tour to approximate string matching. _ACM Computing Surveys_, 33(1), 31-88. [Link](https://doi.org/10.1145/375360.375365)""" ;
     :synonym "Edit Distance" .
 
@@ -12301,7 +12301,7 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-LC" ;
     :definition "A linear classifier is a model that makes a decision to categories a set of data points to a discrete class based on a linear combination of its explanatory variables" ;
-    :kb-article """## References\r
+    :kb-article """## References
 A Look at the Maths Behind Linear Classification. Towards Data Science. [Link](https://towardsdatascience.com/a-look-at-the-maths-behind-linear-classification-166e99a9e5fb).""" .
 
 :LinearLogicProgramming a owl:Class,
@@ -12310,8 +12310,8 @@ A Look at the Maths Behind Linear Classification. Towards Data Science. [Link](h
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-LLP" ;
     :definition "Linear logic programming is a form of logic programming that uses linear logic, that is, it emphasizes the use of formulas as resources." ;
-    :kb-article """## References\r
-1. Cosmo, R. and Miller D. (2019, May 24). _Linear logic_. Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-linear/#LinLogComSci)\r
+    :kb-article """## References
+1. Cosmo, R. and Miller D. (2019, May 24). _Linear logic_. Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-linear/#LinLogComSci)
 2. Linear logic programming. (2023, May 16). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Logic_programming#Linear_logic_programming)""" .
 
 :LinearRegression a owl:Class,
@@ -12320,34 +12320,34 @@ A Look at the Maths Behind Linear Classification. Towards Data Science. [Link](h
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-LR" ;
     :definition "Statistical regression method used for predictive analysis by modeling the linear relationship between independent and dependent variables." ;
-    :kb-article """## How it works\r
-Takes independent variables (i.e. covariate, features, predictors, input variables) and dependent variables (i.e. response, output, “thing to be estimated”) and produces the coefficient(s) and intercept for a linear equation (e.g. (β1, β0) for y = β1x + β0) which predicts the relationship between the independent and independent variables by minimizing a cost function, Mean Squared Error, either directly in the case of univariate linear regression or by gradient descent* in the case of multivariate linear regression.\r
-\r
-## Considerations\r
- - There are four principal assumptions required for good results using linear regression (the first letters of the four principal assumptions form the "LINE" mnemonic):\r
-   - Linearity and Additivity\r
-   - Independent Residuals\r
-   - Normal Residual Distributions\r
-   - Equal Variances (i.e. homoscedasticity)\r
- - Linear regression is a low variance/high bias model.\r
- - Optimizers like Adam, Batch, and Mini-Batch and others are available for certain applications and data sets.\r
-- A large learning ratio or training coefficient may lead to divergent behavior of the model and too small of values may lead to long run times and inefficiency.\r
-\r
-\r
-## Verification Approach\r
- - Models are often evaluated by examining one or more of the metrics of R2, Root Mean Squared Error (RMSE), Mean Absolute Error (MAE), and Mean Absolute Percentage Error (MAPE).\r
- - While there is no generally accepted single best performance metric as a criterion, users of linear regression should consider the suitability of one or more of these metrics for assessing the performance of their model.\r
- - Use well known data sets to verify model execution.\r
-\r
-## Validation Approach\r
- - Violating the principal assumptions of linear regression results in poor or misleading results.\r
- - Ensure data is truly representative and if there are any known biases.\r
-\r
-\r
-## References\r
-1. Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.\r
-1. Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.\r
-1. Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.\r
+    :kb-article """## How it works
+Takes independent variables (i.e. covariate, features, predictors, input variables) and dependent variables (i.e. response, output, “thing to be estimated”) and produces the coefficient(s) and intercept for a linear equation (e.g. (β1, β0) for y = β1x + β0) which predicts the relationship between the independent and independent variables by minimizing a cost function, Mean Squared Error, either directly in the case of univariate linear regression or by gradient descent* in the case of multivariate linear regression.
+
+## Considerations
+ - There are four principal assumptions required for good results using linear regression (the first letters of the four principal assumptions form the "LINE" mnemonic):
+   - Linearity and Additivity
+   - Independent Residuals
+   - Normal Residual Distributions
+   - Equal Variances (i.e. homoscedasticity)
+ - Linear regression is a low variance/high bias model.
+ - Optimizers like Adam, Batch, and Mini-Batch and others are available for certain applications and data sets.
+- A large learning ratio or training coefficient may lead to divergent behavior of the model and too small of values may lead to long run times and inefficiency.
+
+
+## Verification Approach
+ - Models are often evaluated by examining one or more of the metrics of R2, Root Mean Squared Error (RMSE), Mean Absolute Error (MAE), and Mean Absolute Percentage Error (MAPE).
+ - While there is no generally accepted single best performance metric as a criterion, users of linear regression should consider the suitability of one or more of these metrics for assessing the performance of their model.
+ - Use well known data sets to verify model execution.
+
+## Validation Approach
+ - Violating the principal assumptions of linear regression results in poor or misleading results.
+ - Ensure data is truly representative and if there are any known biases.
+
+
+## References
+1. Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.
+1. Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.
+1. Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.
 1. Bochkarev, Alexei. "A New Typology Design of Performance Metrics to Measure Errors in Machine Learning Regression Algorithms", 2019, https://www.researchgate.net/publication/330661543_A_New_Typology_Design_of_Performance_Metrics_to_Measure_Errors_in_Machine_Learning_Regression_Algorithms.""" .
 
 :LinearRegressionLearning a owl:Class,
@@ -12356,10 +12356,10 @@ Takes independent variables (i.e. covariate, features, predictors, input variabl
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-LRL" ;
     :definition "A supervised learning method that builds a linear regression model using training data." ;
-    :kb-article """## References\r
-- Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.\r
-- Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.\r
-- Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.\r
+    :kb-article """## References
+- Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.
+- Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.
+- Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.
 - Bochkarev, Alexei. "A New Typology Design of Performance Metrics to Measure Errors in Machine Learning Regression Algorithms", 2019, https://www.researchgate.net/publication/330661543_A_New_Typology_Design_of_Performance_Metrics_to_Measure_Errors_in_Machine_Learning_Regression_Algorithms.""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#LinearRegression" .
 
@@ -12384,8 +12384,8 @@ Takes independent variables (i.e. covariate, features, predictors, input variabl
     rdfs:label "Linux Clone3" ;
     rdfs:subClassOf :CreateProcess ;
     rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/clone3.2.html" ;
-    :definition """Creates a child process and provides more precise control over the data shared between the parent and child processes.\r
-\r
+    :definition """Creates a child process and provides more precise control over the data shared between the parent and child processes.
+
 Newer system call.""" .
 
 :LinuxClone3ArgumentCLONE_THREAD a owl:Class ;
@@ -12689,10 +12689,10 @@ Newer system call.""" .
             owl:onProperty :contains ;
             owl:someValuesFrom :Log ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Log_file> ;
-    :definition """A log file is a file that records either events that occur in an operating system or other software runs, or messages between different users of a communication software. Logging is the act of keeping a log. In the simplest case, messages are written to a single log file.\r
-\r
-A transaction log is a file (i.e., log) of the communications between a system and the users of that system, or a data collection method that automatically captures the type, content, or time of transactions made by a person from a terminal with that system. For Web searching, a transaction log is an electronic record of interactions that have occurred during a searching episode between a Web search engine and users searching for information on that Web search engine.\r
-\r
+    :definition """A log file is a file that records either events that occur in an operating system or other software runs, or messages between different users of a communication software. Logging is the act of keeping a log. In the simplest case, messages are written to a single log file.
+
+A transaction log is a file (i.e., log) of the communications between a system and the users of that system, or a data collection method that automatically captures the type, content, or time of transactions made by a person from a terminal with that system. For Web searching, a transaction log is an electronic record of interactions that have occurred during a searching episode between a Web search engine and users searching for information on that Web search engine.
+
 Many operating systems, software frameworks and programs include a logging system. A widely used logging standard is syslog, defined in Internet Engineering Task Force (IETF) RFC 5424). The syslog standard enables a dedicated, standardized subsystem to generate, filter, record, and analyze log messages. This relieves software developers of having to design and code their own ad hoc logging systems.""" ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/06515875-n> .
 
@@ -12724,9 +12724,9 @@ Many operating systems, software frameworks and programs include a logging syste
     rdfs:subClassOf :SymbolicLogic ;
     :d3fend-id "D3A-LR" ;
     :definition "A logical rule matches event data or set of values to a conditional expression and results in the determination of a truth value, which may be used to determine the next action or step to take." ;
-    :kb-article """## References\r
-1. Event condition action. (2019, Nov 21). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Event_condition_action)\r
-2. Business rule. (2023, April 10). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Business_rule)\r
+    :kb-article """## References
+1. Event condition action. (2019, Nov 21). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Event_condition_action)
+2. Business rule. (2023, April 10). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Business_rule)
 3. YARA. (2023, June 5). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/YARA)""" .
 
 :LogicProgramming a owl:Class,
@@ -12735,12 +12735,12 @@ Many operating systems, software frameworks and programs include a logging syste
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-LP" ;
     :definition "Logic programming is a programming paradigm which is largely based on formal logic." ;
-    :kb-article """## How it works\r
-Any program written in a logic programming language is a set of sentences in logical form, expressing facts and rules about some problem domain. Major logic programming language families include Prolog, answer set programming (ASP) and Datalog. In all of these languages, rules are written in the form of clauses:\r
-\r
-H :- B_1, ..., B_n.\r
-\r
-## References\r
+    :kb-article """## How it works
+Any program written in a logic programming language is a set of sentences in logical form, expressing facts and rules about some problem domain. Major logic programming language families include Prolog, answer set programming (ASP) and Datalog. In all of these languages, rules are written in the form of clauses:
+
+H :- B_1, ..., B_n.
+
+## References
 1. Logic programming. (2023, May 29). In _Wikipedia_. [Link]( https://en.wikipedia.org/wiki/Logic_programming)""" .
 
 :LoginSession a owl:Class ;
@@ -12755,7 +12755,7 @@ H :- B_1, ..., B_n.\r
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-LR" ;
     :definition "Logistic regression is estimating the parameters of a logistic model." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Logistic_regression)""" .
 
 :LogististicRegressionLearning a owl:Class,
@@ -12764,7 +12764,7 @@ Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Log
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-LRL" ;
     :definition "A supervised learning method that builds a logistic regression model using training data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Logistic_regression)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#LogisticRegression" .
 
@@ -12786,7 +12786,7 @@ Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Log
     rdfs:subClassOf :RecurrentNeuralNetwork ;
     :d3fend-id "D3A-LSTM" ;
     :definition "Unlike standard feedforward neural networks, LSTM has feedback connections. Such a recurrent neural network (RNN) can process not only single data points (such as images), but also entire sequences of data (such as speech or video). This characteristic makes LSTM networks ideal for processing and predicting data" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (2021, September 29). Long short-term memory. [Link](https://en.wikipedia.org/wiki/Long_short-term_memory)""" .
 
 :MachineLearning a owl:Class,
@@ -12795,7 +12795,7 @@ Wikipedia. (2021, September 29). Long short-term memory. [Link](https://en.wikip
     rdfs:subClassOf :AnalyticTechnique ;
     :d3fend-id "D3A-ML" ;
     :definition "Machine learning techniques are computational methods that combine statistics, probability, and optimization to make accurate predictions and/or improve performance." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Machine learning." Wikipedia. [Link](https://en.wikipedia.org/wiki/Machine_learning).""" .
 
 :MacOSKeychain a owl:Class ;
@@ -12849,41 +12849,41 @@ Machine learning." Wikipedia. [Link](https://en.wikipedia.org/wiki/Machine_learn
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-MAC" ;
     :definition "Controlling access to local computer system resources with kernel-level capabilities." ;
-    :kb-article """## How it works\r
-Mandatory access control is a non-discretionary access control system because the rules and polices that determine access is determined by a security control authority and not distributed to local users. Access determinations are based on designed access control polices and are not based on local resource owner determinations.\r
-\r
-Access is typically granted by defining sets of subjects and sets of objects. Subjects are the entities requesting access and objects are the resources that subjects are trying to access. Rules and policies are defined that associate subjects and object permissions and access controls.\r
-\r
-### Common MAC implementations\r
-#### Security label access control\r
-A fine-grained form of mandatory access control is to apply security labels to individual resources, including processes, and the access control decisions are against a particular resource and a given user attempting to gain access. This type of MAC requires that the file system has built-in support for security labels.\r
-\r
-Access controls are typically implemented through the use of label identifiers for every file system object. Identifier labels are applied to resources and users are assigned a similar access identifier. Users attempting to access a resource will result in the operating system performing an access control check. The access control check will compare the assigned user's credentials to that of the resource or object they are attempting to access.\r
-\r
-A security context is associated with resources and is used to determine assess. Typical basic access control elements include users, roles and types and together they form a security context which is the basis for the security labels.\r
-\r
-This type of access control is what is employed in SELinux [2]. This form of MAC is considered the most flexible implementation, but it also is the most complex to deploy across the enterprise. Where multiple virtual machines (VM) are run together this type of access control is typically employed to ensure true isolation of processes and VMs.\r
-\r
-#### File path level controls\r
-A less fine-grained form of mandatory access control is to apply security labels that allow for access control at the file path level.  Access control is filesystem agnostic and no relabeling of resources is required. Pathname access control usually seems more natural for implementation and corresponding access audits.\r
-\r
-This type of MAC is what is employed in AppArmor [3]. AppArmor was developed to provide a simpler alternative MAC method with much less management overhead. A simple access policy is maintained that defines path resource access rules. Access control attributes are typically associated with programs instead of users.\r
-\r
-\r
-## Considerations\r
-Some implementations of security label mandatory access control contain complex rules set that are hard to verify and complex to maintain over time.\r
-\r
-Initial planning of access model and continuous monitoring of the available users, resources and object is necessary.\r
-\r
-## Implementations\r
-\r
- * Linux C-Groups, and policy engines like SELinux and AppArmor\r
- * Windows Mandatory Integrity Control introduced in Windows Vista\r
-\r
-\r
-### Citations\r
-1. [Implementation of Mandatory Access Control in Distributed Systems](https://link.springer.com/article/10.3103/S0146411618080357)\r
-2. [SELinux](https://selinuxproject.org/)\r
+    :kb-article """## How it works
+Mandatory access control is a non-discretionary access control system because the rules and polices that determine access is determined by a security control authority and not distributed to local users. Access determinations are based on designed access control polices and are not based on local resource owner determinations.
+
+Access is typically granted by defining sets of subjects and sets of objects. Subjects are the entities requesting access and objects are the resources that subjects are trying to access. Rules and policies are defined that associate subjects and object permissions and access controls.
+
+### Common MAC implementations
+#### Security label access control
+A fine-grained form of mandatory access control is to apply security labels to individual resources, including processes, and the access control decisions are against a particular resource and a given user attempting to gain access. This type of MAC requires that the file system has built-in support for security labels.
+
+Access controls are typically implemented through the use of label identifiers for every file system object. Identifier labels are applied to resources and users are assigned a similar access identifier. Users attempting to access a resource will result in the operating system performing an access control check. The access control check will compare the assigned user's credentials to that of the resource or object they are attempting to access.
+
+A security context is associated with resources and is used to determine assess. Typical basic access control elements include users, roles and types and together they form a security context which is the basis for the security labels.
+
+This type of access control is what is employed in SELinux [2]. This form of MAC is considered the most flexible implementation, but it also is the most complex to deploy across the enterprise. Where multiple virtual machines (VM) are run together this type of access control is typically employed to ensure true isolation of processes and VMs.
+
+#### File path level controls
+A less fine-grained form of mandatory access control is to apply security labels that allow for access control at the file path level.  Access control is filesystem agnostic and no relabeling of resources is required. Pathname access control usually seems more natural for implementation and corresponding access audits.
+
+This type of MAC is what is employed in AppArmor [3]. AppArmor was developed to provide a simpler alternative MAC method with much less management overhead. A simple access policy is maintained that defines path resource access rules. Access control attributes are typically associated with programs instead of users.
+
+
+## Considerations
+Some implementations of security label mandatory access control contain complex rules set that are hard to verify and complex to maintain over time.
+
+Initial planning of access model and continuous monitoring of the available users, resources and object is necessary.
+
+## Implementations
+
+ * Linux C-Groups, and policy engines like SELinux and AppArmor
+ * Windows Mandatory Integrity Control introduced in Windows Vista
+
+
+### Citations
+1. [Implementation of Mandatory Access Control in Distributed Systems](https://link.springer.com/article/10.3103/S0146411618080357)
+2. [SELinux](https://selinuxproject.org/)
 3. [AppArmor](https://www.apparmor.net/)""" ;
     :kb-reference :Reference-AnalysisOfTheWindowsVistaSecurityModel_SymantecCorporation,
         :Reference-ArchitectureOfTransparentNetworkSecurityForApplicationContainers_NeuvectorInc .
@@ -12903,9 +12903,9 @@ Initial planning of access model and continuous monitoring of the available user
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-MML" ;
     :definition "Maximum-margin classifiers attempt to maximize the distance between the given data points and the decision boundary" ;
-    :kb-article """## References\r
-Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Learning, 109(2), 299-337. [Link](https://link.springer.com/article/10.1007/s10994-019-05855-6).\r
-\r
+    :kb-article """## References
+Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Learning, 109(2), 299-337. [Link](https://link.springer.com/article/10.1007/s10994-019-05855-6).
+
 Support Vector Machines for Machine Learning. [Link](https://machinelearningmastery.com/support-vector-machines-for-machine-learning/#:~:text=The%20distance%20between%20the%20line,called%20the%20Maximal%2DMargin%20hyperplane.)""" .
 
 :Mean a owl:Class,
@@ -12914,7 +12914,7 @@ Support Vector Machines for Machine Learning. [Link](https://machinelearningmast
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-MEA" ;
     :definition "The sum of all measurements divided by the number of observations in the data set." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :MeanAbsoluteDeviation a owl:Class,
@@ -12923,7 +12923,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :AverageAbsoluteDeviation ;
     :d3fend-id "D3A-MAD" ;
     :definition "The mean absolute deviation (MAD), also referred to as the \"mean deviation\" or sometimes \"average absolute deviation\", is the mean of the data's absolute deviations around the data's mean: the average (absolute) distance from the mean." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/wiki/Average_absolute_deviation)""" ;
     :synonym "MAD" .
 
@@ -12938,7 +12938,7 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-MED" ;
     :definition "The middle value that separates the higher half from the lower half of the data set. The median and the mode are the only measures of central tendency that can be used for ordinal data, in which values are ranked relative to each other but are not measured absolutely." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :MedianAbsoluteDeviation a owl:Class,
@@ -12947,7 +12947,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :AverageAbsoluteDeviation ;
     :d3fend-id "D3A-MAD" ;
     :definition "The median absolute deviation (also MAD) is the median of the absolute deviation from the median." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/wiki/Average_absolute_deviation)""" .
 
 :MediaServer a owl:Class ;
@@ -13003,10 +13003,10 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
             owl:someValuesFrom :ProcessCodeSegment ] ;
     :d3fend-id "D3-MBT" ;
     :definition "Analyzing a call stack for return addresses which point to unexpected  memory locations." ;
-    :kb-article """## How it works\r
-This technique monitors for indicators of whether a return address is outside memory previously allocated for an object (i.e. function, module, process, or thread). If so, code that the return address points to is treated as malicious code.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+This technique monitors for indicators of whether a return address is outside memory previously allocated for an object (i.e. function, module, process, or thread). If so, code that the return address points to is treated as malicious code.
+
+## Considerations
 Kernel malware can manipulate memory contents, for example modifying pointers to hide processes, and thereby impact the accuracy of memory allocation information used to perform the analysis.""" ;
     :kb-reference :Reference-InferentialExploitAttemptDetection_CrowdstrikeInc .
 
@@ -13075,10 +13075,10 @@ Kernel malware can manipulate memory contents, for example modifying pointers to
     :d3fend-id "D3-MA" ;
     :definition "Analyzing email or instant message content to detect unauthorized activity." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview\r
-\r
-Email and messaging are frequently used to deliver malicious content to targets. These enterprise capabilities are used to deliver software exploits or social engineering tricks. If the recipient of a message trusts the sender, attackers can avoid escalating suspicion.\r
-\r
+    :kb-article """## Technique Overview
+
+Email and messaging are frequently used to deliver malicious content to targets. These enterprise capabilities are used to deliver software exploits or social engineering tricks. If the recipient of a message trusts the sender, attackers can avoid escalating suspicion.
+
 Emails and messages are also complex data structures. They contain files and links, and complex data encodings which vary region to region. Thus the defensive techniques used to analyze emails and messages are highly varied ranging from deep content analysis and execution to social network graph-style analytics to analyze trust or risk.""" ;
     :synonym "Electronic Message Analysis",
         "Email Or Messaging Analysis" .
@@ -13093,17 +13093,17 @@ Emails and messages are also complex data structures. They contain files and lin
             owl:someValuesFrom :UserToUserMessage ] ;
     :d3fend-id "D3-MAN" ;
     :definition "Authenticating the sender of a message and ensuring message integrity." ;
-    :kb-article """## How it works\r
-\r
-### Digital Signature\r
-Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.\r
-\r
-### Message Authentication Code (MAC)\r
-MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.\r
-\r
-## Considerations\r
-- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.\r
-- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.\r
+    :kb-article """## How it works
+
+### Digital Signature
+Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.
+
+### Message Authentication Code (MAC)
+MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.
+
+## Considerations
+- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.
+- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.
 - Symmetric keys must be exchanged securely via a private channel and management of new symmetric keys are needed for each pair of participants wishing to exchange messages.""" ;
     :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
         :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
@@ -13118,16 +13118,16 @@ MAC is a fixed size string that is appended to a message to provide message auth
             owl:someValuesFrom :UserToUserMessage ] ;
     :d3fend-id "D3-MENCR" ;
     :definition "Encrypting a message body using a cryptographic key." ;
-    :kb-article """## How it works\r
-\r
-### Asymmetric Cryptography\r
-Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.\r
-### Symmetric Cryptography\r
-Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient.\r
-\r
-## Considerations\r
-- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).\r
-- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.\r
+    :kb-article """## How it works
+
+### Asymmetric Cryptography
+Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.
+### Symmetric Cryptography
+Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient.
+
+## Considerations
+- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).
+- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
 - Secure transfer of private keys between multiple devices.""" ;
     :kb-reference :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
 
@@ -13187,7 +13187,7 @@ Symmetric encryption uses the same cryptographic key by both the sender and rece
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-ML" ;
     :definition "Modal logic is a collection of formal systems developed to represent statements about necessity and possibility. It plays a major role in philosophy of language, epistemology, metaphysics, and natural language semantics." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Modal logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic)""" .
 
 :Mode a owl:Class,
@@ -13196,7 +13196,7 @@ Symmetric encryption uses the same cryptographic key by both the sender and rece
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-MOD" ;
     :definition "The most frequent value in the data set. This is the only central tendency measure that can be used with nominal data, which have purely qualitative category assignments." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :Model a :DefensiveTactic,
@@ -13214,7 +13214,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :Model-basedReinforcementLearning ;
     :d3fend-id "D3A-MBPO" ;
     :definition "Model-based policy optimization (MBPO) is a model-based, online, off-policy reinforcement learning algorithm. For more information on the different types of reinforcement learning agents" ;
-    :kb-article """## References\r
+    :kb-article """## References
 MBPO Agents. MathWorks.  [Link](https://www.mathworks.com/help/reinforcement-learning/ug/mbpo-agents.html).""" .
 
 :Model-basedReinforcementLearning a owl:Class,
@@ -13223,7 +13223,7 @@ MBPO Agents. MathWorks.  [Link](https://www.mathworks.com/help/reinforcement-lea
     rdfs:subClassOf :ReinforcementLearning ;
     :d3fend-id "D3A-MBRL" ;
     :definition "Model-based Reinforcement Learning refers to learning optimal behavior indirectly by learning a model of the environment by taking actions and observing the outcomes that include the next state and the immediate reward. The models predict the outcomes of actions and are used in lieu of or in addition to interaction with the environment to learn optimal policies." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Model-Based Reinforcement Learning. In *Encyclopedia of Machine Learning*, pp. 642-644. Springer, 2010.  [Link](https://link.springer.com/referenceworkentry/10.1007/978-0-387-30164-8_556#:~:text=Model%2Dbased%20Reinforcement%20Learning%20refers,state%20and%20the%20immediate%20reward).""" ;
     :todo "Review: Which definition to use" .
 
@@ -13233,7 +13233,7 @@ Model-Based Reinforcement Learning. In *Encyclopedia of Machine Learning*, pp. 6
     rdfs:subClassOf :Model-basedReinforcementLearning ;
     :d3fend-id "D3A-MBVI" ;
     :definition "Value Iteration effectively reducesthe evaluation stage down to a single sweep of the states. Additionally, to improve things further, it combines the Policy Evaluation and Policy Improvement stages into a single update." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Policy and Value Iteration. Towards Data Science.  [Link](https://towardsdatascience.com/policy-and-value-iteration-78501afb41d2).""" ;
     :synonym "MBVI" .
 
@@ -13243,7 +13243,7 @@ Policy and Value Iteration. Towards Data Science.  [Link](https://towardsdatasci
     rdfs:subClassOf :ReinforcementLearning ;
     :d3fend-id "D3A-MFRL" ;
     :definition "In reinforcement learning (RL), a model-free algorithm (as opposed to a model-based one) is an algorithm which does not use the transition probability distribution (and the reward function) associated with the Markov decision process (MDP),which, in RL, represents the problem to be solved. The transition probability distribution (or transition model) and the reward function are often collectively called the \"model\" of the environment (or MDP), hence the name \"model-free\". A model-free RL algorithm can be thought of as an \"explicit\" trial-and-error algorithm. An example of a model-free algorithm is Q-learning." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Model-free (reinforcement learning). Wikipedia. [Link](https://en.wikipedia.org/wiki/Model-free_(reinforcement_learning)).)""" .
 
 :Modem a owl:Class ;
@@ -13258,7 +13258,7 @@ Model-free (reinforcement learning). Wikipedia. [Link](https://en.wikipedia.org/
     rdfs:subClassOf :DistributionProperties ;
     :d3fend-id "D3A-MOM" ;
     :definition "With a probability distribution function, the the first moment is the expected value, the second central moment is the variance, the third standardized moment is the skewness, and the fourth standardized moment is the kurtosis." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Moment (mathematics). [Link](https://en.wikipedia.org/wiki/Moment_(mathematics))""" ;
     :todo "Split out the different moments as leaves under moments instead of having them and moments at the same level" .
 
@@ -13292,7 +13292,7 @@ Wikipedia. (n.d.). Moment (mathematics). [Link](https://en.wikipedia.org/wiki/Mo
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3A-MAM" ;
     :definition "the moving-average model (MA model) is an approach for modeling univariate time series and specifies that the output variable is cross-correlated with a non-identical to itself random-variable." ;
-    :kb-article """## Refrences\r
+    :kb-article """## Refrences
 Wikipedia. (n.d.). Moving average model. [Link](https://en.wikipedia.org/wiki/Moving_average_model)""" ;
     :synonym "MA Model" .
 
@@ -13306,10 +13306,10 @@ Wikipedia. (n.d.). Moving average model. [Link](https://en.wikipedia.org/wiki/Mo
             owl:someValuesFrom :UserAccount ] ;
     :d3fend-id "D3-MFA" ;
     :definition "Requiring proof of two or more pieces of evidence in order to authenticate a user." ;
-    :kb-article """## How it works\r
-When logging into an account users present two or more credentials that fall into different categories: something you know (password or PIN), something you have (smart card or phone), or something you are (fingerprint).\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+When logging into an account users present two or more credentials that fall into different categories: something you know (password or PIN), something you have (smart card or phone), or something you are (fingerprint).
+
+## Considerations
 MFA configuration steps may vary across accounts and in some cases left up to users to activate and implement.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-MethodAndApparatusForUtilizingATokenForResourceAccess_RsaSecurityInc.> .
 
@@ -13323,7 +13323,7 @@ MFA configuration steps may vary across accounts and in some cases left up to us
     rdfs:subClassOf :ArtificialNeuralNetClassification ;
     :d3fend-id "D3A-MPC" ;
     :definition "A multilayer perceptron (MLP) is a fully connected class of feedforward artificial neural network (ANN).An MLP consists of at least three layers of nodes: an input layer, a hidden layer and an output layer." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Multilayer perceptron. Wikipedia. [Link](https://en.wikipedia.org/wiki/Multilayer_perceptron).""" .
 
 :MultimediaDocumentFile a owl:Class ;
@@ -13338,7 +13338,7 @@ Multilayer perceptron. Wikipedia. [Link](https://en.wikipedia.org/wiki/Multilaye
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-MR" ;
     :definition "Multiple (linear) regression attempts to model the relationship between two or more explanatory variables and a response variable by fitting a linear equation to observed data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Yale University Department of Statistics. (1997-98). Linear regression and multivariate analysis. [Link](http://www.stat.yale.edu/Courses/1997-98/101/linmult.htm)""" ;
     :synonym "Multiple Linear Regression" .
 
@@ -13348,7 +13348,7 @@ Yale University Department of Statistics. (1997-98). Linear regression and multi
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-MRL" ;
     :definition "A supervised learning method that builds a multiple regression model using training data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Yale University Department of Statistics. (1997-98). Linear regression and multivariate analysis. [Link](http://www.stat.yale.edu/Courses/1997-98/101/linmult.htm)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#MultipleRegression" .
 
@@ -13358,7 +13358,7 @@ Yale University Department of Statistics. (1997-98). Linear regression and multi
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-MA" ;
     :definition "Multivariate statistics encompassed the simultaneous observation and analysis of more than one outcome variable, i.e., multivariate random variables." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki/Multivariate_statistics)""" ;
     :todo "Looks like there may be lots to add here." .
 
@@ -13368,7 +13368,7 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-NBC" ;
     :definition "The Naïve Bayes classifier is a supervised machine learning algorithm, which is used for classification tasks, like text classification. It is also part of a family of generative learning algorithms, meaning that it seeks to model the distribution of inputs of a given class or category." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_a&mhq=naive%20bayes).""" .
 
 :Network a owl:Class ;
@@ -13480,21 +13480,21 @@ Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_
             owl:someValuesFrom :NetworkNode ] ;
     :d3fend-id "D3-NNI" ;
     :definition "Network node inventorying identifies and records all the network nodes (hosts, routers, switches, firewalls, etc.) in the organization's architecture." ;
-    :kb-article """## How it works\r
-Administrators collect information on network nodes in their architecture using a variety of administrative and management tools that query network devices and nodes for information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to include host discovery and scanning for active ports and services.\r
-\r
-## Considerations\r
-* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.\r
-* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools\r
-\r
-## Examples\r
-* Link-layer discovery\r
-   * Link-layer Discovery Protocol (LLDP)\r
-   * Cisco Discovery Protocol (CDP)\r
-* Application-layer discovery\r
-   * Simple Network Management Protocol (SNMP) collects MIB information\r
-   * Web-based Enterprise Management (WBEM) collects CIM information\r
-      * Windows Management Instrumentation (WMI)\r
+    :kb-article """## How it works
+Administrators collect information on network nodes in their architecture using a variety of administrative and management tools that query network devices and nodes for information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to include host discovery and scanning for active ports and services.
+
+## Considerations
+* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.
+* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools
+
+## Examples
+* Link-layer discovery
+   * Link-layer Discovery Protocol (LLDP)
+   * Cisco Discovery Protocol (CDP)
+* Application-layer discovery
+   * Simple Network Management Protocol (SNMP) collects MIB information
+   * Web-based Enterprise Management (WBEM) collects CIM information
+      * Windows Management Instrumentation (WMI)
       * Windows Management Infrastructure (MI)""" ;
     :kb-reference :Reference-IEEE-802_1AB-2016,
         :Reference-QualysNetworkPassiveSensorGettingStartedGuide,
@@ -13617,11 +13617,11 @@ Administrators collect information on network nodes in their architecture using 
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-NTCD" ;
     :definition "Establishing baseline communities of network hosts and identifying statistically divergent inter-community communication." ;
-    :kb-article """## How it works\r
-Hosts/users within a computer network are analyzed to identify communities of hosts which frequently communicate. Future communications between communities that don't usually communicate can then be detected.  For example, if a community of hosts that communicate in support of a company's finance division suddenly starts to access the code server usually accessed only by engineers, this may indicate unauthorized activity.\r
-\r
-## Considerations\r
-* Potential for false positives in very dynamic network environments.\r
+    :kb-article """## How it works
+Hosts/users within a computer network are analyzed to identify communities of hosts which frequently communicate. Future communications between communities that don't usually communicate can then be detected.  For example, if a community of hosts that communicate in support of a company's finance division suddenly starts to access the code server usually accessed only by engineers, this may indicate unauthorized activity.
+
+## Considerations
+* Potential for false positives in very dynamic network environments.
 * Attackers that move low and slow may not differentiate their behavior enough to trigger an alert.""" ;
     :kb-reference :Reference-SystemForImplementingThreatDetectionUsingDailyNetworkTrafficCommunityOutliers_VECTRANETWORKSInc .
 
@@ -13704,7 +13704,7 @@ Hosts/users within a computer network are analyzed to identify communities of ho
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-NML" ;
     :definition "Non-monotonic logic is a formal logic whose conclusion relation is not monotonic. In other words, non-monotonic logics are devised to capture and represent defeasible inferences (cf. defeasible reasoning), i.e., a kind of inference in which reasoners draw tentative conclusions, enabling reasoners to retract their conclusion(s) based on further evidence." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Non-monotonic logic. (2023, June 1). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Non-monotonic_logic)""" .
 
 :Non-ParametricTests a owl:Class,
@@ -13713,7 +13713,7 @@ Hosts/users within a computer network are analyzed to identify communities of ho
     rdfs:subClassOf :HypothesisTesting ;
     :d3fend-id "D3A-NPT" ;
     :definition "A non-parametric test relies is used when the underlying distribution of data is non-symmetric (non-normal distribution)." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.ncl.ac.uk/webtemplate/ask-assets/external/maths-resources/psychology/non-parametric-hypothesis-tests.html)""" .
 
 :NonlinearRegression a owl:Class,
@@ -13722,7 +13722,7 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-NR" ;
     :definition "Nonlinear regression is a form of regression analysis in which observational data are modeled by a function which is a nonlinear combination of the model parameters and depends on one or more independent variables." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/Nonlinear_regression)""" .
 
 :NonlinearRegressionLearning a owl:Class,
@@ -13731,7 +13731,7 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-NRL" ;
     :definition "A supervised learning method that builds a non-linear regression model using training data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/Nonlinear_regression)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#NonlinearRegression" .
 
@@ -13823,24 +13823,24 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
             owl:someValuesFrom :Password ] ;
     :d3fend-id "D3-OTP" ;
     :definition "A one-time password is valid for only one user authentication." ;
-    :kb-article """## How it works\r
-\r
-When a user initiates authentication, they are asked for a one-time password, often in addition to other credentials such as a traditional password or smart card. The one-time password may be from a list provided in advance, sent via a channel such as SMS or HTTPS to an app, or a generated token.\r
-\r
-In the case of a physical token which generates one-time passwords incrementally based on time elapsed, that token device need not be connected to the internet. In different implementations, an administrator of the system, or a user with additional verification, can adjust for clock skew between the token and the verification system as needed.\r
-\r
-## Considerations\r
-\r
-### Compromise of delivery channel\r
-- SIM Swapping\r
-- Secure token visual compromise\r
-- Insecure delivery channel\r
-\r
-### Compromise of delivery device\r
-Physical loss of One-time Password device.\r
-\r
-### Compromise of long-term backup codes\r
-These are often provided in the form of a downloadable document with a regular name, which can be searched for in the case that the user forgets where they put them.  This digital file or printed document could be stolen.\r
+    :kb-article """## How it works
+
+When a user initiates authentication, they are asked for a one-time password, often in addition to other credentials such as a traditional password or smart card. The one-time password may be from a list provided in advance, sent via a channel such as SMS or HTTPS to an app, or a generated token.
+
+In the case of a physical token which generates one-time passwords incrementally based on time elapsed, that token device need not be connected to the internet. In different implementations, an administrator of the system, or a user with additional verification, can adjust for clock skew between the token and the verification system as needed.
+
+## Considerations
+
+### Compromise of delivery channel
+- SIM Swapping
+- Secure token visual compromise
+- Insecure delivery channel
+
+### Compromise of delivery device
+Physical loss of One-time Password device.
+
+### Compromise of long-term backup codes
+These are often provided in the form of a downloadable document with a regular name, which can be searched for in the case that the user forgets where they put them.  This digital file or printed document could be stolen.
 Additionally, after the code file is printed, it could be recovered from the system printer spool unless the spooler cache is cleared.""" ;
     :kb-reference :Reference-RFC2289-AOne-TimePasswordSystem ;
     rdfs:seeAlso <http://dbpedia.org/resource/One-time_password> ;
@@ -13933,12 +13933,12 @@ Additionally, after the code file is printed, it could be recovered from the sys
     :d3fend-id "D3-OSM" ;
     :definition "The operating system software, for D3FEND's purposes, includes the kernel and its process management functions, hardware drivers, initialization or boot logic. It also includes and other key system daemons and their configuration. The monitoring or analysis of these components for unauthorized activity constitute **Operating System Monitoring**." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview\r
-\r
-"An operating system (OS) is system software that manages computer hardware and software resources and provides common services for computer programs." [1]\r
-\r
-Operating System Monitoring Techniques have varied implementations including built-in kernel modules, third-party privileged system daemons, or even standard systems administration tools included with an operating system.\r
-\r
+    :kb-article """## Technique Overview
+
+"An operating system (OS) is system software that manages computer hardware and software resources and provides common services for computer programs." [1]
+
+Operating System Monitoring Techniques have varied implementations including built-in kernel modules, third-party privileged system daemons, or even standard systems administration tools included with an operating system.
+
 1. http://dbpedia.org/resource/Operating_system""" ;
     :kb-reference :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
         :Reference-UserActivityFromClearingEventLogs_MITRE .
@@ -14176,31 +14176,31 @@ Operating System Monitoring Techniques have varied implementations including bui
             owl:someValuesFrom :OutboundNetworkTraffic ] ;
     :d3fend-id "D3-OTF" ;
     :definition "Restricting network traffic originating from a private host or enclave destined towards untrusted networks." ;
-    :kb-article """## How it works\r
-\r
-Outbound traffic, in this context, is network traffic originating from a private host or enclave destined towards untrusted networks.\r
-For example:\r
-\r
-* An enterprise desktop intranet user connecting to www.example.com\r
-* An internal mail server connecting to an external mail server, mail.example.com\r
-\r
-Filtering is commonly implemented as firewall rulesets to limit outbound traffic permitted to egress a host or network. Firewalls are deployed either directly on hosts through kernel level software implementations or installed in-line directly on network links. There are benefits and disadvantages to each approach.\r
-\r
-There are various strategies for developing filtering rulesets:\r
-\r
-* Block everything by default\r
-* Limit destination hosts\r
-* Limit destination transport or application protocols\r
-* Restrict content outbound (Ex. strings formatted as social security numbers, or proprietary data)\r
-\r
-## Considerations\r
-* Dynamic IP assignment creates challenges for Outbound Traffic Filtering because users are not necessarily associated with the same IP address. This can be addressed by linking IP address management information with the filtering logic.\r
-* Connections using non-standard transport layer ports may circumvent outbound traffic filtering technology which does not detect application protocol based on traffic content.\r
-* Business requirements typically drive the development of filtering rule sets.\r
-\r
-## Implementations\r
-- iptables (Linux)\r
-- Windows Firewall\r
+    :kb-article """## How it works
+
+Outbound traffic, in this context, is network traffic originating from a private host or enclave destined towards untrusted networks.
+For example:
+
+* An enterprise desktop intranet user connecting to www.example.com
+* An internal mail server connecting to an external mail server, mail.example.com
+
+Filtering is commonly implemented as firewall rulesets to limit outbound traffic permitted to egress a host or network. Firewalls are deployed either directly on hosts through kernel level software implementations or installed in-line directly on network links. There are benefits and disadvantages to each approach.
+
+There are various strategies for developing filtering rulesets:
+
+* Block everything by default
+* Limit destination hosts
+* Limit destination transport or application protocols
+* Restrict content outbound (Ex. strings formatted as social security numbers, or proprietary data)
+
+## Considerations
+* Dynamic IP assignment creates challenges for Outbound Traffic Filtering because users are not necessarily associated with the same IP address. This can be addressed by linking IP address management information with the filtering logic.
+* Connections using non-standard transport layer ports may circumvent outbound traffic filtering technology which does not detect application protocol based on traffic content.
+* Business requirements typically drive the development of filtering rule sets.
+
+## Implementations
+- iptables (Linux)
+- Windows Firewall
 - pf (BSD)""" ;
     :kb-reference :Reference-AutomaticallyGeneratingRulesForConnectionSecurity_Microsoft .
 
@@ -14216,12 +14216,12 @@ There are various strategies for developing filtering rulesets:\r
     rdfs:subClassOf :DescriptionLogic ;
     :d3fend-id "D3A-OWL" ;
     :definition "The Web Ontology Language (OWL) is a family of knowledge representation languages for authoring ontologies." ;
-    :kb-article """## How it works\r
-Ontologies are a formal way to describe taxonomies and classification networks, essentially defining the structure of knowledge for various domains: the nouns representing classes of objects and the verbs representing relations between the objects.\r
-\r
-The OWL languages are characterized by formal semantics. They are built upon the World Wide Web Consortium's (W3C) standard for objects called the Resource Description Framework (RDF). OWL classes correspond to description logic (DL) _concepts_.  OWL properties to DL _roles_, and individuals are named the same way in OWL and other DLs.\r
-\r
-## References\r
+    :kb-article """## How it works
+Ontologies are a formal way to describe taxonomies and classification networks, essentially defining the structure of knowledge for various domains: the nouns representing classes of objects and the verbs representing relations between the objects.
+
+The OWL languages are characterized by formal semantics. They are built upon the World Wide Web Consortium's (W3C) standard for objects called the Resource Description Framework (RDF). OWL classes correspond to description logic (DL) _concepts_.  OWL properties to DL _roles_, and individuals are named the same way in OWL and other DLs.
+
+## References
 1. Web Ontology Language. (2023, April 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Web_Ontology_Language)""" ;
     :synonym "Web Ontology Language" .
 
@@ -14267,7 +14267,7 @@ The OWL languages are characterized by formal semantics. They are built upon the
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-PBTL" ;
     :definition "The idea behind parameter-based methods is that a well-trained model on the source domain has learned a well-defined structure, and if two tasks are related, this structure can be transferred to the target model." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.com/georgian-impact-blog/transfer-learning-part-1-ed0c174ad6e7#:~:text=Homogeneous%20Transfer%20Learning-,1.,the%20target%20domain%20for%20training).""" .
 
 :ParametricTests a owl:Class,
@@ -14276,7 +14276,7 @@ Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.co
     rdfs:subClassOf :HypothesisTesting ;
     :d3fend-id "D3A-PT" ;
     :definition "A parametric test relies upon the assumption that the data you want to test is (or approximately is) normally distributed." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.ncl.ac.uk/webtemplate/ask-assets/external/maths-resources/psychology/parametric-hypothesis-tests.html)""" .
 
 :ParentProcess a owl:Class ;
@@ -14292,7 +14292,7 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
     rdfs:subClassOf :StringPatternMatching ;
     :d3fend-id "D3A-PM" ;
     :definition "Partial string pattern matching is a special case of string pattern matching where one seeks to find a pattern within a larger string (text). It allows for the detection of patterns that occur as substrings or partial segments within the full string, rather than requiring an exact match across the entire string." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""",
         "Numeric pattern matching is a method of matching some defined pattern specification against a numeric value." .
 
@@ -14324,34 +14324,34 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
     :d3fend-id "D3-PCA" ;
     :definition "Collecting host certificates from network traffic or other passive sources like a certificate transparency log and analyzing them for unauthorized activity.",
         "Passively collecting certificates and analyzing them." ;
-    :kb-article """## How it works\r
-Certificates are analyzed outside of a TLS server connection using third-party secure update logs, domain name analysis and analytics.\r
-\r
-### Secure update certificate logs\r
-* Certificate Logs\r
-The key enabling feature is a secure service that maintains record logs of certificate activities. The logs allow users to only append certificates and never to delete or modify the log entries. The logs use Merkle Tree Hashes to ensure they have not been tampered with. The logging service also allows for public auditing by any user.\r
-\r
-The logging service, upon receipt of a certificate to log, will respond with a signed certificate timestamp (SCT). The SCT guarantees the certificate will be added to the log within the time specified. The SCT must be present with the certificate during a TLS handshake.\r
-\r
-* Certificate Monitoring\r
-Certificate monitoring, of the logs, is typically done by the CA and they watch for suspicious certificate logging and unusual certificates or extensions or permissions. Monitors are also responsible for verifying the logs are accurate and public.\r
-\r
-* Certificate Auditors\r
-Log integrity is verified by log auditors. Auditors make use of log proofs are used to validate the cryptographic hashes (Merkle Trees) that the log employs are consistent. In order to ensure consistency throughout multiple monitors and auditors, sharing a common logging service, gossip protocol is employed.\r
-\r
-### Phishing domain name analysis\r
-* A curated corpus of known benign domains and phishing domain names is used as training text for machine learning. Through the use of feature set extraction, vectors labels are created with scoring to indicated if they are considered benign or phishing domains.\r
-\r
-* A stream of new or updated SSL certificates with fully qualified domain names (FQDN) is analyzed against the feature vectors and a predictive model determines a score for the domains. The scoring considers distance measures such as Levenshtein distance to help in determining the final label score. Supervised learning is also employed using the curated domains of benign and phishing domains.\r
-\r
-* Subdomain phishing analysis, prepending a trusted domain to a phishing domain, and regular expression comparisons  are also used in the label scoring model. A tunable measure is used to determine the threshold for alerting. This measure helps to balance between precision and recall measures.\r
-\r
-## Considerations\r
-* Some entity will need to run the logging service and a trusted entity is preferred.\r
-* Certificate Authorities will likely need to monitor the logging service for consistency.\r
-* Certificate revocation is unchanged and remains outside of Certificate Transparency, but certificates needing to be revoked are visible.\r
-* Technique dependent of reliable feed of new and updated certificates\r
-* Some certificate authorities allow for certificates to be registered with wildcards in the FQDN and thus will fail some of the subdomain scoring\r
+    :kb-article """## How it works
+Certificates are analyzed outside of a TLS server connection using third-party secure update logs, domain name analysis and analytics.
+
+### Secure update certificate logs
+* Certificate Logs
+The key enabling feature is a secure service that maintains record logs of certificate activities. The logs allow users to only append certificates and never to delete or modify the log entries. The logs use Merkle Tree Hashes to ensure they have not been tampered with. The logging service also allows for public auditing by any user.
+
+The logging service, upon receipt of a certificate to log, will respond with a signed certificate timestamp (SCT). The SCT guarantees the certificate will be added to the log within the time specified. The SCT must be present with the certificate during a TLS handshake.
+
+* Certificate Monitoring
+Certificate monitoring, of the logs, is typically done by the CA and they watch for suspicious certificate logging and unusual certificates or extensions or permissions. Monitors are also responsible for verifying the logs are accurate and public.
+
+* Certificate Auditors
+Log integrity is verified by log auditors. Auditors make use of log proofs are used to validate the cryptographic hashes (Merkle Trees) that the log employs are consistent. In order to ensure consistency throughout multiple monitors and auditors, sharing a common logging service, gossip protocol is employed.
+
+### Phishing domain name analysis
+* A curated corpus of known benign domains and phishing domain names is used as training text for machine learning. Through the use of feature set extraction, vectors labels are created with scoring to indicated if they are considered benign or phishing domains.
+
+* A stream of new or updated SSL certificates with fully qualified domain names (FQDN) is analyzed against the feature vectors and a predictive model determines a score for the domains. The scoring considers distance measures such as Levenshtein distance to help in determining the final label score. Supervised learning is also employed using the curated domains of benign and phishing domains.
+
+* Subdomain phishing analysis, prepending a trusted domain to a phishing domain, and regular expression comparisons  are also used in the label scoring model. A tunable measure is used to determine the threshold for alerting. This measure helps to balance between precision and recall measures.
+
+## Considerations
+* Some entity will need to run the logging service and a trusted entity is preferred.
+* Certificate Authorities will likely need to monitor the logging service for consistency.
+* Certificate revocation is unchanged and remains outside of Certificate Transparency, but certificates needing to be revoked are visible.
+* Technique dependent of reliable feed of new and updated certificates
+* Some certificate authorities allow for certificates to be registered with wildcards in the FQDN and thus will fail some of the subdomain scoring
 * Phishing HTTP domains will not be discovered""" ;
     :kb-reference :Reference-CertificateTransparency,
         :Reference-StreamingPhish .
@@ -14422,7 +14422,7 @@ Log integrity is verified by log auditors. Auditors make use of log proofs are u
     rdfs:subClassOf :LogicalRules ;
     :d3fend-id "D3A-PM" ;
     :definition "Pattern matching is the act of checking a given sequence of tokens for the presence of the constituents of some pattern." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Pattern matching. (2023, May 20). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Pattern_matching)""" .
 
 :PearsonsCorrelationCoefficient a owl:Class,
@@ -14431,7 +14431,7 @@ Log integrity is verified by log auditors. Auditors make use of log proofs are u
     rdfs:subClassOf :Correlation ;
     :comment "Pearson correlation coefficient (PCC), Pearson's r, the Perason product-moment correlation coefficient (PPMCC), or the bivariate correlation, is a quantity that gives the quality of a least squares fitting to the original data." ;
     :d3fend-id "D3A-PCC" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wolfram MathWorld. (n.d.). Correlation Coefficient. [Link](https://mathworld.wolfram.com/CorrelationCoefficient.html)""" .
 
 :PerHostDownload-UploadRatioAnalysis a :NetworkTrafficAnalysis,
@@ -14444,10 +14444,10 @@ Wolfram MathWorld. (n.d.). Correlation Coefficient. [Link](https://mathworld.wol
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-PHDURA" ;
     :definition "Detecting anomalies that indicate malicious activity by comparing the amount of data downloaded versus data uploaded by a host." ;
-    :kb-article """## How it works\r
-Aggregate pull vs. push ratios from metadata are used to develop a baseline for a given host over a specific time period, e.g., over a three-hour period, one day, one week, etc. Anomalies identified over a threshold produce an alert.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Aggregate pull vs. push ratios from metadata are used to develop a baseline for a given host over a specific time period, e.g., over a three-hour period, one day, one week, etc. Anomalies identified over a threshold produce an alert.
+
+## Considerations
 Collection and analysis of large network packet captures requires large storage and intensive computing power. The time windows used to calculate the ratio may vary in implementations, this consideration should take into account a threat model and likely effects (impacts) delivered by an adversary.""" ;
     :kb-reference :Reference-SystemForDetectingThreatsUsingScenario-basedTrackingOfInternalAndExternalNetworkTraffic_VECTRANETWORKSInc .
 
@@ -14468,13 +14468,13 @@ Collection and analysis of large network packet captures requires large storage 
             owl:someValuesFrom :PeripheralFirmware ] ;
     :d3fend-id "D3-PFV" ;
     :definition "Cryptographically verifying peripheral firmware integrity." ;
-    :kb-article """# How it works\r
-Peripherial firmware is collected and  analyzed on a host either periodically or on demand. This information may be collected for future comparisons.\r
-\r
-Changes in firmware hash values may indicate that the firmware has been tampered with or that firmware images are not maintained to current baselined versions, or even known vulnerable versions are deployed.\r
-\r
-## Considerations\r
-* Trust baselines will need to be generated for specific devices\r
+    :kb-article """# How it works
+Peripherial firmware is collected and  analyzed on a host either periodically or on demand. This information may be collected for future comparisons.
+
+Changes in firmware hash values may indicate that the firmware has been tampered with or that firmware images are not maintained to current baselined versions, or even known vulnerable versions are deployed.
+
+## Considerations
+* Trust baselines will need to be generated for specific devices
 * Changes to trusted configurations will need to be managed across the enterprise""" ;
     :kb-reference :Reference-FirmwareVerificationEclypsium,
         :Reference-FirmwareVerificationTrapezoid .
@@ -14519,9 +14519,9 @@ Changes in firmware hash values may indicate that the firmware has been tampered
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-PBL" ;
     :definition "Perturbation based methods are proposed under the smoothness assumption, which indicates that two data points close to each other in feature space are likely to have the same label." ;
-    :kb-article """## References\r
-Zheng, Y., & Song, Y. (2021). An Effective Perturbation-Based Semi-Supervised Learning Method for Acoustic Event Classification. IEEE/ACM Transactions on Audio, Speech, and Language Processing, 29, 3580-3591. [Link](https://www.semanticscholar.org/paper/An-Effective-Perturbation-Based-Semi-Supervised-for-Zheng-Song/b75ae37d137ac354eb2ed42917e461b4dccdc977).\r
-\r
+    :kb-article """## References
+Zheng, Y., & Song, Y. (2021). An Effective Perturbation-Based Semi-Supervised Learning Method for Acoustic Event Classification. IEEE/ACM Transactions on Audio, Speech, and Language Processing, 29, 3580-3591. [Link](https://www.semanticscholar.org/paper/An-Effective-Perturbation-Based-Semi-Supervised-for-Zheng-Song/b75ae37d137ac354eb2ed42917e461b4dccdc977).
+
 Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Learning, 109(2), 299-337. [Link](https://link.springer.com/article/10.1007/s10994-019-05855-6).""" .
 
 :PhiCoefficient a owl:Class,
@@ -14530,7 +14530,7 @@ Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Le
     rdfs:subClassOf :Correlation ;
     :d3fend-id "D3A-PC" ;
     :definition "The phi coefficient (or mean square contingency coefficient is a measure of association for two binary variables." ;
-    :kb-article """## References\r
+    :kb-article """## References
 \\Wikipedia. (n.d.). Phi coefficient. [Link](https://en.wikipedia.org/wiki/Phi_coefficient)""" ;
     :synonym "Matthews Correlation Coefficient (in machine learning)",
         "MCC" .
@@ -14549,8 +14549,8 @@ Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Le
 :PhysicalLink a owl:Class ;
     rdfs:label "Physical Link" ;
     rdfs:subClassOf :Link ;
-    :definition """A physical link is a dedicated connection for communication that uses some physical media (electrical, electromagnetic, optical, to include clear spaces or vacuums.)  A physical link represents only a single hop (link) in any larger communcations path, circuit, or network.\r
-\r
+    :definition """A physical link is a dedicated connection for communication that uses some physical media (electrical, electromagnetic, optical, to include clear spaces or vacuums.)  A physical link represents only a single hop (link) in any larger communcations path, circuit, or network.
+
 NOTE: not synonymous with data link as a data link can be over a telecommunications circuit, which may be a virtual circuit composed of multiple phyical links.""" ;
     rdfs:seeAlso "https://dbpedia.org/resource/Physical_layer" ;
     :synonym "Layer-1 Link" .
@@ -14599,7 +14599,7 @@ NOTE: not synonymous with data link as a data link can be over a telecommunicati
     rdfs:subClassOf :Image-to-ImageTranslationGAN ;
     :d3fend-id "D3A-PIX" ;
     :definition "Pix2Pix is based on condtional GAN architecture and are trained on paired set of images or scenes from two domains to be used for translation." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Esri. (n.d.). How Pix2Pix Works. [Link](https://developers.arcgis.com/python/guide/how-pix2pix-works/)""" .
 
 :Planning a owl:Class ;
@@ -14632,12 +14632,12 @@ Esri. (n.d.). How Pix2Pix Works. [Link](https://developers.arcgis.com/python/gui
             owl:onProperty :enables ;
             owl:someValuesFrom :Harden ] ;
     :d3fend-id "D3-PH" ;
-    :definition """Hardening components of a Platform with the intention of making them more difficult to exploit.\r
-\r
-Platforms includes components such as:\r
-* BIOS UEFI Subsystems\r
-* Hardware security devices such as Trusted Platform Modules\r
-* Boot process logic or code\r
+    :definition """Hardening components of a Platform with the intention of making them more difficult to exploit.
+
+Platforms includes components such as:
+* BIOS UEFI Subsystems
+* Hardware security devices such as Trusted Platform Modules
+* Boot process logic or code
 * Kernel software components""" ;
     :enables :Harden ;
     :synonym "Endpoint Hardening",
@@ -14653,15 +14653,15 @@ Platforms includes components such as:\r
             owl:someValuesFrom :Detect ] ;
     :d3fend-id "D3-PM" ;
     :definition "Monitoring platform components such as operating systems software, hardware devices, or firmware." ;
-    :kb-article """Platform monitoring consists of the analysis and monitoring of system level devices and low-level components, including hardware devices, to detect unauthorized modifications or suspicious activity.\r
-\r
-Monitored platform components includes system files and embedded devices such as:\r
-\r
- * Kernel software modules\r
- * Boot process code and load logic\r
- * Operating system components and device files\r
- * System libraries and dynamically loaded files\r
- * Hardware device drivers\r
+    :kb-article """Platform monitoring consists of the analysis and monitoring of system level devices and low-level components, including hardware devices, to detect unauthorized modifications or suspicious activity.
+
+Monitored platform components includes system files and embedded devices such as:
+
+ * Kernel software modules
+ * Boot process code and load logic
+ * Operating system components and device files
+ * System libraries and dynamically loaded files
+ * Hardware device drivers
  * Embedded firmware devices""" .
 
 :Point-biserialCorrelationCoefficient a owl:Class,
@@ -14670,7 +14670,7 @@ Monitored platform components includes system files and embedded devices such as
     rdfs:subClassOf :Correlation ;
     :d3fend-id "D3A-PBCC" ;
     :definition "The point biserial correlation coefficient (rpb) is a correlation coefficient used when one variable (e.g. Y) is dichotomous; Y can either be \"naturally\" dichotomous, like whether a coin lands heads or tails, or an artificially dichotomized variable." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Point-biserial correlation coefficient. [Link](https://en.wikipedia.org/wiki/Point-biserial_correlation_coefficient)""" .
 
 :Pointer a owl:Class ;
@@ -14689,19 +14689,19 @@ Wikipedia. (n.d.). Point-biserial correlation coefficient. [Link](https://en.wik
             owl:someValuesFrom :Pointer ] ;
     :d3fend-id "D3-PAN" ;
     :definition "Comparing the cryptographic hash or derivative of a pointer's value to an expected value." ;
-    :kb-article """## How It Works\r
-\r
-Pointer Authentication (frequently referred to as PAC, although the technique is properly Pointer Authentication) is a security feature to provide protection against attackers with memory read/write access.  A Pointer Authentication Code (PAC) is a cryptographic hash or derivative computed on the value of a pointer and some additional context information which can then provide a cryptographically strong guarantee about the likelihood that a pointer has been tampered with by an attacker.\r
-\r
-Although pointers are 64 bits, most systems have a substantially smaller virtual address space, leaving unused bits in pointers that can store the value of the PAC, this can be done to reduce memory space requirements. One implementation is in ARMv8.3-A.  A PAC is computed over the 64-bit pointer value and a 64-bit context value.  Instructions are introduced to deal with pointers: one category to compute and insert the PAC into a pointer, another category to verify the pointer and invalidate the pointer if the PAC does not check, and a third category to remove the pointer and restore the original value without verifying.\r
-\r
-The ARM standard specifies a cryptographic algorithm called QARMA-64 (designed by Qualcomm) to compute the signature, although this algorithm is not required.  The architecture provides for five secret 128-bit Pointer Authentication keys: two for instruction pointers, two for data pointers, and a general key for signing larger blocks of data.\r
-\r
-## Considerations\r
-\r
-In the ARM implementation, the mechanisms above for manipulating PACS are provided, but it is up to the code developer to manage the keys for the cryptographic algorithm.\r
-\r
-\r
+    :kb-article """## How It Works
+
+Pointer Authentication (frequently referred to as PAC, although the technique is properly Pointer Authentication) is a security feature to provide protection against attackers with memory read/write access.  A Pointer Authentication Code (PAC) is a cryptographic hash or derivative computed on the value of a pointer and some additional context information which can then provide a cryptographically strong guarantee about the likelihood that a pointer has been tampered with by an attacker.
+
+Although pointers are 64 bits, most systems have a substantially smaller virtual address space, leaving unused bits in pointers that can store the value of the PAC, this can be done to reduce memory space requirements. One implementation is in ARMv8.3-A.  A PAC is computed over the 64-bit pointer value and a 64-bit context value.  Instructions are introduced to deal with pointers: one category to compute and insert the PAC into a pointer, another category to verify the pointer and invalidate the pointer if the PAC does not check, and a third category to remove the pointer and restore the original value without verifying.
+
+The ARM standard specifies a cryptographic algorithm called QARMA-64 (designed by Qualcomm) to compute the signature, although this algorithm is not required.  The architecture provides for five secret 128-bit Pointer Authentication keys: two for instruction pointers, two for data pointers, and a general key for signing larger blocks of data.
+
+## Considerations
+
+In the ARM implementation, the mechanisms above for manipulating PACS are provided, but it is up to the code developer to manage the keys for the cryptographic algorithm.
+
+
 A known potential limitation of PACs concerns signing gadgets. Under certain circumstances PACs can be bypassed by forcing the system to run a signing gadget which will allow the signing of arbitrary pointers to occur.""" ;
     :kb-reference :Reference-PointerAuthenticationOnARMv8.3,
         :Reference-PointerAuthenticationProjectZero .
@@ -14724,7 +14724,7 @@ A known potential limitation of PACs concerns signing gadgets. Under certain cir
     rdfs:subClassOf :Estimation ;
     :d3fend-id "D3A-PE" ;
     :definition "A point estimation is a single value that estimates the parameter. Point estimates are single values calculated from the sample" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Link](https://online.stat.psu.edu/stat504/lesson/statistical-inference-and-estimation)""" .
 
 :Policy a owl:Class ;
@@ -14737,7 +14737,7 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
     rdfs:subClassOf :Model-freeReinforcementLearning ;
     :d3fend-id "D3A-PG" ;
     :definition "The objective of a Reinforcement Learning Policy Gradient agent is to maximize the “expected” reward when following a policy" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdatascience.com/policy-gradients-in-a-nutshell-8b72f9743c5d).""" .
 
 :PolicyReference a owl:Class ;
@@ -14771,9 +14771,9 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-PL" ;
     :definition "Predicate logic is is collection of formal systems used in mathematics, philosophy, linguistics, and computer science. First-order logic and Higher-order logic both incorporate predicate logic." ;
-    :kb-article """## References\r
-1. First-order logic. (2023, May 26). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/First-order_logic)\r
-2. Higher-order logic. (2023, May 13)\r
+    :kb-article """## References
+1. First-order logic. (2023, May 26). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/First-order_logic)
+2. Higher-order logic. (2023, May 13)
 [Link](https://en.wikipedia.org/wiki/Higher-order_logic)""" .
 
 :PrimaryStorage a owl:Class ;
@@ -14796,7 +14796,7 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     rdfs:subClassOf :MultivariateAnalysis ;
     :d3fend-id "D3A-PCA" ;
     :definition "Principal components analysis (PCA) creates a new set of orthogonal variables that contain the same information as the original set. It rotates the axes of variation to give a new set of orthogonal axes, ordered so that they summarize decreasing proportions of the variation." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki/Multivariate_statistics)""" ;
     :synonym "PCA" .
 
@@ -14806,7 +14806,7 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     rdfs:subClassOf :DimensionReduction ;
     :d3fend-id "D3A-PCA" ;
     :definition "Principal Component Analysis (PCA) is a statistic-based method of identifying patterns in a large dataset while increasing interpretability and preserving information." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org/wiki/Principal_component_analysis)""" .
 
 :PrintServer a owl:Class ;
@@ -14848,7 +14848,7 @@ Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-PL" ;
     :definition "Probabilistic logic extends traditional logic truth tables with probabilistic expressions." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Probabilistic logic. (2023, June 5). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Probabilistic_logic)""" .
 
 :Procedure a owl:Class ;
@@ -14933,42 +14933,42 @@ Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org
             owl:someValuesFrom :ProcessCodeSegment ] ;
     :d3fend-id "D3-PCSV" ;
     :definition "Comparing the \"text\" or \"code\" memory segments to a source of truth." ;
-    :kb-article """## How it works\r
-A process code segment is an executable portion of computer memory allocated to a particular process. Process Code Segment Verification implements verification to compare a process code segment to some expected value.\r
-\r
-### Verification logic\r
-Verification can occur during application startup, or continuously during execution. The logic which verifies the process code may be separate in a third-party process, embedded in the application itself at compile time, or dynamically linked at runtime.\r
-\r
-### System of record\r
-Examples of systems of record:\r
-\r
- * On-disk application binary files or checksums\r
- * Remotely stored binary data or checksums\r
- * Embedded binary data or checksums\r
-\r
-### Post Verification Actions\r
-If the verification function determines a process code segment may have been altered, a capability may invoke Eviction techniques  as **Process Termination** to end the current process, or **Executable Blacklisting** to prevent the executable from launching in the future.\r
-\r
-## Considerations\r
-\r
-### False positives\r
-\r
-False positives commonly occur in the case that the layout of code in the process segment is legitimately modified:\r
-\r
-*  Operating system features or third-party security software may modify the layout of process code, for example in the defensive technique **Segment Address Offset Randomization**, or in the case that a module is rebased.  In both of these cases, the alteration occurs before the code is fully loaded into memory, and it would be possible to avoid the false positive by securely feeding this constant offset and any relocation data into the verification logic.\r
-\r
-* Process code segments may be written to modify themselves or other process code segments; however, this goes against widely-accepted current practices in software development.\r
-\r
-### False negatives\r
-\r
-False negatives can occur via alteration of the verification logic or source of truth, or insufficient verification logic.\r
-\r
-* Verification techniques which are executed only locally may be defeated by altering the local verification logic.\r
-\r
-* Verification that is run only on a recurring basis could be evaded if the malicious alteration is completed before verification is run.\r
-\r
-* Verification that requests an operation to be performed on a subset of the code segment could be evaded by performing that operation on a copy of the relevant bytes of the code segment.\r
-\r
+    :kb-article """## How it works
+A process code segment is an executable portion of computer memory allocated to a particular process. Process Code Segment Verification implements verification to compare a process code segment to some expected value.
+
+### Verification logic
+Verification can occur during application startup, or continuously during execution. The logic which verifies the process code may be separate in a third-party process, embedded in the application itself at compile time, or dynamically linked at runtime.
+
+### System of record
+Examples of systems of record:
+
+ * On-disk application binary files or checksums
+ * Remotely stored binary data or checksums
+ * Embedded binary data or checksums
+
+### Post Verification Actions
+If the verification function determines a process code segment may have been altered, a capability may invoke Eviction techniques  as **Process Termination** to end the current process, or **Executable Blacklisting** to prevent the executable from launching in the future.
+
+## Considerations
+
+### False positives
+
+False positives commonly occur in the case that the layout of code in the process segment is legitimately modified:
+
+*  Operating system features or third-party security software may modify the layout of process code, for example in the defensive technique **Segment Address Offset Randomization**, or in the case that a module is rebased.  In both of these cases, the alteration occurs before the code is fully loaded into memory, and it would be possible to avoid the false positive by securely feeding this constant offset and any relocation data into the verification logic.
+
+* Process code segments may be written to modify themselves or other process code segments; however, this goes against widely-accepted current practices in software development.
+
+### False negatives
+
+False negatives can occur via alteration of the verification logic or source of truth, or insufficient verification logic.
+
+* Verification techniques which are executed only locally may be defeated by altering the local verification logic.
+
+* Verification that is run only on a recurring basis could be evaded if the malicious alteration is completed before verification is run.
+
+* Verification that requests an operation to be performed on a subset of the code segment could be evaded by performing that operation on a copy of the relevant bytes of the code segment.
+
 * Verification based on a system of record that can be altered may fail if that system of record is modifiable by a malicious user.""" ;
     :kb-reference :Reference-Anti-tamperSystemWithSelf-adjustingGuards_ARXANTECHNOLOGIESInc,
         :Reference-GuardsForApplicationInSoftwareTamperproofing_PurdueResearchFoundation,
@@ -15026,14 +15026,14 @@ False negatives can occur via alteration of the verification logic or source of 
             owl:someValuesFrom :ProcessTree ] ;
     :d3fend-id "D3-PLA" ;
     :definition "Identification of suspicious processes executing on an end-point device by examining the ancestry and siblings of a process, and the associated metadata of each node on the tree, such as process execution, duration, and order relative to siblings and ancestors." ;
-    :kb-article """## How it works\r
-Process tree analysis techniques gather information on how a process was initiated to determine if a process is malicious. For example, if a process was not initiated from boot or not initiated by another process, that process is identified as suspicious. Also, if a new process was started before a process initiated by the device (ex. during boot) and that new process was not initiated by a user (which can be determined by examining process parameters such as type of process, its creator, source, etc.) the process is identified as suspicious.\r
-\r
-For example, Microsoft Word may block execution of any subprocess that is not in an approved path.\r
-\r
-## Considerations\r
-* Attackers may spoof the parent PID (https://attack.mitre.org/techniques/T1502/), rendering such after-the-fact analysis on process lineage ineffective.\r
-* Processes may hide from various means of detection; an example on Linux is where a rootkit might remove key files for the process from its directory in /proc.\r
+    :kb-article """## How it works
+Process tree analysis techniques gather information on how a process was initiated to determine if a process is malicious. For example, if a process was not initiated from boot or not initiated by another process, that process is identified as suspicious. Also, if a new process was started before a process initiated by the device (ex. during boot) and that new process was not initiated by a user (which can be determined by examining process parameters such as type of process, its creator, source, etc.) the process is identified as suspicious.
+
+For example, Microsoft Word may block execution of any subprocess that is not in an approved path.
+
+## Considerations
+* Attackers may spoof the parent PID (https://attack.mitre.org/techniques/T1502/), rendering such after-the-fact analysis on process lineage ineffective.
+* Processes may hide from various means of detection; an example on Linux is where a rootkit might remove key files for the process from its directory in /proc.
 * Zombie processes.""" ;
     :kb-reference :Reference-CAR-2020-11-002%3ALocalNetworkSniffing_MITRE,
         :Reference-CAR-2020-11-004%3AProcessesStartedFromIrregularParent_MITRE,
@@ -15090,25 +15090,25 @@ For example, Microsoft Word may block execution of any subprocess that is not in
             owl:someValuesFrom :ProcessSegment ] ;
     :d3fend-id "D3-PSEP" ;
     :definition "Preventing execution of any address in a memory region other than the code segment." ;
-    :kb-article """## How it works\r
-\r
-During execution of a process, the instruction pointer register should only point to addresses in a code segment (also called the .text segment), as this is the sole segment which should contain program code.\r
-\r
-When this technique detects an attempt to execute something that has been designated as non-executable, other techniques such as those in **Process Eviction** might be invoked, such as **Process Termination** to end the current process, or **Executable Blacklisting** to blacklist the potentially vulnerable or malfunctioning executable.\r
-\r
-### Software-based implementations\r
-The software-based implementation in Windows XP SP2 might not check that every time the instruction pointer is changed, and does not check on each jump or return.  Before calling an exception handler, Windows XP SP2 software-enforced DEP checks whether the exception handler is located in a memory region marked as executable.  If the program was also built with SafeSEH, this implementation also checks before changing control to the exception handler whether it is a registered exception handler in the program's file on disk.\r
-\r
-### Hardware-based implementations\r
-The NX (No Execute) or XD (Execute Disable) bit on the processor specifies whether a certain part of memory is executable.  Early implementations set this bit by the memory segment, while modern implementations which are built on the flat memory model often store this bit in each entry of the page table, to control execution by the page.\r
-\r
-\r
-## Considerations\r
-\r
-Non-hardware process data segment execution prevention is more susceptible to being able to be turned off for a page of memory.\r
-\r
-Different implementations of this defense have been in place since the 1980s, but implementation stalled when larger 16-bit programs began stuffing code in the segments usually reserved for data. Many modern programs follow the best practice of separation of code and data, are able to run under this defense.\r
-\r
+    :kb-article """## How it works
+
+During execution of a process, the instruction pointer register should only point to addresses in a code segment (also called the .text segment), as this is the sole segment which should contain program code.
+
+When this technique detects an attempt to execute something that has been designated as non-executable, other techniques such as those in **Process Eviction** might be invoked, such as **Process Termination** to end the current process, or **Executable Blacklisting** to blacklist the potentially vulnerable or malfunctioning executable.
+
+### Software-based implementations
+The software-based implementation in Windows XP SP2 might not check that every time the instruction pointer is changed, and does not check on each jump or return.  Before calling an exception handler, Windows XP SP2 software-enforced DEP checks whether the exception handler is located in a memory region marked as executable.  If the program was also built with SafeSEH, this implementation also checks before changing control to the exception handler whether it is a registered exception handler in the program's file on disk.
+
+### Hardware-based implementations
+The NX (No Execute) or XD (Execute Disable) bit on the processor specifies whether a certain part of memory is executable.  Early implementations set this bit by the memory segment, while modern implementations which are built on the flat memory model often store this bit in each entry of the page table, to control execution by the page.
+
+
+## Considerations
+
+Non-hardware process data segment execution prevention is more susceptible to being able to be turned off for a page of memory.
+
+Different implementations of this defense have been in place since the 1980s, but implementation stalled when larger 16-bit programs began stuffing code in the segments usually reserved for data. Many modern programs follow the best practice of separation of code and data, are able to run under this defense.
+
 ROP or ret2libc/return-to-function attacks could bypass this defense, as although they may pass attacker-controlled data or stack frames to a function, they abuse functions that are legitimately located in the .text segment (code segment) of the program.  For those, more advanced defenses such as a table of valid jump addresses, function call analysis, or return depth analysis could be used.""" ;
     :kb-reference :Reference-DataExecutionPrevention_Microsoft,
         :Reference-WhatIsNX_XDFeature_RedHat ;
@@ -15125,15 +15125,15 @@ ROP or ret2libc/return-to-function attacks could bypass this defense, as althoug
             owl:someValuesFrom :Process ] ;
     :d3fend-id "D3-PSMD" ;
     :definition "Detects processes that modify, change, or replace their own code at runtime." ;
-    :kb-article """## How it Works\r
-A security agent installed on the host machine intercepts API calls between a process and operating system. Intercepted API calls are then compared against attack signatures/patterns to identify API calls that modify executable memory or modify the entry point address of a suspended child process. Attack patterns include:\r
-\r
-* Executable code of a suspended child process removed from memory by one or more API calls.\r
-* New executable code injected and / or loaded into memory of a suspended child process by one or more API calls.\r
-* Executable code modified by one or more API calls.\r
-* Next instruction pointer value in memory modified by one or more API calls.\r
-\r
-## Considerations\r
+    :kb-article """## How it Works
+A security agent installed on the host machine intercepts API calls between a process and operating system. Intercepted API calls are then compared against attack signatures/patterns to identify API calls that modify executable memory or modify the entry point address of a suspended child process. Attack patterns include:
+
+* Executable code of a suspended child process removed from memory by one or more API calls.
+* New executable code injected and / or loaded into memory of a suspended child process by one or more API calls.
+* Executable code modified by one or more API calls.
+* Next instruction pointer value in memory modified by one or more API calls.
+
+## Considerations
 Comparing loaded code segments of processes with what is expected to have been loaded from a file can result in false positives, due to legitimate uses of self-modification for decrypting or uncompressing code segments.""" ;
     :kb-reference :Reference-SystemAndMethodForProcessHollowingDetection_CarbonBlackInc .
 
@@ -15150,21 +15150,21 @@ Comparing loaded code segments of processes with what is expected to have been l
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-PSA" ;
     :definition "Analyzing spawn arguments or attributes of a process to detect processes that are unauthorized." ;
-    :kb-article """## How it works\r
-Process attributes are established when an operating system spawns a new process. These attributes are analyzed to look for the presence or absence of specific values or patterns.\r
-\r
-Some attributes of interest are:\r
- - user\r
- - process name\r
- - image path\r
- - security content\r
-\r
-## Considerations\r
-\r
- - Attackers can spoof the parent process identifier (PPID), which could bypass this defense to allow execution of a malicious process from an arbitrary parent process.\r
- - Attackers could have legitimately compromised any of the process properties, such as the user, to make the execution appear legitimate.\r
- - Location: If the full image path is not checked, there could be a conflict with an executable that appears earlier due to resolution involving the system environment path/classpath variable.\r
- - Parsing issues: If the raw command from a shell is analyzed, rather than the actual function call, it is important to identify the actual command  being run from its arguments.  In Windows, services with unquoted file paths containing spaces will try to use the first token as the executable and the rest as arguments -- and shift tokens to the executable until a valid one is found.\r
+    :kb-article """## How it works
+Process attributes are established when an operating system spawns a new process. These attributes are analyzed to look for the presence or absence of specific values or patterns.
+
+Some attributes of interest are:
+ - user
+ - process name
+ - image path
+ - security content
+
+## Considerations
+
+ - Attackers can spoof the parent process identifier (PPID), which could bypass this defense to allow execution of a malicious process from an arbitrary parent process.
+ - Attackers could have legitimately compromised any of the process properties, such as the user, to make the execution appear legitimate.
+ - Location: If the full image path is not checked, there could be a conflict with an executable that appears earlier due to resolution involving the system environment path/classpath variable.
+ - Parsing issues: If the raw command from a shell is analyzed, rather than the actual function call, it is important to identify the actual command  being run from its arguments.  In Windows, services with unquoted file paths containing spaces will try to use the first token as the executable and the rest as arguments -- and shift tokens to the executable until a valid one is found.
  - Some [operating systems](/dao/artifact/d3f:OperatingSystem) can spawn processes without forking.""" ;
     :kb-reference :Reference-ActiveDirectoryDumpingViaNTDSUtil_MITRE,
         :Reference-CAR-2020-04-001%3AShadowCopyDeletion_MITRE,
@@ -15227,13 +15227,13 @@ Some attributes of interest are:\r
             owl:someValuesFrom :Process ] ;
     :d3fend-id "D3-PS" ;
     :definition "Suspending a running process on a computer system." ;
-    :kb-article """## How it works\r
-\r
-A running process might be suspended to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior. Defenders may choose to suspend rather than terminate to analyze the process first and resume the process if deemed benign.\r
-\r
-### System-provided functions\r
-\r
-#### Windows tools\r
+    :kb-article """## How it works
+
+A running process might be suspended to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior. Defenders may choose to suspend rather than terminate to analyze the process first and resume the process if deemed benign.
+
+### System-provided functions
+
+#### Windows tools
 In Windows, the `PsSuspend` command line utility from the SysInternals Suite provides functionality to suspend processes on a local or remote system.""" ;
     :kb-reference :Reference-PsSuspend .
 
@@ -15247,95 +15247,95 @@ In Windows, the `PsSuspend` command line utility from the SysInternals Suite pro
             owl:someValuesFrom :Process ] ;
     :d3fend-id "D3-PT" ;
     :definition "Terminating a running application process on a computer system." ;
-    :kb-article """## How it works\r
-\r
-Processes are managed by the operating system kernel.  Different operating system kernels manage the creation and termination of processes in a different manner, and expose this functionality via the kernel API.\r
-\r
-A running process might be terminated to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior; such as after detecting anomalous behavior via <a href="https://d3fend.mitre.org/technique/d3f:AdministrativeNetworkActivityAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#AdministrativeNetworkActivityAnalysis">Administrative Network Activity Analysis</a>, after a failed check from <a href="https://d3fend.mitre.org/technique/d3f:StackFrameCanaryVerification" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#StackFrameCanaryValidation">Stack Frame Canary Validation</a>, or after <a href="https://d3fend.mitre.org/technique/d3f:SystemCallAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#SystemCallAnalysis">System Call Analysis</a> finds an attempt to execute an unauthorized system call.\r
-\r
-### Proprietary technology\r
-Security software might use proprietary technology to terminate processes, instead of the system-provided functions.    Further research may provide specific detail on such methods used.\r
-\r
-### System-provided functions\r
-\r
-#### Windows tools\r
-In Windows, `ExitProcess()` is used to send a signal to a process to request it to exit, and `TerminateProcess()` is used to force a process to exit.\r
-\r
-The `taskkill` executable available in the cmd shell is used to kill a process, with the `/F` switch forcing termination as with `TerminateProcess()`.  In PowerShell, `Stop-Process` is used, which is aliased by default to `spps` and `kill`.  Processes started in the Windows Subsystem for Linux (WSL) environment may be terminated there with the `kill` command.\r
-\r
-In some cases, existing drivers can also be leveraged to kill processes.\r
-\r
-#### Unix/Linux tools\r
-In Unix-like systems, all process termination requests are handled using signals.  The `kill` function takes the Process ID and signal to send, and is accessible with the `kill` command.  Some shells have a `kill` builtin function which is separate than the `kill` binary, which can also kill background jobs in the shell and additionally perform the function faster, and can run from an existing instance of the shell if the process table is full.  The signal SIGTERM specifies that the process to terminate may invoke a handler that it has defined instead of terminating, and the signal SIGKILL forces immediate termination.\r
-\r
-The related command `xkill` terminates the connection of a program to the X window server, after which the user process may decide to terminate itself; however, termination is not guaranteed as the process, which could be on the same or different host, could then run in a terminal or reconnect to a different X server on any host.  Emacs is such a program that would not terminate itself after its connection to the X server is terminated.\r
-\r
-## Considerations\r
-\r
-### Persistence Mechanisms\r
-Terminating a malicious process is not enough to stop an adversary that has already gained persistence in the host via any initial access mechanism, including through that process or another access mechanism.\r
-\r
-### Terminating Multiple Processes\r
-On most operating systems, process termination operations typically occur independently of each other, without functionality provided to atomically terminate multiple processes.  If there are multiple malicious processes which can make system calls to spawn other processes once one of them is closed, user session termination or system restart might be required.\r
-\r
-### Process Access Permissions\r
-Users must have permissions to kill the process.  On Unix-like systems, either root or the process user can kill the process.  On Windows systems, process permissions are managed separately via process security tokens.\r
-\r
-### Process Resource Handles\r
-\r
-#### Terminating Processes with Open Resource Handles\r
-\r
-Processes may have open resource handles, which could leave those resources in an undesired state if the process is forced to terminate.  As such, most operating systems provide a means to send a signal to a process to inform it to gracefully terminate, and on most of these operating systems, it is the typical first step used to terminate a process.\r
-\r
-#### Signal Traps\r
-As the process may have open resource handles, commonly-used methods of process termination involve sending a signal to the process to terminate.\r
-On Windows, the `ExitProcess()` function is used for this purpose.  Process instructions, as well as a third-party DLL can also cause the process to exit.\r
-On Linux, the process is sent a signal on the occurrence of various events: when it loses the console, `SIGHUP`; when termination is requested, `SIGTERM`.  The processor then redirects execution to the function registered to handle the signal.\r
-\r
-Therefore, sending a signal to the process to ask it to terminate may not always work.\r
-\r
-##### Avoiding Signal Traps\r
-\r
-On Unix-like systems, sending the `SIGKILL` signal for a process does not send a message to the process or invoke an implementation-defined handler; instead, it immediately does not allow the process to execute any further processor instructions.   On Windows `TerminateProcess()` instead of `ExitProcess()` performs the equivalent.\r
-\r
-#### Hang on System Call Execution\r
-\r
-Even still, as the operating system kernel manages the processes, kernel code may block process signals, including those which cannot be trapped, and does in certain circumstances.  Signals are blocked and queued for the duration of the system call when interrupting the system call would result in a kernel invariant being violated, such as when an action results in a malformed data structure; this blocking is common for filesystem requests.  Such system calls can hang when a filesystem has gone offline, leading to a long-term uninterruptible sleep, represented in POSIX command `ps` output as D state.\r
-Any malicious system calls or system call handlers are issues of a much larger problem (a kernel-level rootkit) and the system should be redeployed entirely or restored from a backup known to be prior to compromise, and other systems accessible directly and indirectly from that one should also be examined.\r
-\r
-A process that is truly hung in a system call may prevent the system from shutting down and leave it in an unresponsive state; a hard power off is required.\r
-\r
-To speed up the action of terminating a process in uninterruptible sleep, the process resource accesses (handles) could be analyzed.\r
-\r
-On Linux, [`sync` followed by `echo 3 > /proc/sys/vm/drop_caches`](https://www.kernel.org/doc/Documentation/sysctl/vm.txt) is a safe way to free up some inactive resource handles.\r
-\r
-\r
-#### Kernel Processes and Threads\r
-The kernel may not allow kernel processes, which are created via methods other than user-space processes, to be terminated.\r
-\r
-#### Other Code using the Process\r
-\r
-Terminating a shared library can lead to unexpected errors; such shared libraries have their own mechanisms for termination.\r
-\r
-On Windows, a DLL is unloaded when the reference count of the library reaches 0.\r
-\r
-#### Zombie process\r
-\r
-After a process has been terminated, it may still take up an entry in the operating system process table until another event occurs.\r
-\r
-##### Windows\r
-In Windows, a process object is deleted when the last handle to the process is closed.\r
-\r
-##### Linux\r
-In Linux, a process is removed from the process table when it is reaped by its parent process.  If the parent terminates, historically the parent has been changed to pid 1; however, in the Linux kernel 3.4 and above, processes can set a different process as the subreaper using the `prctl()` system call.\r
-\r
-Zombie processes and hung processes could be resolved with a restart of the system.\r
-\r
-#### System restart\r
-Finally a system restart might be required to kill a process.\r
-Systems which are only accessible via a remote in-band connection may become inaccessible if a process termination operation that is necessary for reboot does not complete.\r
-\r
-### Subsystems\r
+    :kb-article """## How it works
+
+Processes are managed by the operating system kernel.  Different operating system kernels manage the creation and termination of processes in a different manner, and expose this functionality via the kernel API.
+
+A running process might be terminated to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior; such as after detecting anomalous behavior via <a href="https://d3fend.mitre.org/technique/d3f:AdministrativeNetworkActivityAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#AdministrativeNetworkActivityAnalysis">Administrative Network Activity Analysis</a>, after a failed check from <a href="https://d3fend.mitre.org/technique/d3f:StackFrameCanaryVerification" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#StackFrameCanaryValidation">Stack Frame Canary Validation</a>, or after <a href="https://d3fend.mitre.org/technique/d3f:SystemCallAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#SystemCallAnalysis">System Call Analysis</a> finds an attempt to execute an unauthorized system call.
+
+### Proprietary technology
+Security software might use proprietary technology to terminate processes, instead of the system-provided functions.    Further research may provide specific detail on such methods used.
+
+### System-provided functions
+
+#### Windows tools
+In Windows, `ExitProcess()` is used to send a signal to a process to request it to exit, and `TerminateProcess()` is used to force a process to exit.
+
+The `taskkill` executable available in the cmd shell is used to kill a process, with the `/F` switch forcing termination as with `TerminateProcess()`.  In PowerShell, `Stop-Process` is used, which is aliased by default to `spps` and `kill`.  Processes started in the Windows Subsystem for Linux (WSL) environment may be terminated there with the `kill` command.
+
+In some cases, existing drivers can also be leveraged to kill processes.
+
+#### Unix/Linux tools
+In Unix-like systems, all process termination requests are handled using signals.  The `kill` function takes the Process ID and signal to send, and is accessible with the `kill` command.  Some shells have a `kill` builtin function which is separate than the `kill` binary, which can also kill background jobs in the shell and additionally perform the function faster, and can run from an existing instance of the shell if the process table is full.  The signal SIGTERM specifies that the process to terminate may invoke a handler that it has defined instead of terminating, and the signal SIGKILL forces immediate termination.
+
+The related command `xkill` terminates the connection of a program to the X window server, after which the user process may decide to terminate itself; however, termination is not guaranteed as the process, which could be on the same or different host, could then run in a terminal or reconnect to a different X server on any host.  Emacs is such a program that would not terminate itself after its connection to the X server is terminated.
+
+## Considerations
+
+### Persistence Mechanisms
+Terminating a malicious process is not enough to stop an adversary that has already gained persistence in the host via any initial access mechanism, including through that process or another access mechanism.
+
+### Terminating Multiple Processes
+On most operating systems, process termination operations typically occur independently of each other, without functionality provided to atomically terminate multiple processes.  If there are multiple malicious processes which can make system calls to spawn other processes once one of them is closed, user session termination or system restart might be required.
+
+### Process Access Permissions
+Users must have permissions to kill the process.  On Unix-like systems, either root or the process user can kill the process.  On Windows systems, process permissions are managed separately via process security tokens.
+
+### Process Resource Handles
+
+#### Terminating Processes with Open Resource Handles
+
+Processes may have open resource handles, which could leave those resources in an undesired state if the process is forced to terminate.  As such, most operating systems provide a means to send a signal to a process to inform it to gracefully terminate, and on most of these operating systems, it is the typical first step used to terminate a process.
+
+#### Signal Traps
+As the process may have open resource handles, commonly-used methods of process termination involve sending a signal to the process to terminate.
+On Windows, the `ExitProcess()` function is used for this purpose.  Process instructions, as well as a third-party DLL can also cause the process to exit.
+On Linux, the process is sent a signal on the occurrence of various events: when it loses the console, `SIGHUP`; when termination is requested, `SIGTERM`.  The processor then redirects execution to the function registered to handle the signal.
+
+Therefore, sending a signal to the process to ask it to terminate may not always work.
+
+##### Avoiding Signal Traps
+
+On Unix-like systems, sending the `SIGKILL` signal for a process does not send a message to the process or invoke an implementation-defined handler; instead, it immediately does not allow the process to execute any further processor instructions.   On Windows `TerminateProcess()` instead of `ExitProcess()` performs the equivalent.
+
+#### Hang on System Call Execution
+
+Even still, as the operating system kernel manages the processes, kernel code may block process signals, including those which cannot be trapped, and does in certain circumstances.  Signals are blocked and queued for the duration of the system call when interrupting the system call would result in a kernel invariant being violated, such as when an action results in a malformed data structure; this blocking is common for filesystem requests.  Such system calls can hang when a filesystem has gone offline, leading to a long-term uninterruptible sleep, represented in POSIX command `ps` output as D state.
+Any malicious system calls or system call handlers are issues of a much larger problem (a kernel-level rootkit) and the system should be redeployed entirely or restored from a backup known to be prior to compromise, and other systems accessible directly and indirectly from that one should also be examined.
+
+A process that is truly hung in a system call may prevent the system from shutting down and leave it in an unresponsive state; a hard power off is required.
+
+To speed up the action of terminating a process in uninterruptible sleep, the process resource accesses (handles) could be analyzed.
+
+On Linux, [`sync` followed by `echo 3 > /proc/sys/vm/drop_caches`](https://www.kernel.org/doc/Documentation/sysctl/vm.txt) is a safe way to free up some inactive resource handles.
+
+
+#### Kernel Processes and Threads
+The kernel may not allow kernel processes, which are created via methods other than user-space processes, to be terminated.
+
+#### Other Code using the Process
+
+Terminating a shared library can lead to unexpected errors; such shared libraries have their own mechanisms for termination.
+
+On Windows, a DLL is unloaded when the reference count of the library reaches 0.
+
+#### Zombie process
+
+After a process has been terminated, it may still take up an entry in the operating system process table until another event occurs.
+
+##### Windows
+In Windows, a process object is deleted when the last handle to the process is closed.
+
+##### Linux
+In Linux, a process is removed from the process table when it is reaped by its parent process.  If the parent terminates, historically the parent has been changed to pid 1; however, in the Linux kernel 3.4 and above, processes can set a different process as the subreaper using the `prctl()` system call.
+
+Zombie processes and hung processes could be resolved with a restart of the system.
+
+#### System restart
+Finally a system restart might be required to kill a process.
+Systems which are only accessible via a remote in-band connection may become inaccessible if a process termination operation that is necessary for reboot does not complete.
+
+### Subsystems
 Processes that are started in a subsystem might not be fully terminated if they are terminated using the command for that subsystem.  For example, in the Windows Subsystem for Linux (WSL), processes started and terminated via WSL calls such as with the `kill` command in Bash may still have an entry in the Windows process table.""" ;
     :kb-reference :Reference-InstantProcessTerminationToolToRecoverControlOfAnInformationHandlingSystem_DellProductsLP,
         :Reference-MalwareDetectionUsingLocalComputationalModels_CrowdstrikeInc ;
@@ -15370,8 +15370,8 @@ Processes that are started in a subsystem might not be fully terminated if they 
     rdfs:subClassOf :ImageSynthesisGAN ;
     :d3fend-id "D3A-PGG" ;
     :definition "Progressive Growing GAN (ProGAN) is an extension to the GAN training process that allows for the stable training of generator models that can output large high-quality images." ;
-    :kb-article """## References\r
-\r
+    :kb-article """## References
+
 Machine Learning Mastery. (n.d.). Introduction to Progressive Growing Generative Adversarial Networks. [Link](https://machinelearningmastery.com/introduction-to-progressive-growing-generative-adversarial-networks/)""" ;
     :synonym "ProGAN" .
 
@@ -15381,7 +15381,7 @@ Machine Learning Mastery. (n.d.). Introduction to Progressive Growing Generative
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-PC" ;
     :definition "Projected clustering is a dimension reduction subspace clustering method." ;
-    :kb-article """## References\r
+    :kb-article """## References
 GeeksforGeeks. (n.d.). Projected Clustering in Data Analytics. [Link](https://www.geeksforgeeks.org/projected-clustering-in-data-analytics/)""" .
 
 :Projection-basedClustering a owl:Class,
@@ -15390,9 +15390,9 @@ GeeksforGeeks. (n.d.). Projected Clustering in Data Analytics. [Link](https://ww
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-PBC" ;
     :definition "Projection Based Clustering is a clustering framework based on a chosen projection method and projection method a parameter-free high-dimensional data visualization technique." ;
-    :kb-article """## References\r
-R Core Team. (2021). ProjectionBasedClustering: Projection Based Clustering. [Link](https://cran.r-project.org/web/packages/ProjectionBasedClustering/ProjectionBasedClustering.pdf)\r
-\r
+    :kb-article """## References
+R Core Team. (2021). ProjectionBasedClustering: Projection Based Clustering. [Link](https://cran.r-project.org/web/packages/ProjectionBasedClustering/ProjectionBasedClustering.pdf)
+
 Lai, J. H., Liu, Y., & Wu, W. (2017). Projection Based Clustering. [Link](https://www.researchgate.net/publication/319006501_Projection_Based_Clustering)""" .
 
 :Prolog a owl:Class,
@@ -15401,10 +15401,10 @@ Lai, J. H., Liu, Y., & Wu, W. (2017). Projection Based Clustering. [Link](https:
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-PRO" ;
     :definition "Prolog has its roots in first-order logic, a formal logic, and unlike many other programming languages." ;
-    :kb-article """## How it works\r
-Prolog is intended primarily as a declarative programming language: the program logic is expressed in terms of relations, represented as facts and rules. A computation is initiated by running a query over these relations.\r
-\r
-## References\r
+    :kb-article """## How it works
+Prolog is intended primarily as a declarative programming language: the program logic is expressed in terms of relations, represented as facts and rules. A computation is initiated by running a query over these relations.
+
+## References
 1. Prolog. (2023, April 5). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Prolog)""" .
 
 :PropertyListFile a owl:Class ;
@@ -15425,10 +15425,10 @@ Prolog is intended primarily as a declarative programming language: the program 
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-PL" ;
     :definition "Propositional logic deals with statements (i.e., propositions, which can be true or false) and relations between propositions, including the construction of arguments based on them." ;
-    :kb-article """## How it works\r
-Compound propositions are formed by connecting propositions by logical connectives. Propositions that contain no logical connectives are called atomic propositions.\r
-\r
-## References\r
+    :kb-article """## How it works
+Compound propositions are formed by connecting propositions by logical connectives. Propositions that contain no logical connectives are called atomic propositions.
+
+## References
 1. Propositional Calculus. (2022, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Propositional_calculus)""" ;
     :synonym "Propositional Calculus" .
 
@@ -15446,10 +15446,10 @@ Compound propositions are formed by connecting propositions by logical connectiv
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-PMAD" ;
     :definition "Collecting network communication protocol metadata and identifying statistical outliers." ;
-    :kb-article """## How it works\r
-Network protocol metadata is first collected and processed in real-time or post-facto. Metadata may include packet header information or information about a session (ex. time between requests/responses). Metadata is then grouped based on shared characteristics and those groups are compared to each other. If particular metadata differs significantly from other data, an alert is generated, identifying the network event as anomalous. Anomalous activity may indicate unauthorized activity.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Network protocol metadata is first collected and processed in real-time or post-facto. Metadata may include packet header information or information about a session (ex. time between requests/responses). Metadata is then grouped based on shared characteristics and those groups are compared to each other. If particular metadata differs significantly from other data, an alert is generated, identifying the network event as anomalous. Anomalous activity may indicate unauthorized activity.
+
+## Considerations
 Metadata collection on enterprises can yield large data sets. Storage, indexing, querying, and aging should be considered prior to implementation.""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingThreatsUsingMetadataVectors_VECTRANETWORKSInc,
         :Reference-MethodAndSystemForDetectingThreatsUsingPassiveClusterMapping_VectraNetworksInc,
@@ -15492,7 +15492,7 @@ Metadata collection on enterprises can yield large data sets. Storage, indexing,
     rdfs:subClassOf :Model-freeReinforcementLearning ;
     :d3fend-id "D3A-QL" ;
     :definition "Q-learning is a model-free reinforcement learning algorithm to learn the value of an action in a particular state. It does not require a model of the environment (hence \"model-free\"), and it can handle problems with stochastic transitions and rewards without requiring adaptations." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Q-learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Q-learning).""" .
 
 :QueryByCommittee a owl:Class,
@@ -15501,7 +15501,7 @@ Q-learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Q-learning).""" .
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-QBC" ;
     :definition "Query by Committee (QBC) takes inspiration from ensemble methods. Instead of just one classifier, it takes into account the decision of a committee 𝐶=ℎ1,…,ℎc of classifiers ℎ𝑖. Each classifier has the same target classes, but a different underlying model or a different view on the data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :RadioModem a owl:Class ;
@@ -15523,7 +15523,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :BootstrapAggregating ;
     :d3fend-id "D3A-RF" ;
     :definition "Random Forest is a ML method that combines several other ML methods. At its core, Random Forest is an ensemble method of multiple bootstrapped decision trees filled with training data and random feature selection." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Random forest. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Random_forest).""" .
 
 :RandomSplits a owl:Class,
@@ -15532,7 +15532,7 @@ Random forest. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Random_forest)."
     rdfs:subClassOf :ResamplingEnsemble ;
     :d3fend-id "D3A-RS" ;
     :definition "The dataset is repeatedly sampled with a random split of the data into train and test sets." ;
-    :kb-article """## References\r
+    :kb-article """## References
 How to Create a Random Split Cross-Validation and Bagging Ensemble for Deep Learning in Keras."*Machine Learning Mastery*.  [Link](https://machinelearningmastery.com/how-to-create-a-random-split-cross-validation-and-bagging-ensemble-for-deep-learning-in-keras/).""" .
 
 :Range a owl:Class,
@@ -15541,7 +15541,7 @@ How to Create a Random Split Cross-Validation and Bagging Ensemble for Deep Lear
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-RAN" ;
     :definition "The range of a set of data is the difference between the largest and smallest value." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Range_(statistics))""" .
 
 :RangeMatching a owl:Class,
@@ -15609,7 +15609,7 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
     rdfs:subClassOf :DeepNeuralNetClassification ;
     :d3fend-id "D3A-RNN" ;
     :definition "Recurrent Nerual Networks (RNN) are a class of artificial neural networks where connections between nodes can create a cycle, allowing output from some nodes to affect subsequent input to the same nodes. This allows it to exhibit temporal dynamic behavior." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (2021, September 7). Recurrent Neural Network. [Link](https://en.wikipedia.org/wiki/Recurrent_neural_network)""" ;
     :todo "Review: Which Definition" .
 
@@ -15627,8 +15627,8 @@ Wikipedia. (2021, September 7). Recurrent Neural Network. [Link](https://en.wiki
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-RM" ;
     :definition "Regular expression matching is type of partial string matching using a regular expression, which is a sequence of characters that specifies a match pattern in text." ;
-    :kb-article """## References\r
-1. Regular expression. (2023, June 1). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Regular_expression)\r
+    :kb-article """## References
+1. Regular expression. (2023, June 1). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Regular_expression)
 2. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""" ;
     :synonym "Regex",
         "Regexp" .
@@ -15639,7 +15639,7 @@ Wikipedia. (2021, September 7). Recurrent Neural Network. [Link](https://en.wiki
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-RA" ;
     :definition "Regression analysis is a set of statistical processes for estimating the relationships between a dependent variable (often called the 'outcome' or 'response' variable, or a 'label' in machine learning parlance) and one or more independent variables (often called 'predictors', 'covariates', 'explanatory variables' or 'features')." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Regression analysis. [Link](https://en.wikipedia.org/wiki/Regression_analysis)""" .
 
 :RegressionAnalysisLearning a owl:Class,
@@ -15648,7 +15648,7 @@ Wikipedia. (n.d.). Regression analysis. [Link](https://en.wikipedia.org/wiki/Reg
     rdfs:subClassOf :SupervisedLearning ;
     :d3fend-id "D3A-RAL" ;
     :definition "Regression is used to understand the relationship between dependent and independent variables which is then used to make projections, such as for sales revenue for a given business." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning).""" .
 
 :ReinforcementLearning a owl:Class,
@@ -15657,7 +15657,7 @@ Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning)
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-RL" ;
     :definition "Reinforcement Learning is a subjugate technique of machine learning that uses feedback to reinforce good or valid rules and lessen the reliance of bad or ineffective rules" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Reinforcement learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Reinforcement_learning).""" .
 
 :Relational-basedTransferLearning a owl:Class,
@@ -15666,7 +15666,7 @@ Reinforcement learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Reinfor
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-RBTL" ;
     :definition "Relational-based Transfer Learning is a subfield of machine learning where knowledge and patterns learned from one domain, characterized by relational and structured data, are transferred to enhance the learning of another related domain. This approach leverages shared concepts, relations, and structures across domains, taking advantage of the rich semantic knowledge within relational data to improve learning performance in the target task." ;
-    :kb-article """## References\r
+    :kb-article """## References
 V7 Labs. (n.d.). Transfer Learning Guide. [Link](https://www.v7labs.com/blog/transfer-learning-guide#:~:text=Relational%2Dbased%20transfer%20learning%20approaches,domain%20to%20the%20target%20domain).""" .
 
 :RelayPatternAnalysis a :NetworkTrafficAnalysis,
@@ -15679,11 +15679,11 @@ V7 Labs. (n.d.). Transfer Learning Guide. [Link](https://www.v7labs.com/blog/tra
             owl:someValuesFrom :OutboundInternetNetworkTraffic ] ;
     :d3fend-id "D3-RPA" ;
     :definition "The detection of an internal host relaying traffic between the internal network and the external network." ;
-    :kb-article """## How it works\r
-A relay may use a variety of proxying, forwarding, or routing technologies to bridge a protected network with an external network. A defensive analytic to detect a relay network may compare the network sessions among multiple hosts. Hosts which have nearly similar network statistics may be part of a relay network. The statistics may include number of bytes sent to and from, time of session initiation, packet size, or packet arrival time data.\r
-\r
-## Considerations\r
-\r
+    :kb-article """## How it works
+A relay may use a variety of proxying, forwarding, or routing technologies to bridge a protected network with an external network. A defensive analytic to detect a relay network may compare the network sessions among multiple hosts. Hosts which have nearly similar network statistics may be part of a relay network. The statistics may include number of bytes sent to and from, time of session initiation, packet size, or packet arrival time data.
+
+## Considerations
+
 Complex intranet VPNs or routing encapsulation may affect the detection analytics.  In addition, unwanted packets might not be forwarded, and additional packets may be added at the relay, further complicating detection.""" ;
     :kb-reference :Reference-MaliciousRelayDetectionOnNetworks_VECTRANETWORKSInc ;
     :synonym "Relay Network Detection" .
@@ -15744,25 +15744,25 @@ Complex intranet VPNs or routing encapsulation may affect the detection analytic
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-RTSD" ;
     :definition "Detection of an unauthorized remote live terminal console session by examining network traffic to a network host." ;
-    :kb-article """## How it works\r
-An external attacker takes remote control of a host inside a company or organization's network and manually directs offensive techniques. Nonstandard terminal sessions and abnormal behaviors are analyzed in this technique. Abnormal behavior detection includes analysis of user input patterns in the real-time session, keyboard output and packet inspection.\r
-\r
-### Network Traffic Inspection\r
-Network traffic from internal hosts is the main concern and focus for the traffic inspection. The network traffic is collected into inspection groups. The groups of traffic are assembled into distinct pair flows (outbound/inbound) and the pair flows are further divided into sessions. Only sessions originated inside of the network are considered for the inspection. Traffic inspection includes analysis to determine if a human is involved in the session exchanges. Time-based statistics are captured for each session being analyzed by the detection engine.\r
-\r
-### Algorithm Analysis Description\r
-Analysis algorithms look for patterns in the network traffic captured from the session data.  A detection engine groups the session traffic data, between the hosts, into rapid exchange instances. Analysis of rapid exchange traffic patterns can lead to the discovery of abnormal behavior which is indicative of a compromised internal host. The analysis algorithms look for patterns in the traffic which correlate to known activity (e.g., relay attacks, bot activity, bitcoin mining). Some metrics used during inspection include the following.\r
-\r
-* Number of rapid-exchange instances\r
-* Time interval between packets\r
-* Fixed cadence of traffic\r
-* Rhythm and direction of the initiation of instances\r
-* Volume of data flowing from internal to external controlling host\r
-* Data transfer characteristics\r
-* Variability in length of silent periods\r
-\r
-## Considerations\r
-* Full packet capture is required which can be process intensive to analyze\r
+    :kb-article """## How it works
+An external attacker takes remote control of a host inside a company or organization's network and manually directs offensive techniques. Nonstandard terminal sessions and abnormal behaviors are analyzed in this technique. Abnormal behavior detection includes analysis of user input patterns in the real-time session, keyboard output and packet inspection.
+
+### Network Traffic Inspection
+Network traffic from internal hosts is the main concern and focus for the traffic inspection. The network traffic is collected into inspection groups. The groups of traffic are assembled into distinct pair flows (outbound/inbound) and the pair flows are further divided into sessions. Only sessions originated inside of the network are considered for the inspection. Traffic inspection includes analysis to determine if a human is involved in the session exchanges. Time-based statistics are captured for each session being analyzed by the detection engine.
+
+### Algorithm Analysis Description
+Analysis algorithms look for patterns in the network traffic captured from the session data.  A detection engine groups the session traffic data, between the hosts, into rapid exchange instances. Analysis of rapid exchange traffic patterns can lead to the discovery of abnormal behavior which is indicative of a compromised internal host. The analysis algorithms look for patterns in the traffic which correlate to known activity (e.g., relay attacks, bot activity, bitcoin mining). Some metrics used during inspection include the following.
+
+* Number of rapid-exchange instances
+* Time interval between packets
+* Fixed cadence of traffic
+* Rhythm and direction of the initiation of instances
+* Volume of data flowing from internal to external controlling host
+* Data transfer characteristics
+* Variability in length of silent periods
+
+## Considerations
+* Full packet capture is required which can be process intensive to analyze
 * Attackers that move low and slow may blend in with existing traffic resulting in false negatives""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingExternalControlOfCompromisedHosts_VECTRANETWORKSInc,
         :Reference-RDPConnectionDetection_MITRE,
@@ -15780,9 +15780,9 @@ Analysis algorithms look for patterns in the network traffic captured from the s
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-RE" ;
     :definition "In the method, the small classes are oversampled and large classes are undersampled. The resampling scale is determined by the ratio of the min class number and max class number. And multiple machine learning methods are selected to construct the ensemble" ;
-    :kb-article """## References\r
-Ensemble learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Ensemble_learning).\r
-\r
+    :kb-article """## References
+Ensemble learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Ensemble_learning).
+
 Torgo, L. (2014). A resampling ensemble algorithm for improved accuracy. *Neurocomputing*, 134, 55-66.  [Link](https://www.sciencedirect.com/science/article/pii/S0925231214007644#:~:text=A%20resampling%20ensemble%20algorithm%20is,and%20undersampling%20are%20empirically%20analyzed).""" .
 
 :ResidualNeuralNetwork a owl:Class,
@@ -15791,7 +15791,7 @@ Torgo, L. (2014). A resampling ensemble algorithm for improved accuracy. *Neuroc
     rdfs:subClassOf :ConvolutionalNeuralNetwork ;
     :d3fend-id "D3A-RNN" ;
     :definition "A residual neural network (ResNet) is an artificial neural network (ANN). It is a gateless or open-gated variant of the HighwayNet, the first working very deep feedforward neural network with hundreds of layers, much deeper than previous neural networks." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia contributors. (2021, August 23). Residual neural network. In Wikipedia, The Free Encyclopedia. [Link](https://en.wikipedia.org/wiki/Residual_neural_network)""" .
 
 :Resource a owl:Class ;
@@ -15820,12 +15820,12 @@ Wikipedia contributors. (2021, August 23). Residual neural network. In Wikipedia
             owl:someValuesFrom :Authorization ] ;
     :d3fend-id "D3-RAPA" ;
     :definition "Analyzing the resources accessed by a user to identify unauthorized activity." ;
-    :kb-article """## How it works\r
-This technique analyzes a user's resource accesses by comparing the user's recent activity against a baseline activity model. Major differences between the current activity and the baseline model might indicate unauthorized activity if they are severe enough.\r
-\r
-\r
-## Considerations\r
-* Potential for false positives from anomalies that are not associated with malicious activity.\r
+    :kb-article """## How it works
+This technique analyzes a user's resource accesses by comparing the user's recent activity against a baseline activity model. Major differences between the current activity and the baseline model might indicate unauthorized activity if they are severe enough.
+
+
+## Considerations
+* Potential for false positives from anomalies that are not associated with malicious activity.
 * Attackers that move low and slow may not differentiate their resource access activity behavior enough to trigger an alert.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
@@ -15867,22 +15867,22 @@ This technique analyzes a user's resource accesses by comparing the user's recen
             owl:someValuesFrom :InboundInternetDNSResponseTraffic ] ;
     :d3fend-id "D3-RRDD" ;
     :definition "Blocking a reverse DNS lookup's answer's domain name value." ;
-    :kb-article """## How it works\r
-\r
-In reverse resolution requests, the client sends to a nameserver (such as a DNS server) a query of an IP address, to get a response of the associated domain name(s). This technique drops reverse lookup responses where a domain name matches an entry in the blacklist, either verbatim or as a wildcard subdomain of a higher-level domain on the list. Such domain names might be unwanted because Forward Domain Name Resolution requests to such a blacklisted domain might return an unwanted IP address.\r
-\r
-This technique is useful because relying solely on Forward Resolution Domain Blacklisting will miss instances where the domain in question is forward-resolved in a manner that is not inspected via a subsequent technique (as is likely the case if that resolution is performed with DoH (DNS over HTTPS) or DoT (DNS over TLS)). Additionally, note that responses to forward lookups of that domain are *not* necessarily equal to the original IP in the reverse lookup request, and that future lookups of a string based on this domain may even employ a less-common name resolution protocol, such as NBNS.\r
-\r
-The DNS response can either be blocked by dropping the network traffic with an inline device, or by modifying the value of the response sent by the DNS server.  To prevent client applications from hanging on a request, it is common practice to replace malicious values, either with names like "localhost." or the address of a honeypot maintained by the network administrators.\r
-\r
-## Considerations\r
-\r
-* This technique does not prevent the client from contacting the blacklisted domain or any IP addresses that it might resolve to, only from learning about this domain name via a nameserver lookup.\r
-* DNS response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer domain name value(s).\r
-  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.\r
-  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.\r
-* This technique must be deployed between the application that receives the response and the server which sent the response.\r
-  * DNS responses sent in an encrypted manner, such as using DoH or DoT, will require interception of the TLS connections in order to determine the domain name(s) in the response.\r
+    :kb-article """## How it works
+
+In reverse resolution requests, the client sends to a nameserver (such as a DNS server) a query of an IP address, to get a response of the associated domain name(s). This technique drops reverse lookup responses where a domain name matches an entry in the blacklist, either verbatim or as a wildcard subdomain of a higher-level domain on the list. Such domain names might be unwanted because Forward Domain Name Resolution requests to such a blacklisted domain might return an unwanted IP address.
+
+This technique is useful because relying solely on Forward Resolution Domain Blacklisting will miss instances where the domain in question is forward-resolved in a manner that is not inspected via a subsequent technique (as is likely the case if that resolution is performed with DoH (DNS over HTTPS) or DoT (DNS over TLS)). Additionally, note that responses to forward lookups of that domain are *not* necessarily equal to the original IP in the reverse lookup request, and that future lookups of a string based on this domain may even employ a less-common name resolution protocol, such as NBNS.
+
+The DNS response can either be blocked by dropping the network traffic with an inline device, or by modifying the value of the response sent by the DNS server.  To prevent client applications from hanging on a request, it is common practice to replace malicious values, either with names like "localhost." or the address of a honeypot maintained by the network administrators.
+
+## Considerations
+
+* This technique does not prevent the client from contacting the blacklisted domain or any IP addresses that it might resolve to, only from learning about this domain name via a nameserver lookup.
+* DNS response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer domain name value(s).
+  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.
+  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.
+* This technique must be deployed between the application that receives the response and the server which sent the response.
+  * DNS responses sent in an encrypted manner, such as using DoH or DoT, will require interception of the TLS connections in order to determine the domain name(s) in the response.
 * Replacing the response is not effective in the case that the nameserver uses a technique to provide integrity of its responses, such as DNSSEC for DNS responses.""" ;
     :synonym "Reverse Resolution Domain Blacklisting" .
 
@@ -15896,15 +15896,15 @@ The DNS response can either be blocked by dropping the network traffic with an i
             owl:someValuesFrom :OutboundInternetDNSLookupTraffic ] ;
     :d3fend-id "D3-RRID" ;
     :definition "Blocking a reverse lookup based on the query's IP address value." ;
-    :kb-article """## How it works\r
-This technique prevents a client from learning domains deemed to be potentially malicious, which would have been delivered via reverse resolution responses over the DNS protocol.\r
-\r
-Queries for reverse resolution requests (that is, requests where IP(s) are sent and a domain is returned) are collected, and the IP address(es) included in the query are examined. If the IP address(es) are in a range included in the blacklist, then the query is dropped.\r
-\r
-## Considerations\r
-- The blacklist will have to be maintained and will need to be kept up to date with identified maintenance cycles to ensure lists are not stale.\r
-- DNS query traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS query IP address value(s).\r
-  - DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.\r
+    :kb-article """## How it works
+This technique prevents a client from learning domains deemed to be potentially malicious, which would have been delivered via reverse resolution responses over the DNS protocol.
+
+Queries for reverse resolution requests (that is, requests where IP(s) are sent and a domain is returned) are collected, and the IP address(es) included in the query are examined. If the IP address(es) are in a range included in the blacklist, then the query is dropped.
+
+## Considerations
+- The blacklist will have to be maintained and will need to be kept up to date with identified maintenance cycles to ensure lists are not stale.
+- DNS query traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS query IP address value(s).
+  - DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.
   - Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS queries. These protocols have often been enabled in browser settings transparently after a browser update, with DNS queries proxied over one of these cryptographic protocols through a specified host.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Reverse Resolution IP Blacklisting" .
@@ -15963,28 +15963,28 @@ Queries for reverse resolution requests (that is, requests where IP(s) are sent 
             owl:someValuesFrom :RPCNetworkTraffic ] ;
     :d3fend-id "D3-RTA" ;
     :definition "Monitoring the activity of remote procedure calls in communication traffic to establish standard protocol operations and potential attacker activities." ;
-    :kb-article """## How it works\r
-A remote procedure call (RPC) enables one computer to execute a specific function on another computer, as if it were a local application process. There are numerous RPC specifications and implementations. RPC capabilities can be abused by attackers in order to achieve a variety of tactical objectives including execution, persistence, initial access, and more. RPC proxies may be used to collect and store RPC traffic. RPCs can occur over network sockets or named pipes.\r
-\r
-Analytics look for unauthorized behavior such as:\r
-\r
-* Processes being launched or scheduled remotely\r
-* System configurations being changed remotely\r
-* Unauthorized file read activity\r
-\r
-Example RPC Protocols:\r
-\r
-* DCE/RPC\r
-* CORBA\r
-* Open Network Computing Remote Procedure Call\r
-* D-Bus\r
-* XML-RPC\r
-* JSON-RPC\r
-* SOAP\r
-* Apache Thrift\r
-\r
-## Considerations\r
-* RPC is widely used in enterprise environments, and significant data filtering may be required in large environments to enable analytic processing.\r
+    :kb-article """## How it works
+A remote procedure call (RPC) enables one computer to execute a specific function on another computer, as if it were a local application process. There are numerous RPC specifications and implementations. RPC capabilities can be abused by attackers in order to achieve a variety of tactical objectives including execution, persistence, initial access, and more. RPC proxies may be used to collect and store RPC traffic. RPCs can occur over network sockets or named pipes.
+
+Analytics look for unauthorized behavior such as:
+
+* Processes being launched or scheduled remotely
+* System configurations being changed remotely
+* Unauthorized file read activity
+
+Example RPC Protocols:
+
+* DCE/RPC
+* CORBA
+* Open Network Computing Remote Procedure Call
+* D-Bus
+* XML-RPC
+* JSON-RPC
+* SOAP
+* Apache Thrift
+
+## Considerations
+* RPC is widely used in enterprise environments, and significant data filtering may be required in large environments to enable analytic processing.
 * RPC traffic may occur over a pipe, or within a host over loopback interface, thus making network collection difficult.""" ;
     :kb-reference :Reference-CAR-2014-05-001%3ARPCActivity_MITRE,
         :Reference-CAR-2014-11-007-RemoteWindowsManagementInstrumentation_WMI_OverRPC_MITRE,
@@ -16003,7 +16003,7 @@ Example RPC Protocols:\r
     rdfs:isDefinedBy "https://dbpedia.org/page/State%E2%80%93action%E2%80%93reward%E2%80%93state%E2%80%93action" ;
     :d3fend-id "D3A-SAR" ;
     :definition "State-action-reward-state-action (SARSA) is an algorithm for learning a Markov decision process policy, used in the reinforcement learning area of machine learning." ;
-    :kb-article """## References\r
+    :kb-article """## References
 State-action-reward-state-action. Wikipedia.  [Link](https://en.wikipedia.org/wiki/State%E2%80%93action%E2%80%93reward%E2%80%93state%E2%80%93action).""" .
 
 :SavedInstructionPointer a owl:Class ;
@@ -16043,12 +16043,12 @@ State-action-reward-state-action. Wikipedia.  [Link](https://en.wikipedia.org/wi
             owl:someValuesFrom :JobSchedule ] ;
     :d3fend-id "D3-SJA" ;
     :definition "Analysis of source files, processes, destination files, or destination servers associated with a scheduled job to detect unauthorized use of job scheduling." ;
-    :kb-article """## How it works\r
-Scheduled job execution can be utilized by adversaries for the purpose of persistence, conducting remote execution, or gaining privileges. Details of a scheduled job such as associated source files, processes, destination files, or destination servers are first identified and analyzed and then compared against an anti-malware signature database, whitelist, or reputation server. For example, a file associated with a scheduled job to be executed at a specified time or a remote server that is accessed as part of a scheduled task is compared against an anti-malware signature database, whitelist, or reputation server, and if a match is found, execution is denied and an alert is generated.\r
-\r
-In addition to traditional scheduled jobs, triggers can be set to execute a specific command after detecting a specific event in the system, such as with WMI Event Subscriptions in Windows.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Scheduled job execution can be utilized by adversaries for the purpose of persistence, conducting remote execution, or gaining privileges. Details of a scheduled job such as associated source files, processes, destination files, or destination servers are first identified and analyzed and then compared against an anti-malware signature database, whitelist, or reputation server. For example, a file associated with a scheduled job to be executed at a specified time or a remote server that is accessed as part of a scheduled task is compared against an anti-malware signature database, whitelist, or reputation server, and if a match is found, execution is denied and an alert is generated.
+
+In addition to traditional scheduled jobs, triggers can be set to execute a specific command after detecting a specific event in the system, such as with WMI Event Subscriptions in Windows.
+
+## Considerations
 Jobs can be scheduled in many different and sometimes creative ways through operating system capabilities.""" ;
     :kb-reference :Reference-ExecutionWithAT_MITRE,
         :Reference-ExecutionWithSchtasks_MITRE,
@@ -16079,10 +16079,10 @@ Jobs can be scheduled in many different and sometimes creative ways through oper
             owl:someValuesFrom :ScriptApplicationProcess ] ;
     :d3fend-id "D3-SEA" ;
     :definition "Analyzing the execution of a script to detect unauthorized user activity." ;
-    :kb-article """## How it works\r
-Software installed on the host system hooks into a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. Pattern matching is used to identify unauthorized commands or in the case of script files, a hash of the file is compared against hashes of known unauthorized script files.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+Software installed on the host system hooks into a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. Pattern matching is used to identify unauthorized commands or in the case of script files, a hash of the file is compared against hashes of known unauthorized script files.
+
+## Considerations
 List of known unauthorized script files or regular expression patterns must be kept up to date to ensure detection of new threats.""" ;
     :kb-reference :Reference-DetectingScript-basedMalware_CrowdstrikeInc .
 
@@ -16118,21 +16118,21 @@ List of known unauthorized script files or regular expression patterns must be k
             owl:someValuesFrom :ProcessSegment ] ;
     :d3fend-id "D3-SAOR" ;
     :definition "Randomizing the base (start) address of one or more segments of memory during the initialization of a process." ;
-    :kb-article """## How it works\r
-\r
-Many application exploits rely on an attacker specifying a location in memory, which points to data or code used by the attacker.  If the addresses are changed each time the program is run, then it becomes more difficult for the attacker to determine the location that will contain the code they wish to run.\r
-\r
-Imported modules may be similarly realigned if their default memory addresses conflict with other modules, in a process known as "rebasing."  Just as not all code is built for participation in ASLR, not all modules can be rebased; instead, modules must indicate whether they implement support for rebasing.  Such information to relocate the executable is typically stored in the ".reloc" segment -- each of the addresses pointed to in this segment has its address increased by the amount of the offset.\r
-(An alternative method for relocation would be to add an amount to a global variable each time -- leading to less overhead in the module load, but more for each access.  Still another implementation could instead contain code to deference each changeable memory location on the fly, so that each of the references do not need to be updated.\r
-\r
-\r
-## Considerations\r
-\r
-As the offset for each segment is constant, it is possible to guess at the value of the address given the address of another variable.  Alternatively, memory pointers may be kept around, which contain the address of another variable.\r
-Another bypass technique is known as an "egg hunt," whereby the attacker searches for a rather unique piece of the data or code in memory to determine its likely address.\r
-\r
-The program needs to store these addresses for the functions somewhere.  In Linux, the PLT contains a "trampoline" to these addresses.  If an attacker desires to jump to the start of an existing function, they can jump directly to the trampoline anyway, and may have the opportunity to provide their own stack frame to the function with a write to the stack. If they overwrite a saved stack pointer which is loaded back into memory, or execute a function, that changes the address of a stack pointer.\r
-\r
+    :kb-article """## How it works
+
+Many application exploits rely on an attacker specifying a location in memory, which points to data or code used by the attacker.  If the addresses are changed each time the program is run, then it becomes more difficult for the attacker to determine the location that will contain the code they wish to run.
+
+Imported modules may be similarly realigned if their default memory addresses conflict with other modules, in a process known as "rebasing."  Just as not all code is built for participation in ASLR, not all modules can be rebased; instead, modules must indicate whether they implement support for rebasing.  Such information to relocate the executable is typically stored in the ".reloc" segment -- each of the addresses pointed to in this segment has its address increased by the amount of the offset.
+(An alternative method for relocation would be to add an amount to a global variable each time -- leading to less overhead in the module load, but more for each access.  Still another implementation could instead contain code to deference each changeable memory location on the fly, so that each of the references do not need to be updated.
+
+
+## Considerations
+
+As the offset for each segment is constant, it is possible to guess at the value of the address given the address of another variable.  Alternatively, memory pointers may be kept around, which contain the address of another variable.
+Another bypass technique is known as an "egg hunt," whereby the attacker searches for a rather unique piece of the data or code in memory to determine its likely address.
+
+The program needs to store these addresses for the functions somewhere.  In Linux, the PLT contains a "trampoline" to these addresses.  If an attacker desires to jump to the start of an existing function, they can jump directly to the trampoline anyway, and may have the opportunity to provide their own stack frame to the function with a write to the stack. If they overwrite a saved stack pointer which is loaded back into memory, or execute a function, that changes the address of a stack pointer.
+
 If an attacker wants to inject some data into the program, for example as a parameter to a known function that is not under ASLR or a pointer to a trampoline function in the PLT, then they can repeat the data until they exceed the range of ASLR coverage, which on 32-bit systems is accomplishable in a few seconds with a heap spray.  Microsoft's EMET and Windows 10 Exploit Guard can pre-allocate particular addresses that are commonly used in heap sprays.  However, in many products, there does not seem to be nearly a complete coverage of such addresses, which only need to be executable and in the range of the heap; 0x0c0c0c0c is such an address that is commonly used for the x86 processor architecture, as when executed it only performs a numeric operation to a register four times.""" ;
     :kb-reference :Reference-DYNAMICBASE_UseAddressSpaceLayoutRandomization_MicrosoftDocs,
         :Reference-HowASLRProtectsLinuxSystemsFromBufferOverflowAttacks_NetworkWorld ;
@@ -16145,7 +16145,7 @@ If an attacker wants to inject some data into the program, for example as a para
     rdfs:subClassOf :ANN-basedClustering ;
     :d3fend-id "D3A-SOM" ;
     :definition "A Self-Organizing Map (SOM) is a unsupervised learning model in Artificial Neural Network where the feature maps are the generated two-dimensional discretized form of an input space during the model training (based on competitive learning)" ;
-    :kb-article """## References\r
+    :kb-article """## References
 GeeksforGeeks. (n.d.). ANN - Self Organizing Neural Network (SONN). [Link](https://www.geeksforgeeks.org/ann-self-organizing-neural-network-sonn/)""" ;
     :todo "May be called SONN based on citation" .
 
@@ -16155,7 +16155,7 @@ GeeksforGeeks. (n.d.). ANN - Self Organizing Neural Network (SONN). [Link](https
     rdfs:subClassOf :Semi-supervisedWrapperMethod ;
     :d3fend-id "D3A-SSB" ;
     :definition "Boosting methods can be readily extended to the semi-supervised setting, by introducing pseudo-labeled data after each learning step; which gives rise to the idea of semi-supervised boosting methods. The pseudo-labeling approach of self- training and co-training can be easily extended to boosting methods. Several boosting methods such as SSMBoost, ASSEMBLE, SemiBoost, RegBoost, etc can be found which can be applied for utilizing unlabeled datasets for supervised classifiers." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedCluster-then-label a owl:Class,
@@ -16164,7 +16164,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :UnsupervisedPreprocessing ;
     :d3fend-id "D3A-SSCTL" ;
     :definition "Pre-training methods are aimed to guide the parameters of a network towards interesting regions in model space using unlabeled data, before fine-tuning the parameters with the labeled data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedCo-training a owl:Class,
@@ -16173,7 +16173,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :Semi-supervisedWrapperMethod ;
     :d3fend-id "D3A-SSCT" ;
     :definition "Multi-view co-training involves training the classifiers in completely different views of training data. On the other hand, single-view co-training methods are generally applied as ensemble methods." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedFeatureExtraction a owl:Class,
@@ -16182,7 +16182,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :UnsupervisedPreprocessing ;
     :d3fend-id "D3A-SSFE" ;
     :definition "Feature extraction refers to reducing the number of dimensions in a data point so that it is computationally feasible and effective to learn a model." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedGenerativeModelLearning a owl:Class,
@@ -16191,7 +16191,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-SSGML" ;
     :definition "A Semi Supervised Machine Learning model which assume that the distributions take some particular form p(x|y,theta) parameterized by the vector. If these assumptions are incorrect, the unlabeled data may actually decrease the accuracy of the solution relative to what would have been obtained from labeled data alone. However, if the assumptions are correct, then the unlabeled data necessarily improves performance." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervision#Generative_models).""" .
 
 :Semi-supervisedInductiveLearning a owl:Class,
@@ -16199,11 +16199,11 @@ Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervis
     rdfs:label "Semi-supervised Inductive Learning" ;
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-SSIL" ;
-    :definition """The goal of inductive learning is to infer the correct mapping from\r
+    :definition """The goal of inductive learning is to infer the correct mapping from
 X to Y""" ;
-    :kb-article """## References\r
-Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).\r
-\r
+    :kb-article """## References
+Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).
+
 Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularization. In Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL) (pp. 1-9).  [Link](https://www.cs.sfu.ca/~anoop/papers/pdf/semisup_naacl.pdf).""" .
 
 :Semi-SupervisedLearning a owl:Class,
@@ -16212,7 +16212,7 @@ Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularizati
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-SSL" ;
     :definition "Semi-supervised learning is a branch of machine learning that combines a small amount of labeled data with a large amount of unlabeled data during training." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning).""" ;
     rdfs:seeAlso "https://link.springer.com/article/10.1007/s10994-019-05855-6" .
 
@@ -16222,7 +16222,7 @@ Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-SSML" ;
     :definition "A version of Semi-Supervised Learning that applies the Manifold assumption that the data like approximately on a manifold of much lower dimension than the input space." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervision#Generative_models).""" .
 
 :Semi-supervisedPre-training a owl:Class,
@@ -16231,7 +16231,7 @@ Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervis
     rdfs:subClassOf :UnsupervisedPreprocessing ;
     :d3fend-id "D3A-SSPT" ;
     :definition "Pre-training methods are aimed to guide the parameters of a network towards interesting regions in model space using unlabeled data, before fine-tuning the parameters with the labeled data" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedSelf-training a owl:Class,
@@ -16240,7 +16240,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :Semi-supervisedWrapperMethod ;
     :d3fend-id "D3A-SSST" ;
     :definition "Self-training is the procedure in which a supervised method for classification or regression is modified it to work in a semi-supervised manner, taking advantage of labeled and unlabeled data" ;
-    :kb-article """## References\r
+    :kb-article """## References
 AltexSoft. (n.d.). Semi-Supervised Learning: A Technical Guide with Python Examples. [Link](https://www.altexsoft.com/blog/semi-supervised-learning/#:~:text=One%20of%20the%20simplest%20examples,of%20labeled%20and%20unlabeled%20data.)""" .
 
 :Semi-supervisedTransductiveLearning a owl:Class,
@@ -16248,11 +16248,11 @@ AltexSoft. (n.d.). Semi-Supervised Learning: A Technical Guide with Python Examp
     rdfs:label "Semi-supervised Transductive Learning" ;
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-SSTL" ;
-    :definition """The goal of transductive learning is to infer the correct labels for the given unlabeled data\r
+    :definition """The goal of transductive learning is to infer the correct labels for the given unlabeled data
 x_{l+1},... ,x_{l+u} only""" ;
-    :kb-article """## References\r
-Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).\r
-\r
+    :kb-article """## References
+Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).
+
 Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularization. In Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL) (pp. 1-9). [Link](https://www.cs.sfu.ca/~anoop/papers/pdf/semisup_naacl.pdf).""" .
 
 :Semi-supervisedWrapperMethod a owl:Class,
@@ -16261,7 +16261,7 @@ Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularizati
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-SSWM" ;
     :definition "The principle behind wrapper methods is that we train a model with labeled data and then generate pseudo-labels for the unlabeled data using the trained model iteratively." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Jashish, M. (n.d.). Beginner's Guide to Semi-Supervised Learning. Jashish Blog.  [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/).""" .
 
 :SenderMTAReputationAnalysis a :MessageAnalysis,
@@ -16274,20 +16274,20 @@ Jashish, M. (n.d.). Beginner's Guide to Semi-Supervised Learning. Jashish Blog. 
             owl:someValuesFrom :Email ] ;
     :d3fend-id "D3-SMRA" ;
     :definition "Characterizing the reputation of mail transfer agents (MTA) to determine the security risk in emails." ;
-    :kb-article """## How it works\r
-The sender message transfer agent (MTA) trust rating can be considered an indicator of the level of security risk and/or a trust level associated with sender MTAs in an email header.\r
-\r
-The features considered in determining the trust rating may include:\r
-\r
-* Length of time MTA has interacted with the enterprise\r
-* Number of sender domains sending emails from the MTA\r
-* Number of recipients in the enterprise the MTA sends emails to\r
-* Number of emails received from this MTA\r
-* Number of email replies received from this MTA\r
-\r
-For example, higher values for the length of time an MTA has interacted with the enterprise, or number of emails received from an MTA can result in a higher trust rating. The trust rating categorizes the sender MTA as unrated, neutral, trusted, suspicious, or malicious.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+The sender message transfer agent (MTA) trust rating can be considered an indicator of the level of security risk and/or a trust level associated with sender MTAs in an email header.
+
+The features considered in determining the trust rating may include:
+
+* Length of time MTA has interacted with the enterprise
+* Number of sender domains sending emails from the MTA
+* Number of recipients in the enterprise the MTA sends emails to
+* Number of emails received from this MTA
+* Number of email replies received from this MTA
+
+For example, higher values for the length of time an MTA has interacted with the enterprise, or number of emails received from an MTA can result in a higher trust rating. The trust rating categorizes the sender MTA as unrated, neutral, trusted, suspicious, or malicious.
+
+## Considerations
 Legitimate emails from a sender MTA may receive a lower trust rating over time if the sender's domain gets spoofed and is used to send unauthorized emails.""" ;
     :kb-reference :Reference-SystemsAndMethodsForDetectingAnd_orHandlingTargetedAttacksInTheEmailChannel_GraphusInc .
 
@@ -16301,25 +16301,25 @@ Legitimate emails from a sender MTA may receive a lower trust rating over time i
             owl:someValuesFrom :Email ] ;
     :d3fend-id "D3-SRA" ;
     :definition "Ascertaining sender reputation based on information associated with a message (e.g. email/instant messaging)." ;
-    :kb-article """## How it works\r
-\r
-Sender trust rating can be considered an indicator of the level of security risk and/or a trust level associated with a sender. The features considered in determining the trust rating include:\r
-\r
-* Length of time sender has sent emails to the enterprise\r
-* Number of recipients in the enterprise the sender interacts with\r
-* Sender vs. enterprise originated message ratio\r
-* Sender messages opened vs. not-opened ratio\r
-* Number of emails received from this sender\r
-* Number of emails replied to this sender\r
-* Number of emails from this sender not opened\r
-* Number of emails from this sender not opened that contain an attachment\r
-* Number of emails from this sender not opened that contain a URL\r
-* Number of emails sent to this sender\r
-* Number of email replies received from this sender.\r
-\r
-Higher values for the number of recipients the sender has interacted with or the number of emails received from the sender, for example, results in a higher trust rating. The trust rating can categorize the sender as unrated, neutral, trusted, suspicious, or malicious.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+
+Sender trust rating can be considered an indicator of the level of security risk and/or a trust level associated with a sender. The features considered in determining the trust rating include:
+
+* Length of time sender has sent emails to the enterprise
+* Number of recipients in the enterprise the sender interacts with
+* Sender vs. enterprise originated message ratio
+* Sender messages opened vs. not-opened ratio
+* Number of emails received from this sender
+* Number of emails replied to this sender
+* Number of emails from this sender not opened
+* Number of emails from this sender not opened that contain an attachment
+* Number of emails from this sender not opened that contain a URL
+* Number of emails sent to this sender
+* Number of email replies received from this sender.
+
+Higher values for the number of recipients the sender has interacted with or the number of emails received from the sender, for example, results in a higher trust rating. The trust rating can categorize the sender as unrated, neutral, trusted, suspicious, or malicious.
+
+## Considerations
 Legitimate emails from a sender may receive a lower trust rating over time if the sender's domain gets spoofed and is used to send unauthorized emails.""" ;
     :kb-reference :Reference-SystemsAndMethodsForDetectingAnd_orHandlingTargetedAttacksInTheEmailChannel_GraphusInc .
 
@@ -16334,7 +16334,7 @@ Legitimate emails from a sender may receive a lower trust rating over time if th
     rdfs:subClassOf :GenerativeAdversarialNetwork ;
     :d3fend-id "D3A-SEQ" ;
     :definition "Sequence Generation Framework (SeqGAN) models the data generator as a stochastic policy in reinforcement learning (RL), SeqGAN bypasses the generator differentiation problem by directly performing gradient policy update." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Yu, L., Zhang, W., Wang, J., & Yu, Y. (2017). SeqGAN: Sequence Generative Adversarial Nets with Policy Gradient. ArXiv preprint ArXiv:1609.05473. [Link](https://arxiv.org/abs/1609.05473)""" ;
     :synonym "Sequence GAN" .
 
@@ -16381,11 +16381,11 @@ Yu, L., Zhang, W., Wang, J., & Yu, Y. (2017). SeqGAN: Sequence Generative Advers
             owl:someValuesFrom :ServiceApplication ] ;
     :d3fend-id "D3-SBV" ;
     :definition "Analyzing changes in service binary files by comparing to a source of truth." ;
-    :kb-article """## How it works\r
-System service applications may originate from the operating system installation or third-party applications installed with administrative privileges. These services have an entry point of some executable file-- a binary or a script. Attackers sometimes modify these executables to launch their own code. Analyzing changes in these files may uncover unauthorized activity.\r
-\r
-## Considerations\r
-* These files change for legitimate reasons when the system or software updates.\r
+    :kb-article """## How it works
+System service applications may originate from the operating system installation or third-party applications installed with administrative privileges. These services have an entry point of some executable file-- a binary or a script. Attackers sometimes modify these executables to launch their own code. Analyzing changes in these files may uncover unauthorized activity.
+
+## Considerations
+* These files change for legitimate reasons when the system or software updates.
 * The source of truth must not be corrupted in order for this method to work.""" ;
     :kb-reference :Reference-ServiceBinaryModifications_MITRE .
 
@@ -16404,12 +16404,12 @@ System service applications may originate from the operating system installation
             owl:someValuesFrom :ServiceDependency ] ;
     :d3fend-id "D3-SVCDM" ;
     :definition "Service dependency mapping determines the services on which each given service relies." ;
-    :kb-article """## How it works\r
-The organization collects and models architectural information about the services and consumers of services and maps the dependencies between the services.\r
-\r
-## Considerations\r
-* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.\r
-* Service dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.\r
+    :kb-article """## How it works
+The organization collects and models architectural information about the services and consumers of services and maps the dependencies between the services.
+
+## Considerations
+* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.
+* Service dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.
 * Service dependencies in cloud or microservice architectures may be discovered using distributed tracing capabilities""" ;
     :kb-reference :Reference-CatiaUAFPlugin,
         :Reference-TivoliApplicationDependencyDiscoverManager7_3_0DependenciesBetweenResources,
@@ -16455,11 +16455,11 @@ The organization collects and models architectural information about the service
             owl:someValuesFrom :Authorization ] ;
     :d3fend-id "D3-SDA" ;
     :definition "Analyzing the duration of user sessions in order to detect unauthorized  activity." ;
-    :kb-article """## How it works\r
-Detecting unauthorized user sessions by comparing the duration of a user logon session with a baseline behavior model. The behavior model comprises historical user session duration times.  Abnormalities between session duration and the behavior model may indicate suspicious activity.\r
-\r
-## Considerations\r
-* Potential for false positives from anomalies that are not associated with malicious activity.\r
+    :kb-article """## How it works
+Detecting unauthorized user sessions by comparing the duration of a user logon session with a baseline behavior model. The behavior model comprises historical user session duration times.  Abnormalities between session duration and the behavior model may indicate suspicious activity.
+
+## Considerations
+* Potential for false positives from anomalies that are not associated with malicious activity.
 * Attackers may not differentiate their session duration enough to trigger an alert.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC .
@@ -16492,10 +16492,10 @@ Detecting unauthorized user sessions by comparing the duration of a user logon s
             owl:someValuesFrom :StackFrame ] ;
     :d3fend-id "D3-SSC" ;
     :definition "Comparing a call stack in system memory with a shadow call stack maintained by the processor to determine unauthorized shellcode activity." ;
-    :kb-article """## How it works\r
-This technique compares the call stack stored in system memory with the shadow call stack maintained in the cache memory of the processor.  Mismatches between the two are compared since a return oriented programming attack may only be able to control or spoof the call stack and not the shadow call stack. Mismatches are counted and if the number of mismatches exceeds a certain threshold it is an indication of unauthorized activity and a security response action is performed.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+This technique compares the call stack stored in system memory with the shadow call stack maintained in the cache memory of the processor.  Mismatches between the two are compared since a return oriented programming attack may only be able to control or spoof the call stack and not the shadow call stack. Mismatches are counted and if the number of mismatches exceeds a certain threshold it is an indication of unauthorized activity and a security response action is performed.
+
+## Considerations
 If the threshold for detecting a stack anomaly is low, it may not detect a return-oriented attack with just one gadget, such as a return-to-libc or return-to-plt attack.  Additionally, this technique may not detect JOP (Jump-oriented programming), as the return instruction is not executed.""" ;
     :kb-reference :Reference-ThreatDetectionForReturnOrientedProgramming_CrowdstrikeInc .
 
@@ -16535,20 +16535,20 @@ If the threshold for detecting a stack anomaly is low, it may not detect a retur
 :ShortcutFile a owl:Class ;
     rdfs:label "Shortcut File" ;
     rdfs:subClassOf :File ;
-    :definition """A shortcut file, or shortcut, is a handle that allows the user to find a file or resource located in a different directory or folder from the place where the shortcut is located.\r
-\r
-Shortcuts, which are supported by the graphical file browsers of some operating systems, may resemble symbolic links but differ in a number of important ways. One difference is what type of software is able to follow them:\r
-\r
- - Symbolic links are automatically resolved by the file system. Any software program, upon accessing a symbolic link, will see the target instead, whether the program is aware of symbolic links or not.\r
-\r
- - Shortcuts are treated like ordinary files by the file system and by software programs that are not aware of them. Only software programs that understand shortcuts (such as the Windows shell and file browsers) treat them as references to other files.\r
-\r
-Another difference are the capabilities of the mechanism:\r
-\r
- - Microsoft Windows shortcuts normally refer to a destination by an absolute path (starting from the root directory), whereas POSIX symbolic links can refer to destinations via either an absolute or a relative path. The latter is useful if both the location and destination of the symbolic link share a common path prefix[clarification needed], but that prefix is not yet known when the symbolic link is created (e.g., in an archive file that can be unpacked anywhere).\r
-\r
-- Microsoft Windows application shortcuts contain additional metadata that can be associated with the destination, whereas POSIX symbolic links are just strings that will be interpreted as absolute or relative pathnames.\r
-\r
+    :definition """A shortcut file, or shortcut, is a handle that allows the user to find a file or resource located in a different directory or folder from the place where the shortcut is located.
+
+Shortcuts, which are supported by the graphical file browsers of some operating systems, may resemble symbolic links but differ in a number of important ways. One difference is what type of software is able to follow them:
+
+ - Symbolic links are automatically resolved by the file system. Any software program, upon accessing a symbolic link, will see the target instead, whether the program is aware of symbolic links or not.
+
+ - Shortcuts are treated like ordinary files by the file system and by software programs that are not aware of them. Only software programs that understand shortcuts (such as the Windows shell and file browsers) treat them as references to other files.
+
+Another difference are the capabilities of the mechanism:
+
+ - Microsoft Windows shortcuts normally refer to a destination by an absolute path (starting from the root directory), whereas POSIX symbolic links can refer to destinations via either an absolute or a relative path. The latter is useful if both the location and destination of the symbolic link share a common path prefix[clarification needed], but that prefix is not yet known when the symbolic link is created (e.g., in an archive file that can be unpacked anywhere).
+
+- Microsoft Windows application shortcuts contain additional metadata that can be associated with the destination, whereas POSIX symbolic links are just strings that will be interpreted as absolute or relative pathnames.
+
 - Unlike symbolic links, Windows shortcuts maintain their references to their targets even when the target is moved or renamed. Windows domain clients may subscribe to a Windows service called Distributed Link Tracking to track the changes in files and folders to which they are interested. The service maintains the integrity of shortcuts, even when files and folders are moved across the network.[14] Additionally, in Windows 9x and later, Windows shell tries to find the target of a broken shortcut before proposing to delete it.""" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Shortcut_(computing)>,
         <http://dbpedia.org/resource/Symbolic_link#Shortcuts> .
@@ -16563,7 +16563,7 @@ Another difference are the capabilities of the mechanism:\r
     rdfs:subClassOf :DimensionReduction ;
     :d3fend-id "D3A-SVD" ;
     :definition "Singular Value Decomposition (SVD) is an algorithm that represents a matrix as a linear series of data and to find the set of factors that will best predict an outcome" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Singular value decomposition. [Link](https://en.wikipedia.org/wiki/Singular_value_decomposition)""" .
 
 :Skewness a owl:Class,
@@ -16572,7 +16572,7 @@ Wikipedia. (n.d.). Singular value decomposition. [Link](https://en.wikipedia.org
     rdfs:subClassOf :DistributionProperties ;
     :d3fend-id "D3A-SKE" ;
     :definition "Skewness is a measure of the asymmetry of the probability distribution of a real-valued random variable about its mean. The standardized moment of a probability distribution function." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
 
 :SlowSymbolicLink a owl:Class ;
@@ -16620,20 +16620,20 @@ Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
             owl:someValuesFrom :Software ] ;
     :d3fend-id "D3-SWI" ;
     :definition "Software inventorying identifies and records the software items in the organization's architecture." ;
-    :kb-article """## How it works\r
-Administrators collect information on software items in their architecture using a variety of administrative and management tools that query network nodes for information.  In limited cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to determine services responding on network nodes.\r
-\r
-## Considerations\r
-* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.\r
-* An adversary conducting network enumeration may engage in activities that parallel normal software inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools.\r
-\r
-## Examples\r
-\r
-Application-layer discovery:\r
-\r
-* Simple Network Management Protocol (SNMP) collects MIB information\r
-* Web-based Enterprise Management (WBEM) collects CIM information\r
-   * Windows Management Instrumentation (WMI)\r
+    :kb-article """## How it works
+Administrators collect information on software items in their architecture using a variety of administrative and management tools that query network nodes for information.  In limited cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to determine services responding on network nodes.
+
+## Considerations
+* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.
+* An adversary conducting network enumeration may engage in activities that parallel normal software inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools.
+
+## Examples
+
+Application-layer discovery:
+
+* Simple Network Management Protocol (SNMP) collects MIB information
+* Web-based Enterprise Management (WBEM) collects CIM information
+   * Windows Management Instrumentation (WMI)
    * Windows Management Infrastructure (MI)""" ;
     :kb-reference :Reference-Web-BasedEnterpriseManagement,
         :Reference-Windows-Management-Infrastructure,
@@ -16718,10 +16718,10 @@ Application-layer discovery:\r
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-SM" ;
     :definition "Soundex is a phonetic algorithm for indexing names by sound, as pronounced in English." ;
-    :kb-article """## How it works\r
-The goal is for homophones to be encoded to the same representation so that they can be matched despite minor differences in spelling. The algorithm mainly encodes consonants; a vowel will not be encoded unless it is the first letter. Soundex is the most widely known of all phonetic algorithms (in part because it is a standard feature of popular database software. Improvements to Soundex are the basis for many modern phonetic algorithms.\r
-\r
-## References\r
+    :kb-article """## How it works
+The goal is for homophones to be encoded to the same representation so that they can be matched despite minor differences in spelling. The algorithm mainly encodes consonants; a vowel will not be encoded unless it is the first letter. Soundex is the most widely known of all phonetic algorithms (in part because it is a standard feature of popular database software. Improvements to Soundex are the basis for many modern phonetic algorithms.
+
+## References
 1. Soundex. (2023, April 19). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Soundex)""" .
 
 :SourceCode a owl:Class,
@@ -16772,7 +16772,7 @@ The goal is for homophones to be encoded to the same representation so that they
     rdfs:subClassOf :Graph-basedClustering ;
     :d3fend-id "D3A-SC" ;
     :definition "Spectral clustering is a technique that identifies communities of nodes in a graph based on the edges connecting them." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Towards Data Science. (n.d.). Spectral Clustering. [Link](https://towardsdatascience.com/spectral-clustering-aba2640c0d5b)""" .
 
 :SSHSession a owl:Class ;
@@ -16819,33 +16819,33 @@ Towards Data Science. (n.d.). Spectral Clustering. [Link](https://towardsdatasci
             owl:someValuesFrom :StackFrame ] ;
     :d3fend-id "D3-SFCV" ;
     :definition "Comparing a value stored in a stack frame with a known good value in order to prevent or detect a memory segment overwrite." ;
-    :kb-article """## How it works\r
-\r
-This defense must be applied at compile-time, or via a patch to the program binary.  Stack Frame Canary Verification inserts instructions at the prologue and epilogue of desired functions.  In the prologue, a canary value, typically with the same size as the register size, is stored in the system of record and on the stack.  Typically, the canary is loaded to where it has a memory address just below that of the saved instruction pointer and base pointer.  In the epilogue, the canary value stored on the stack and, is compared to the canary value in the system of record.  If the values are different, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.\r
-\r
-Stack Frame Canary Verification is commonly used to detect potential tampering of a saved register value on the stack before it has been restored.  Examples of registers with values commonly saved to the stack include the instruction pointer and the base pointer.\r
-\r
-The canary should be stored between where the start of a buffer overrun is likely, and the data to protect, in cases where the buffer size increases it will overwrite the data to be protected.\r
-\r
-On most processor architectures, including x86, x64, and ARM, a "push" operation to store data to the stack grows the stack towards a lower memory address.  As in these architectures, saved register values are stored to the stack at a point in time just before space is made for the local function variables, the saved register values have a higher address than that of the local function variables.  Values at increasing indexes of a buffer are written to increasing memory addresses; therefore, an overwrite in the local variable buffer could overwrite saved register values, and a stack canary between these two would be useful in detecting an overwrite.\r
-\r
-On some other processor architectures such as the B5000, the stack grows towards increasing memory addresses, and some architectures, such as System Z and RCA1802A, stack direction can be chosen.  If the stack grows towards increasing memory addresses, while this architecture inherently provides more protection against a saved register being overwritten, other data including local function variables might be overwritten.\r
-\r
-\r
-## Considerations\r
-\r
-There are several ways that the protection provided by a canary could be rendered ineffective.\r
-\r
-### Performing a malicious action before the canary is checked\r
-\r
-If the attacker alters the memory in such a way that it performs a malicious action before the epilogue is called, then this protection will not be effective.  This includes altering the logic of the program by altering the values of local variables stored on the function stack, or by causing an exception and exploiting the exception mechanism such as the SEH (Structured Exception Handling) mechanism on Windows.\r
-\r
-### Determining the canary value\r
-\r
-Determining the canary value is possible through reading memory either for the code used to check the canary, or from the stored canary value itself in a stack frame.\r
-\r
-### Changing the canary value\r
-\r
+    :kb-article """## How it works
+
+This defense must be applied at compile-time, or via a patch to the program binary.  Stack Frame Canary Verification inserts instructions at the prologue and epilogue of desired functions.  In the prologue, a canary value, typically with the same size as the register size, is stored in the system of record and on the stack.  Typically, the canary is loaded to where it has a memory address just below that of the saved instruction pointer and base pointer.  In the epilogue, the canary value stored on the stack and, is compared to the canary value in the system of record.  If the values are different, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.
+
+Stack Frame Canary Verification is commonly used to detect potential tampering of a saved register value on the stack before it has been restored.  Examples of registers with values commonly saved to the stack include the instruction pointer and the base pointer.
+
+The canary should be stored between where the start of a buffer overrun is likely, and the data to protect, in cases where the buffer size increases it will overwrite the data to be protected.
+
+On most processor architectures, including x86, x64, and ARM, a "push" operation to store data to the stack grows the stack towards a lower memory address.  As in these architectures, saved register values are stored to the stack at a point in time just before space is made for the local function variables, the saved register values have a higher address than that of the local function variables.  Values at increasing indexes of a buffer are written to increasing memory addresses; therefore, an overwrite in the local variable buffer could overwrite saved register values, and a stack canary between these two would be useful in detecting an overwrite.
+
+On some other processor architectures such as the B5000, the stack grows towards increasing memory addresses, and some architectures, such as System Z and RCA1802A, stack direction can be chosen.  If the stack grows towards increasing memory addresses, while this architecture inherently provides more protection against a saved register being overwritten, other data including local function variables might be overwritten.
+
+
+## Considerations
+
+There are several ways that the protection provided by a canary could be rendered ineffective.
+
+### Performing a malicious action before the canary is checked
+
+If the attacker alters the memory in such a way that it performs a malicious action before the epilogue is called, then this protection will not be effective.  This includes altering the logic of the program by altering the values of local variables stored on the function stack, or by causing an exception and exploiting the exception mechanism such as the SEH (Structured Exception Handling) mechanism on Windows.
+
+### Determining the canary value
+
+Determining the canary value is possible through reading memory either for the code used to check the canary, or from the stored canary value itself in a stack frame.
+
+### Changing the canary value
+
 A vulnerability such as a write-what-where condition that allows one to write data after the canary in the stack, would allow control of the value of the saved instruction pointer without needing to know the canary value.""" ;
     :kb-reference :Reference-GS_BufferSecurityCheck_MicrosoftDocs,
         :Reference-StackSmashingProtection_StackGuard_RedHat .
@@ -16856,7 +16856,7 @@ A vulnerability such as a write-what-where condition that allows one to write da
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-STA" ;
     :definition "Stacking is a method of using the results and predictions from one layer of ML models as inputs to another layer of ML models. Stacking (sometimes called stacked generalization) involves training a model to combine the predictions of several other learning algorithms." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :StackSegment a owl:Class ;
@@ -16879,10 +16879,10 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
             owl:someValuesFrom :IntranetNetwork ] ;
     :d3fend-id "D3-SHN" ;
     :definition "An environment created for the purpose of attracting attackers and eliciting their behaviors that is not connected to any production enterprise systems." ;
-    :kb-article """## How it works\r
-A standalone honeynet does not directly interact with the real enterprise environment. It may be located near or in some portion of the enterprise address space, but it does not interact with enterprise resources.\r
-\r
-## Considerations\r
+    :kb-article """## How it works
+A standalone honeynet does not directly interact with the real enterprise environment. It may be located near or in some portion of the enterprise address space, but it does not interact with enterprise resources.
+
+## Considerations
 A standalone honeynet is a lower risk to deploy compared to connected or integrated honeynets due to its isolation from the enterprise network. However, this comes at cost in loss of fidelity and realism. Significant extra effort must be made in order to make the environment look realistic.""" ;
     :kb-reference :Reference-DynamicSelectionAndGenerationOfAVirtualCloneForDetonationOfSuspiciousContentWithinAHoneyNetwork_PaloAltoNetworksInc .
 
@@ -16892,7 +16892,7 @@ A standalone honeynet is a lower risk to deploy compared to connected or integra
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-SD" ;
     :definition "The standard deviation is a measure of the amount of variation or dispersion of a set of values." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Standard deviation. [Link](https://en.wikipedia.org/wiki/Standard_deviation)""" ;
     :synonym "SD" .
 
@@ -16924,7 +16924,7 @@ Wikipedia. (n.d.). Standard deviation. [Link](https://en.wikipedia.org/wiki/Stan
     rdfs:subClassOf :AnalyticTechnique ;
     :d3fend-id "D3A-SM" ;
     :definition "Building methods using the mathematical study of the likelihood and probability of events occurring based on known information and inferred by taking a limited number of samples." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Statistics.html)""" .
 
 :Step a owl:Class ;
@@ -16966,8 +16966,8 @@ Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Stat
         :StringPatternMatching ;
     :d3fend-id "D3A-SEM" ;
     :definition "String equivalence matching is a type of string pattern matching which is exact; that is, the strings being compared must have the same value for each character in their sequence and be of the same length." ;
-    :kb-article """## References\r
-1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)\r
+    :kb-article """## References
+1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)
 2. Types of Equality. (2007, March 2). In _WikiWikiWeb_. [Link](https://wiki.c2.com/?TypesOfEquality)""" .
 
 :StringFormatFunction a owl:Class ;
@@ -16981,12 +16981,12 @@ Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Stat
     rdfs:subClassOf :PatternMatching ;
     :d3fend-id "D3A-SPM" ;
     :definition "String pattern-matching algorithms, also known as string-matching algorithms, are an important class of string algorithms that try to find a place where one or several strings (also called patterns) are found within a larger string or text" ;
-    :kb-article """## How it works\r
-A basic example of string searching is when the pattern and the searched text are arrays of elements of an alphabet (finite set) Σ. Σ may be a human language alphabet, for example, the letters A through Z and other applications may use a binary alphabet (Σ = {0,1}) or a DNA alphabet (Σ = {A,C,G,T}) in bioinformatics.\r
-\r
-In practice, the method of feasible string-search algorithm may be affected by the string encoding. In particular, if a variable-width encoding is in use, then it may be slower to find the Nth character, perhaps requiring time proportional to N. This may significantly slow some search algorithms. One of many possible solutions is to search for the sequence of code units instead, but doing so may produce false matches unless the encoding is specifically designed to avoid it.\r
-\r
-## References\r
+    :kb-article """## How it works
+A basic example of string searching is when the pattern and the searched text are arrays of elements of an alphabet (finite set) Σ. Σ may be a human language alphabet, for example, the letters A through Z and other applications may use a binary alphabet (Σ = {0,1}) or a DNA alphabet (Σ = {A,C,G,T}) in bioinformatics.
+
+In practice, the method of feasible string-search algorithm may be affected by the string encoding. In particular, if a variable-width encoding is in use, then it may be slower to find the Nth character, perhaps requiring time proportional to N. This may significantly slow some search algorithms. One of many possible solutions is to search for the sequence of code units instead, but doing so may produce false matches unless the encoding is specifically designed to avoid it.
+
+## References
 1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""" .
 
 :StrongPasswordPolicy a :CredentialHardening,
@@ -17002,9 +17002,9 @@ In practice, the method of feasible string-search algorithm may be affected by t
             owl:someValuesFrom :UserAccount ] ;
     :d3fend-id "D3-SPP" ;
     :definition "Modifying system configuration to increase password strength." ;
-    :kb-article """## How it works\r
-Password strength guidelines include increasing password length, permitting passwords that contain ASCII or Unicode characters, and requiring systems to screen new passwords against lists of commonly used or compromised passwords.\r
-## Considerations\r
+    :kb-article """## How it works
+Password strength guidelines include increasing password length, permitting passwords that contain ASCII or Unicode characters, and requiring systems to screen new passwords against lists of commonly used or compromised passwords.
+## Considerations
 Extremely complex password requirements may lead users to saving passwords in text files or picking obvious passwords that meet the policy.""" ;
     :kb-reference :Reference-DigitalIdentityGuidelines800-63-3,
         :Reference-Testing_Metrics_for_Password_Creation_Policies_by_Attacking_Large_Sets_of_Revealed_Passwords .
@@ -17015,7 +17015,7 @@ Extremely complex password requirements may lead users to saving passwords in te
     rdfs:subClassOf :ImageSynthesisGAN ;
     :d3fend-id "D3A-STY" ;
     :definition "Successor to the ProGAN." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). StyleGAN. [Link](https://en.wikipedia.org/wiki/StyleGAN)""" ;
     :synonym "Style GAN" .
 
@@ -17033,7 +17033,7 @@ Wikipedia. (n.d.). StyleGAN. [Link](https://en.wikipedia.org/wiki/StyleGAN)""" ;
     rdfs:subClassOf :CorrelationClustering ;
     :d3fend-id "D3A-SC" ;
     :definition "Subspace clustering is an extension of traditional clustering that seeks to find clusters in different subspaces within a dataset." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Parsons, L., Haque, E., & Liu, H. (2004). Subspace Clustering for High Dimensional Data: A Review. [Link](https://www.kdd.org/exploration_files/parsons.pdf)""" .
 
 :SubstringMatching a owl:Class,
@@ -17042,7 +17042,7 @@ Parsons, L., Haque, E., & Liu, H. (2004). Subspace Clustering for High Dimension
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-SM" ;
     :definition "String-searching algorithms, sometimes called string-matching algorithms, are an important class of string algorithms that try to find a place where one or several strings (also called patterns) are found within a larger string or text." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""" .
 
 :Summarizing a owl:Class ;
@@ -17055,7 +17055,7 @@ Parsons, L., Haque, E., & Liu, H. (2004). Subspace Clustering for High Dimension
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-SL" ;
     :definition "Supervised learning establishes a relationship between the known input and output variables to conduct a predictive analysis." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Supervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Supervised_learning).""" .
 
 :SupportVectorMachineClassification a owl:Class,
@@ -17064,7 +17064,7 @@ Supervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Supervised
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-SVMC" ;
     :definition "Support Vector Machine (SVM) is a robust classification and regression technique that maximizes the predictive accuracy of a model without overfitting the training data. SVM is particularly suited to analyzing data with very large numbers (for example, thousands) of predictor fields." ;
-    :kb-article """## References\r
+    :kb-article """## References
 About Support Vector Machine (SVM). IBM SPSS Modeler SaaS Documentation. [Link](https://www.ibm.com/docs/en/spss-modeler/saas?topic=models-about-svm&mhsrc=ibmsearch_a&mhq=support%20vector%20machine).""" .
 
 :SuspendProcess a owl:Class ;
@@ -17099,10 +17099,10 @@ About Support Vector Machine (SVM). IBM SPSS Modeler SaaS Documentation. [Link](
     rdfs:subClassOf :SymbolicLogic ;
     :d3fend-id "D3A-SR" ;
     :definition "Symbolic artificial intelligence is the term for the collection of all methods in artificial intelligence that are based on high-level symbolic (human-readable) representations of problems, logic, and search." ;
-    :kb-article """## How it works\r
-Symbolic artificial intelligence is used in tools such as logic programming, production rules, semantic nets and frames, and it developed applications such as knowledge-based systems (in particular, expert systems), symbolic mathematics, automated theorem provers, ontologies, the semantic web, and automated planning and scheduling systems. The Symbolic AI paradigm led to seminal ideas in search, symbolic programming languages, agents, multi-agent systems, the semantic web, and the strengths and limitations of formal knowledge and reasoning systems.\r
-\r
-## References\r
+    :kb-article """## How it works
+Symbolic artificial intelligence is used in tools such as logic programming, production rules, semantic nets and frames, and it developed applications such as knowledge-based systems (in particular, expert systems), symbolic mathematics, automated theorem provers, ontologies, the semantic web, and automated planning and scheduling systems. The Symbolic AI paradigm led to seminal ideas in search, symbolic programming languages, agents, multi-agent systems, the semantic web, and the strengths and limitations of formal knowledge and reasoning systems.
+
+## References
 1. Symbolic artifical intelligence. (2023, May 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Symbolic_artificial_intelligence)""" ;
     :synonym "Symbolic Artificial Intelligence" .
 
@@ -17125,11 +17125,11 @@ Symbolic artificial intelligence is used in tools such as logic programming, pro
     rdfs:subClassOf :AnalyticTechnique ;
     :d3fend-id "D3A-SL" ;
     :definition "Symbolic Logic, also known as formal logic, is a branch of mathematics that uses symbolic representations for logical expressions and relationships. It provides a systematic method for examining the structure of arguments and reasoning, focusing on the relationships between propositions rather than the content of those propositions." ;
-    :kb-article """## How it Works\r
-\r
-## References\r
-1. Symbolic Logic. (2023, June 6). In _Wolfram Mathworld_. [Link](https://mathworld.wolfram.com/SymbolicLogic.html)\r
-2. Hughes, G. and Schagrin, M. (2023, Apr 19). Formal Logic. _Encyclopedia Brittanica_. [Link](https://www.britannica.com/topic/formal-logic)\r
+    :kb-article """## How it Works
+
+## References
+1. Symbolic Logic. (2023, June 6). In _Wolfram Mathworld_. [Link](https://mathworld.wolfram.com/SymbolicLogic.html)
+2. Hughes, G. and Schagrin, M. (2023, Apr 19). Formal Logic. _Encyclopedia Brittanica_. [Link](https://www.britannica.com/topic/formal-logic)
 3. Carnap, R. (1953). Introduction to Symbolic Logic and Its Applications. Dover Publications. [Link](https://archive.org/details/rudolf-carnap-introduction-to-symbolic-logic-and-its-applications/page/3/mode/2up)""" .
 
 :SymmetricFeature-basedTransferLearning a owl:Class,
@@ -17138,7 +17138,7 @@ Symbolic artificial intelligence is used in tools such as logic programming, pro
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-SFTL" ;
     :definition "Homogeneous symmetric transformation takes both the source feature space Xs and target feature space Xt and learns feature transformations as to project each onto a common subspace Xc for adaptation purposes. This derived subspace becomes a domain-invariant feature subspace to associate cross-domain data, and in effect, reduces marginal distribution differences." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learning. *Journal of Big Data, 4*(1), 29. [Link](https://doi.org/10.1186/s40537-017-0089-0).""" .
 
 :SymmetricKey a owl:Class ;
@@ -17174,37 +17174,37 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
             owl:someValuesFrom :SystemCall ] ;
     :d3fend-id "D3-SCA" ;
     :definition "Analyzing system calls to determine whether a process is exhibiting unauthorized behavior." ;
-    :kb-article """## How it works\r
-\r
-System calls are APIs between a user application and the operating system [1].\r
-\r
-By analyzing a process's use of these APIs, it is, in some cases, possible to ascertain whether a program is exhibiting unauthorized behavior, including trying to escalate its privileges.\r
-\r
-### Gathering System Calls\r
-A common method to capture system calls is to use kernel APIs to hook [2] a process's system call invocations.\r
-\r
-The Linux system call `ptrace` tracks other system calls in a process and allows their alteration; this is made use of by GDB.  `strace` utilizes `ptrace` and will print to stdout each system call invoked. Other applications record this data in local or remote databases.\r
-\r
-The log entry for each system call, which may reference additional information such as the date and time, and the process tree for the process which made the system call, is relayed, in real time or post-facto, to an analysis module which consults a catalog or model to determine whether the distribution matches a known-good or known-bad pattern.\r
-\r
-\r
-### Analysis\r
-\r
-System calls are analyzed with a variety of methods. Some analytics look for specific sequences of instructions, others may apply statistical methods to identify abnormal behavior. Sequences of instructions can be abstracted into conceptually higher order user activities, for example:\r
-\r
-* An attacker executes many system calls in a short period of time, with several sequences which could be used to escalate privileges.\r
-* Getting the contents from a URL, writing to a new file, and then executing the same file.\r
-* A ransomware program which either uses a loop or creates many threads to: read a specified file, encrypt its contents, create an output file with a similar name to the original file, and delete the unencrypted original.\r
-\r
-## Considerations\r
-\r
-* Duplicative or extraneous system calls may be added to malware to defeat analytics.\r
-* Malware could replace API hooking instructions to allow system calls to be made without being monitored.\r
-* A model built from a training set of system calls and related data may not be updated fast enough to detect new threats.\r
-\r
-\r
-[1] [Syscalls](http://man7.org/linux/man-pages/man2/syscalls.2.html)\r
-\r
+    :kb-article """## How it works
+
+System calls are APIs between a user application and the operating system [1].
+
+By analyzing a process's use of these APIs, it is, in some cases, possible to ascertain whether a program is exhibiting unauthorized behavior, including trying to escalate its privileges.
+
+### Gathering System Calls
+A common method to capture system calls is to use kernel APIs to hook [2] a process's system call invocations.
+
+The Linux system call `ptrace` tracks other system calls in a process and allows their alteration; this is made use of by GDB.  `strace` utilizes `ptrace` and will print to stdout each system call invoked. Other applications record this data in local or remote databases.
+
+The log entry for each system call, which may reference additional information such as the date and time, and the process tree for the process which made the system call, is relayed, in real time or post-facto, to an analysis module which consults a catalog or model to determine whether the distribution matches a known-good or known-bad pattern.
+
+
+### Analysis
+
+System calls are analyzed with a variety of methods. Some analytics look for specific sequences of instructions, others may apply statistical methods to identify abnormal behavior. Sequences of instructions can be abstracted into conceptually higher order user activities, for example:
+
+* An attacker executes many system calls in a short period of time, with several sequences which could be used to escalate privileges.
+* Getting the contents from a URL, writing to a new file, and then executing the same file.
+* A ransomware program which either uses a loop or creates many threads to: read a specified file, encrypt its contents, create an output file with a similar name to the original file, and delete the unencrypted original.
+
+## Considerations
+
+* Duplicative or extraneous system calls may be added to malware to defeat analytics.
+* Malware could replace API hooking instructions to allow system calls to be made without being monitored.
+* A model built from a training set of system calls and related data may not be updated fast enough to detect new threats.
+
+
+[1] [Syscalls](http://man7.org/linux/man-pages/man2/syscalls.2.html)
+
 [2] [Hooking](http://dbpedia.org/resource/Hooking)""" ;
     :kb-reference :Reference-CAR-2020-05-001%3AMiniDumpOfLSASS_MITRE,
         :Reference-CAR-2021-05-011%3ACreateRemoteThreadIntoLSASS_MITRE,
@@ -17283,7 +17283,7 @@ System calls are analyzed with a variety of methods. Some analytics look for spe
             owl:someValuesFrom :OperatingSystemProcess ] ;
     :d3fend-id "D3-SDM" ;
     :definition "Tracking changes to the state or configuration of critical system level processes." ;
-    :kb-article """## How it works\r
+    :kb-article """## How it works
 Attackers may manipulate system settings or services to disable system logging or monitoring of security tools and events. Firewall and antivirus services are popular targets for attackers. Disabling system logs will also allow an attacker's actions to go unnoticed. Analysis of logs, registries, and process monitoring help defenders locate signs of tampering. Two possible approaches are to monitor hardened system services or to monitor registry updates for modifications to security settings.""" ;
     :kb-reference :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
         :Reference-MethodUsingKernelModeAssistanceForTheDetectionAndRemovalOfThreatsWhichAreActivelyPreventingDetectionAndRemovalFromARunningSystem_SymantecCorporation,
@@ -17307,15 +17307,15 @@ Attackers may manipulate system settings or services to disable system logging o
             owl:someValuesFrom :SystemDependency ] ;
     :d3fend-id "D3-SYSDM" ;
     :definition "System dependency mapping identifies and models the dependencies of system components on each other to carry out their function." ;
-    :kb-article """## How it works\r
-The organization collects and models architectural information about the software, hardware, and products and maps the dependencies between systems, including each system's internal components and dependencies.\r
-\r
-## Considerations\r
-* Data exchanges identified in the network mapping efforts usually indicate such dependencies, but may not be part of the intended design.\r
-* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.\r
-* System depedency mapping can identify internal dependencies of standard and pre-built systems that should be incorporated into a complete system dependency model.\r
-* System dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.\r
-* System dependencies should identify the integral components of a given named system and their structure to form a system.\r
+    :kb-article """## How it works
+The organization collects and models architectural information about the software, hardware, and products and maps the dependencies between systems, including each system's internal components and dependencies.
+
+## Considerations
+* Data exchanges identified in the network mapping efforts usually indicate such dependencies, but may not be part of the intended design.
+* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.
+* System depedency mapping can identify internal dependencies of standard and pre-built systems that should be incorporated into a complete system dependency model.
+* System dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.
+* System dependencies should identify the integral components of a given named system and their structure to form a system.
 * System dependencies with a given system may be fixed by a particular product's configuration, and leveraging external knowledge bases about dependencies available (e.g., from package managers) is essential.""" ;
     :kb-reference :Reference-CatiaUAFPlugin,
         :Reference-SoftwareVulnerabilityGraphDatabase,
@@ -17332,13 +17332,13 @@ The organization collects and models architectural information about the softwar
             owl:someValuesFrom :OperatingSystemFile ] ;
     :d3fend-id "D3-SFA" ;
     :definition "Monitoring system files such as authentication databases, configuration files, system logs, and system executables for modification or tampering." ;
-    :kb-article """## How it works\r
-This technique ensures the integrity of system owned file resources. System files can impact the behavior below the user level.\r
-\r
-\r
-## Considerations\r
-* Need to manage the size of log file analysis.\r
-* False positives are a concern with this technique and filtering will need to be given additional thought.\r
+    :kb-article """## How it works
+This technique ensures the integrity of system owned file resources. System files can impact the behavior below the user level.
+
+
+## Considerations
+* Need to manage the size of log file analysis.
+* False positives are a concern with this technique and filtering will need to be given additional thought.
 * A baseline or snapshot of file checksums should be established for future comparison.""" ;
     :kb-reference :Reference-AccessPermissionModification_MITRE,
         :Reference-AutorunDifferences_MITRE,
@@ -17371,13 +17371,13 @@ This technique ensures the integrity of system owned file resources. System file
             owl:someValuesFrom :SystemFirmware ] ;
     :d3fend-id "D3-SFV" ;
     :definition "Cryptographically verifying installed system firmware integrity." ;
-    :kb-article """## How it works\r
-Cryptographic hash values are computed for system firmware. The hash values are compared against precomputed firmware hash values to determine if the firmware has been tampered with.\r
-\r
-When system firmware verification fails a set of predefined responses is typically invoked. The responses may direct the system to disable some devices or operations.\r
-\r
-## Considerations\r
-* Requires the use of system provided security modules\r
+    :kb-article """## How it works
+Cryptographic hash values are computed for system firmware. The hash values are compared against precomputed firmware hash values to determine if the firmware has been tampered with.
+
+When system firmware verification fails a set of predefined responses is typically invoked. The responses may direct the system to disable some devices or operations.
+
+## Considerations
+* Requires the use of system provided security modules
 * Secure hash values will need to be computed for firmware""" ;
     :kb-reference :Reference-FirmwareVerificationEclypsium,
         :Reference-PlatformFirmwareResiliencyGuidelines_NIST .
@@ -22655,7 +22655,7 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :Projection-basedClustering ;
     :d3fend-id "D3A-TSC" ;
     :definition "T-distributed Stochastic Neighbor Embedding (t-SNE) is a statistical method for visualizing high-dimensional data by giving each datapoint a location in a two or three-dimensional map." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). T-distributed stochastic neighbor embedding. [Link](https://en.wikipedia.org/wiki/T-distributed_stochastic_neighbor_embedding)""" .
 
 :TabletComputer a owl:Class ;
@@ -22701,7 +22701,7 @@ Wikipedia. (n.d.). T-distributed stochastic neighbor embedding. [Link](https://e
     rdfs:comment "Temporal difference (TD) learning refers to a class of model-free reinforcement learning methods which learn by bootstrapping from the current estimate of the value function." ;
     :d3fend-id "D3A-TDL" ;
     :definition "Temporal difference (TD) learning refers to a class of model-free reinforcement learning methods which learn by bootstrapping from the current estimate of the value function. These methods sample from the environment, like Monte Carlo methods, and perform updates based on current estimates, like dynamic programming methods" ;
-    :kb-article """## References\r
+    :kb-article """## References
 Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Temporal_difference_learning).""" .
 
 :TemporalLogic a owl:Class,
@@ -22710,7 +22710,7 @@ Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/T
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-TL" ;
     :definition "Temporal logic addresses the semantics of tense; i.e., qualifying expressions of when." ;
-    :kb-article """## References\r
+    :kb-article """## References
 1. Temporal logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Temporal_logic)""" .
 
 :TerminateProcess a owl:Class ;
@@ -22782,7 +22782,7 @@ Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/T
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-TSA" ;
     :definition "Time series analysis comprises methods for analyzing time series data in order to extract meaningful statistics and other characteristics of the data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Time series. [Link](https://en.wikipedia.org/wiki/Time_series)""" ;
     :todo "Lots of time series leaves couls be put here." .
 
@@ -22793,18 +22793,18 @@ Wikipedia. (n.d.). Time series. [Link](https://en.wikipedia.org/wiki/Time_series
     rdfs:subClassOf :PlatformHardening ;
     :d3fend-id "D3-TBI" ;
     :definition "Assuring the integrity of a platform by demonstrating that the boot process starts from a trusted combination of hardware and software and continues until the operating system has fully booted and applications are running.  Sometimes called Static Root of Trust Measurement (STRM)." ;
-    :kb-article """## How it works\r
-During the boot process, the BIOS boot block (which with this defense enabled, is the Core Root of Trust for Measurement) measures boot components (firmware, ROM). The TPM hashes those measurements and stores the hashes in Platform Configuration Registers (PCRs).  Upon a subsequent boot, these hashes are provided to a verifier which compares the stored measurements to the new boot measurements. Integrity of the boot components is assured if they match.\r
-\r
-Attestation of the secure boot occurs when a verifying entity requests a Quote which is a concatenation of the requested PCR values, hashed and signed by the TPM's unique RSA key.  The TPM signature is trusted because the private key is stored securely in hardware and never leaves the TPM.\r
-\r
-## Considerations\r
-\r
-* The TPM does not perform the follow-on actions of acting on the PCR value information, it just provides the PCR stored information.\r
-* The current version of TPM is 2.0.; most existing implementations use TPM 1.2.\r
-\r
-## Citations\r
-[1] [TPM 2.0 Library](https://trustedcomputinggroup.org/resource/tpm-library-specification/)\r
+    :kb-article """## How it works
+During the boot process, the BIOS boot block (which with this defense enabled, is the Core Root of Trust for Measurement) measures boot components (firmware, ROM). The TPM hashes those measurements and stores the hashes in Platform Configuration Registers (PCRs).  Upon a subsequent boot, these hashes are provided to a verifier which compares the stored measurements to the new boot measurements. Integrity of the boot components is assured if they match.
+
+Attestation of the secure boot occurs when a verifying entity requests a Quote which is a concatenation of the requested PCR values, hashed and signed by the TPM's unique RSA key.  The TPM signature is trusted because the private key is stored securely in hardware and never leaves the TPM.
+
+## Considerations
+
+* The TPM does not perform the follow-on actions of acting on the PCR value information, it just provides the PCR stored information.
+* The current version of TPM is 2.0.; most existing implementations use TPM 1.2.
+
+## Citations
+[1] [TPM 2.0 Library](https://trustedcomputinggroup.org/resource/tpm-library-specification/)
 [2] [TCG Trusted Attestation Protocol (TAP) Use Cases for TPM Families 1.2 and 2.0 and DICE](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TNC_TAP_Use_Cases_v1r0p35_published.pdf)""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-TPM2.0LibrarySpecification_TrustedComputingGroup,Incorporated>,
         :Reference-TCGTrustedAttestationProtocolUseCasesForTPMFamilies1.2And2.0AndDICE,
@@ -22834,22 +22834,22 @@ Attestation of the secure boot occurs when a verifying entity requests a Quote w
     rdfs:subClassOf :MessageHardening ;
     :d3fend-id "D3-TAAN" ;
     :definition "Validating that server components of a messaging infrastructure are authorized to send a particular message." ;
-    :kb-article """## How it works\r
-Transfer Agent Authentication can be accomplished in different ways for depending on the protocol. In Email,  Sender Policy Framework (SPF), Domain Key Identified Email (DKIM) or Domain-based Message Authentication Reporting and Conformance (DMARC) to validate sender domain ownership.\r
-\r
-### SPF\r
-SPF protocol allows for mail domain owners to specify the mail servers they use when sending email. SPF requires the use of SPF records published in the Domain Name System (DNS). The records record the authorized IPs for email senders. SPF uses the return-path address for domain IP identification. Email that is forwarded may cause the return-path validation problems.\r
-### DKIM\r
-DKIM also uses a record entry in DNS for authentication but does not rely on the simple return-path for validation. A signature header is added to email and encryption is used for security. This adds an additional layer of complexity and requires that DKIM servers be configured identified cryptographic signatures. The additional complexity results in a validation process that can survive complex routing of emails.\r
-\r
-### DMARC\r
-DMARC is an email policy and authentication protocol that seeks to ensure that the "From" field of emails is not spoofed. DMARC makes use of both SPF records and DKIM published key validation. DMARC also has a decision policy framework, contained in a DMARC record, for handling of rejected email. The DMARC framework also updates DMARC domains with authentication statues for allowed senders of that domain.\r
-\r
-## Considerations\r
-- Additional work is required to ensure that all SPF, DKIM and DMARC records are current and up to date.\r
-- Maintenance of DKIM signing keys is needed.\r
-- Using SPF without DKIM and DMARC verifies the Return-Path domain however does not prevent spoofing of the displayed From: address.\r
-- Parts of an email that are not signed or verified by email authentication methods, such as the message body or the header To: and Subject: fields, can be altered or modified.\r
+    :kb-article """## How it works
+Transfer Agent Authentication can be accomplished in different ways for depending on the protocol. In Email,  Sender Policy Framework (SPF), Domain Key Identified Email (DKIM) or Domain-based Message Authentication Reporting and Conformance (DMARC) to validate sender domain ownership.
+
+### SPF
+SPF protocol allows for mail domain owners to specify the mail servers they use when sending email. SPF requires the use of SPF records published in the Domain Name System (DNS). The records record the authorized IPs for email senders. SPF uses the return-path address for domain IP identification. Email that is forwarded may cause the return-path validation problems.
+### DKIM
+DKIM also uses a record entry in DNS for authentication but does not rely on the simple return-path for validation. A signature header is added to email and encryption is used for security. This adds an additional layer of complexity and requires that DKIM servers be configured identified cryptographic signatures. The additional complexity results in a validation process that can survive complex routing of emails.
+
+### DMARC
+DMARC is an email policy and authentication protocol that seeks to ensure that the "From" field of emails is not spoofed. DMARC makes use of both SPF records and DKIM published key validation. DMARC also has a decision policy framework, contained in a DMARC record, for handling of rejected email. The DMARC framework also updates DMARC domains with authentication statues for allowed senders of that domain.
+
+## Considerations
+- Additional work is required to ensure that all SPF, DKIM and DMARC records are current and up to date.
+- Maintenance of DKIM signing keys is needed.
+- Using SPF without DKIM and DMARC verifies the Return-Path domain however does not prevent spoofing of the displayed From: address.
+- Parts of an email that are not signed or verified by email authentication methods, such as the message body or the header To: and Subject: fields, can be altered or modified.
 - Email message authentication does not replace the need to do email content analysis since executables, attachments, or links or other parts of the email beyond the sender domain are not verified.""" ;
     :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
         :Reference-RFC7208-SenderPolicyFramework-SPF-ForAuthorizingUseOfDomainsInEmail-IETF,
@@ -22861,7 +22861,7 @@ DMARC is an email policy and authentication protocol that seeks to ensure that t
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-TL" ;
     :definition "Transfer learning (TL) is a research problem in machine learning (ML) that focuses on storing knowledge gained while solving one problem and applying it to a different but related problem." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Transfer learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Transfer_learning).""" ;
     rdfs:seeAlso "https://arxiv.org/abs/1808.01974",
         "https://arxiv.org/abs/1911.02685",
@@ -22873,7 +22873,7 @@ Transfer learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Transfer_lea
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-TBL" ;
     :definition "A transformer is a deep learning model. It is distinguished by its adoption of self-attention, differentially weighting the significance of each part of the input (which includes the recursive output) data." ;
-    :kb-article """## References\r
+    :kb-article """## References
 "Transformer (machine learning model)." Wikipedia. [Link](https://en.wikipedia.org/wiki/Transformer_(machine_learning_model)).""" .
 
 :Transformer-XL a owl:Class,
@@ -22882,7 +22882,7 @@ Transfer learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Transfer_lea
     rdfs:subClassOf :Transformer-basedLearning ;
     :d3fend-id "D3A-TX" ;
     :definition "Transformer-XL is a transformer architecture that introduces the notion of recurrence to the deep self-attention network. Instead of computing the hidden states from scratch for each new segment, Transformer-XL reuses the hidden states obtained in previous segments." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Transformer-XL. (n.d.). Papers with Code. [Link](https://paperswithcode.com/method/transformer-xl)""" .
 
 :TranslationLookasideBuffer a owl:Class ;
@@ -22901,7 +22901,7 @@ Transformer-XL. (n.d.). Papers with Code. [Link](https://paperswithcode.com/meth
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-TM" ;
     :definition "The arithmetic mean of data values after a certain number or proportion of the highest and lowest data values have been discarded." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" ;
     :synonym "Truncated mean" .
 
@@ -22919,7 +22919,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-US" ;
     :definition "Makes the utility inversely proportional to the uncertainty of the model with respect to the sample and will work with any  model provided it can assess its uncertainty of a predection." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :UnitTestExecutionTool a owl:Class ;
@@ -22946,7 +22946,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-UL" ;
     :definition "Unsupervised learning creates relationships with unlabeled data without the input of a human or other outside actor. Uses only input data. " ;
-    :kb-abstract """## References\r
+    :kb-abstract """## References
 Unsupervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Unsupervised_learning).""" .
 
 :UnsupervisedPreprocessing a owl:Class,
@@ -22955,7 +22955,7 @@ Unsupervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Unsuperv
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-UP" ;
     :definition "When performing unsupervised learning, the machine is presented with unlabeled data. (Unlabeled data has no target.) Unsupervised learning algorithms seek to discover intrinsic patterns that underlie the data, such as a clustering parameter or a redundant parameter (dimension) that can be reduced." ;
-    :kb-article """## References\r
+    :kb-article """## References
 SAS Institute Inc. (n.d.). Decision Trees. In SAS® Visual Data Mining and Machine Learning.[Link](https://documentation.sas.com/doc/en/vdmmlcdc/8.4/vdmmladvug/n1e4spzcnv1f0fn1vsxhbzgdp1bb.htm).""" .
 
 :URL a owl:Class ;
@@ -22979,32 +22979,32 @@ SAS Institute Inc. (n.d.). Decision Trees. In SAS® Visual Data Mining and Machi
             owl:someValuesFrom :URL ] ;
     :d3fend-id "D3-UA" ;
     :definition "Determining if a URL is benign or malicious by analyzing the URL or its components." ;
-    :kb-article """## How it works\r
-\r
-URLs may contain components, for example:\r
-\r
- * scheme\r
- * userinfo\r
- * host name\r
- * port\r
- * path\r
- * query\r
- * fragment\r
-\r
-These components are used as features in analysis algorithms.\r
-\r
-Contextual information about a URL such as where it is embedded (ex. emails, files, network protocols), header, path, location, and origin information, as well as information about the content returned from the URL request, may be incorporated into an analytic for URL analysis. For example, if a URL indicates a .pdf file but an executable is actually returned, the combination of these two pieces of information indicates suspicious activity.\r
-\r
-Additional techniques include:\r
-\r
-* Extracting features of a URL such as domain name length, ratio of consecutive consonants, percentage of digits in a domain, and number of vowels. Values for each feature are combined to develop a score for the URL.\r
-* Determining the probability of a character occurring in the URL given the preceding two characters. For example, for google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an o" occurring after a 'g' and "o, and so forth. A dictionary or a list of known good domains is used to determine probability. Probabilities are multiplied to develop a score for the URL.\r
-\r
-URL analysis may trigger follow-on analytics such as **File Analysis**\r
-\r
-## Considerations\r
-\r
-* Volume of URLs being analyzed, combined with the speed at which they are analyzed\r
+    :kb-article """## How it works
+
+URLs may contain components, for example:
+
+ * scheme
+ * userinfo
+ * host name
+ * port
+ * path
+ * query
+ * fragment
+
+These components are used as features in analysis algorithms.
+
+Contextual information about a URL such as where it is embedded (ex. emails, files, network protocols), header, path, location, and origin information, as well as information about the content returned from the URL request, may be incorporated into an analytic for URL analysis. For example, if a URL indicates a .pdf file but an executable is actually returned, the combination of these two pieces of information indicates suspicious activity.
+
+Additional techniques include:
+
+* Extracting features of a URL such as domain name length, ratio of consecutive consonants, percentage of digits in a domain, and number of vowels. Values for each feature are combined to develop a score for the URL.
+* Determining the probability of a character occurring in the URL given the preceding two characters. For example, for google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an o" occurring after a 'g' and "o, and so forth. A dictionary or a list of known good domains is used to determine probability. Probabilities are multiplied to develop a score for the URL.
+
+URL analysis may trigger follow-on analytics such as **File Analysis**
+
+## Considerations
+
+* Volume of URLs being analyzed, combined with the speed at which they are analyzed
 * Fidelity of analysis technique at detecting brand new URLs versus analyzing URLs of established domains""" ;
     :kb-reference :Reference-MethodAndApparatusForDetectingMaliciousWebsites_EndgameInc,
         :Reference-MethodAndSystemForDetectingRestrictedContentAssociatedWithRetrievedContent_SophosLtd .
@@ -23106,10 +23106,10 @@ URL analysis may trigger follow-on analytics such as **File Analysis**\r
     :d3fend-id "D3-UBA" ;
     :definition "User behavior analytics (\"UBA\") as defined by Gartner, is a cybersecurity process about detection of insider threats, targeted attacks, and financial fraud. UBA solutions look at patterns of human behavior, and then apply algorithms and statistical analysis to detect meaningful anomalies from those patterns-anomalies that indicate potential threats.' Instead of tracking devices or security events, UBA tracks a system's users. Big data platforms are increasing UBA functionality by allowing them to analyze petabytes worth of data to detect insider threats and advanced persistent threats." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview\r
-\r
-Some techniques monitor patterns of human behavior and then apply algorithms and to identify patterns such as repeated login attempts from a single IP address or large file downloads, or abnormal accesses.\r
-\r
+    :kb-article """## Technique Overview
+
+Some techniques monitor patterns of human behavior and then apply algorithms and to identify patterns such as repeated login attempts from a single IP address or large file downloads, or abnormal accesses.
+
 Other techniques may have explicit or rigid definitions of "bad behavior" which are then matched against instances in a computer network environment.""" ;
     :synonym "Credential Monitoring",
         "UBA" .
@@ -23124,11 +23124,11 @@ Other techniques may have explicit or rigid definitions of "bad behavior" which 
             owl:someValuesFrom :ResourceAccess ] ;
     :d3fend-id "D3-UDTA" ;
     :definition "Analyzing the amount of data transferred by a user." ;
-    :kb-article """## How it works\r
-Unusual data transfer activity may indicate unauthorized activity. Data transfers can be analyzed by collecting network traffic or application logs.\r
-\r
-## Considerations\r
-* There is a potential for false positives from anomalies that are not associated with unauthorized activity.\r
+    :kb-article """## How it works
+Unusual data transfer activity may indicate unauthorized activity. Data transfers can be analyzed by collecting network traffic or application logs.
+
+## Considerations
+* There is a potential for false positives from anomalies that are not associated with unauthorized activity.
 * Attackers that move low and slow may not differentiate their data transfer behavior enough for an alert to trigger.""" ;
     :kb-reference :Reference-SystemAndMethodThereofForIdentifyingAndRespondingToSecurityIncidentsBasedOnPreemptiveForensics_PaloAltoNetworksInc,
         :Reference-SystemForImplementingThreatDetectionUsingThreatAndRiskAssessmentOfAsset-actorInteractions_VECTRANETWORKSInc ;
@@ -23144,15 +23144,15 @@ Unusual data transfer activity may indicate unauthorized activity. Data transfer
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-UGLPA" ;
     :definition "Monitoring geolocation data of user logon attempts and comparing it to a baseline user behavior profile to identify anomalies in logon location." ;
-    :kb-article """## How it works\r
-Geolocation data for each user logon attempt is collected and used to create a baseline user behavior profile. Current geolocation logon data is then compared against the user behavior profile. Logon activity that deviates from normal patterns and can help in identifying situations that may be indicative of a remote attacker using stolen credentials. For example:\r
-\r
-* logons from locations that are different from where a user usually logs in\r
-* logons from a location in which an enterprise has no users located\r
-* logon that is not physically possible given the elapsed time since a logon from another location.\r
-\r
-## Considerations\r
-* Potential for false positives from logon anomalies that are not associated with malicious activity.\r
+    :kb-article """## How it works
+Geolocation data for each user logon attempt is collected and used to create a baseline user behavior profile. Current geolocation logon data is then compared against the user behavior profile. Logon activity that deviates from normal patterns and can help in identifying situations that may be indicative of a remote attacker using stolen credentials. For example:
+
+* logons from locations that are different from where a user usually logs in
+* logons from a location in which an enterprise has no users located
+* logon that is not physically possible given the elapsed time since a logon from another location.
+
+## Considerations
+* Potential for false positives from logon anomalies that are not associated with malicious activity.
 * Attackers may not differentiate their logon behavior enough to trigger an alert.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC .
@@ -23273,7 +23273,7 @@ Geolocation data for each user logon attempt is collected and used to create a b
     rdfs:subClassOf :DescriptiveStatistics ;
     :d3fend-id "D3A-VAR" ;
     :definition "Dispersion (also called variability, scatter, or spread) is the extent to which a distribution is stretched or squeezed. A measure of statistical dispersion is a nonnegative real number that is zero if all the data are the same and increases as the data become more diverse." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Statistical dispersion. [Link](https://en.wikipedia.org/wiki/Statistical_dispersion)""" ;
     :todo "Name should maybe be thought about as dispersion may be more descriptive or intuitive. Perhaps dispersion measure" .
 
@@ -23283,7 +23283,7 @@ Wikipedia. (n.d.). Statistical dispersion. [Link](https://en.wikipedia.org/wiki/
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-VAR" ;
     :definition "Variance is a measure of dispersion, meaning it is a measure of how far a set of numbers is spread out from their average value." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Wikipedia. (n.d.). Variance. [Link](https://en.wikipedia.org/wiki/Variance)""" .
 
 :VarianceReduction a owl:Class,
@@ -23292,7 +23292,7 @@ Wikipedia. (n.d.). Variance. [Link](https://en.wikipedia.org/wiki/Variance)""" .
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-VR" ;
     :definition "Leverages a well-known result from statistical learning and decomposes the model error into a data noise term, a model bias term and a model variance term. As the noise term only depends on the data and the bias is induced by the choice of model, any reduction in the error can only come from the variance term." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :Vendor a owl:Class ;
@@ -23359,15 +23359,15 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-VOT" ;
     :definition "Voting is another form of ensembling." ;
-    :kb-article """## References\r
+    :kb-article """## References
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :VPNServer a owl:Class ;
     rdfs:label "VPN Server" ;
     rdfs:subClassOf :Server ;
     rdfs:isDefinedBy <https://www.techopedia.com/definition/30750/vpn-server> ;
-    :definition """A VPN server is a type of server that enables hosting and delivery of VPN services.\r
-\r
+    :definition """A VPN server is a type of server that enables hosting and delivery of VPN services.
+
 It is a combination of VPN hardware and software technologies that provides VPN clients with connectivity to a secure and/or private network, or rather, the VPN.""" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Virtual_private_network> .
 
@@ -23452,11 +23452,11 @@ It is a combination of VPN hardware and software technologies that provides VPN 
             owl:someValuesFrom :WebResourceAccess ] ;
     :d3fend-id "D3-WSAA" ;
     :definition "Monitoring changes in user web session behavior by comparing current web session activity to a baseline behavior profile or a catalog of predetermined malicious behavior." ;
-    :kb-article """## How it works\r
-User web session data is collected over a period of time to create a user behavior profile. Data collected includes clicks made on a website, average time between clicks, filling out web forms, order in which pages are viewed, and downloading files. Current user web session behavior is then compared against the use behavior profile to identify anomalies and a likelihood that the current user web session is malicious. Current user web session behavior can also be compared to predetermined known malicious behavior profiles that are developed through analysis of malware in run time at a threat research facility.\r
-\r
-## Considerations\r
-* Potential for false positives from anomalies that are not associated with malicious activity.\r
+    :kb-article """## How it works
+User web session data is collected over a period of time to create a user behavior profile. Data collected includes clicks made on a website, average time between clicks, filling out web forms, order in which pages are viewed, and downloading files. Current user web session behavior is then compared against the use behavior profile to identify anomalies and a likelihood that the current user web session is malicious. Current user web session behavior can also be compared to predetermined known malicious behavior profiles that are developed through analysis of malware in run time at a threat research facility.
+
+## Considerations
+* Potential for false positives from anomalies that are not associated with malicious activity.
 * Attackers may not differentiate their web session activity enough to trigger an alert.""" ;
     :kb-reference :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
         :Reference-SystemAndMethodForDetectionOfAChangeInBehaviorInTheUseOfAWebsiteThroughVectorVelocityAnalysis_SilverTailSystems,
@@ -23469,10 +23469,10 @@ User web session data is collected over a period of time to create a user behavi
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-WM" ;
     :definition "A mean that incorporates weighting to certain data elements." ;
-    :kb-article """## Considerations\r
-The arithmetic mean, geometric mean, and harmonic mean can all be weighted.\r
-\r
-## References\r
+    :kb-article """## Considerations
+The arithmetic mean, geometric mean, and harmonic mean can all be weighted.
+
+## References
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :WideAreaNetwork a owl:Class ;
@@ -23787,7 +23787,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         owl:NamedIndividual ;
     rdfs:label "Reference - Continuous authentication by analysis of keyboard typing characteristics - Bradford Univ., UK" ;
     :has-link "https://ieeexplore.ieee.org/document/491588?reload=true&arnumber=491588"^^xsd:anyURI ;
-    :kb-abstract """This paper describes a simple, software based keyboard monitoring system for the IBM PC for the continuous analysis of the typing characteristics of the user for the purpose of continuous authentication. By exploiting the electrical characteristics of the PC keyboard interface together with modifications to the internal system timer, very accurate measurements can be made of keystroke interval and duration, including measurements of rollover. Rollover patterns, particularly when typing common diphthongs, can be highly characteristic of individual users and provide quite an accurate indication of the users identity.\r
+    :kb-abstract """This paper describes a simple, software based keyboard monitoring system for the IBM PC for the continuous analysis of the typing characteristics of the user for the purpose of continuous authentication. By exploiting the electrical characteristics of the PC keyboard interface together with modifications to the internal system timer, very accurate measurements can be made of keystroke interval and duration, including measurements of rollover. Rollover patterns, particularly when typing common diphthongs, can be highly characteristic of individual users and provide quite an accurate indication of the users identity.
 Published in: European Convention on Security and Detection, 1995.""" ;
     :kb-author "S.J. Shepherd" ;
     :kb-mitre-analysis " " ;
@@ -23800,8 +23800,8 @@ Published in: European Convention on Security and Detection, 1995.""" ;
         :PatentReference ;
     rdfs:label "Reference - Decoy and deceptive data object technology - Cymmetria, Inc." ;
     :has-link "https://patents.google.com/patent/US20170134423A1"^^xsd:anyURI ;
-    :kb-abstract """A computer implemented method of detecting unauthorized access to a protected network by monitoring a dynamically updated deception environment, comprising launching, on one or more decoy endpoints, one or more decoy operating system (OS) managing one or more of a plurality of deception applications mapping a plurality of applications executed in a protected network, updating dynamically a usage indication for a plurality of deception data objects deployed in the protected network to emulate usage of the plurality of deception data objects for accessing the deception application(s) wherein the plurality of deception data objects are configured to trigger an interaction with the deception application(s) when used, detecting usage of data contained in the deception data object(s) by monitoring the interaction and identifying one or more potential unauthorized operations based on analysis of the detection.\r
-\r
+    :kb-abstract """A computer implemented method of detecting unauthorized access to a protected network by monitoring a dynamically updated deception environment, comprising launching, on one or more decoy endpoints, one or more decoy operating system (OS) managing one or more of a plurality of deception applications mapping a plurality of applications executed in a protected network, updating dynamically a usage indication for a plurality of deception data objects deployed in the protected network to emulate usage of the plurality of deception data objects for accessing the deception application(s) wherein the plurality of deception data objects are configured to trigger an interaction with the deception application(s) when used, detecting usage of data contained in the deception data object(s) by monitoring the interaction and identifying one or more potential unauthorized operations based on analysis of the detection.
+
 In order to convince the potential attacker that the deception environment is the real (valid) processing environment and/or part thereof, the campaign manager may construct the false identity according to the public information of the certain user that may typically be available to the potential attacker. By exposing the real (public) information of the certain user to the potential attacker, the false identity may seem consistent and legitimate to the potential attacker. For example, the campaign manager may create a false account, for example, a Facebook account of the certain user that includes the same public information that is publicly available to other Facebook users from the real (genuine) Facebook account of the certain user. The fake company account may include information specific to the role and/or job title of certain user within the company, for example, a programmer, an accountant, an IT person and/or the like.""" ;
     :kb-author "Dean Sysman, Gadi Evron, Imri Goldberg, Itamar Sher, Shmuel Ur" ;
     :kb-mitre-analysis " " ;
@@ -23841,23 +23841,23 @@ In order to convince the potential attacker that the deception environment is th
     :kb-reference-of :DecoyFile ;
     :kb-reference-title "Supply chain cyber-deception" ;
     :todo "MITRE Analysis was not found",
-        """Section header did not match either 'MITRE Analysis' or 'Document Abstract' (possible typo?):  Additional Information from Document\r
-The deception data objects 214 may include, for example, one or more of the following:\r
-\r
-Cookies and/or history log entries. In case the access client 255 is browsing, for example, to a supplier-facing website (an exemplary resource 222) of the protected network 235, typically, a cookie is added to the to be added to the access client 255 and the website's address added to the history log of the access client 255. In such a case, the campaign manager 216 may, for example, open an iframe to a deception website (an exemplary deception resource 210 corresponding to the exemplary resource 222) in which different cookie(s) and/or different history log entry(s) may be added to the access client 255. The different cookie(s) and/or history log entry(s) may point to the deception environment, for example, a false website, an identical system that is not used by real users (internal and/or external), a proxy that redirects to a real system within the protected network 235, a different service, such as, for example, email, SharePoint and/or the like.\r
-\r
-JavaScripts, pop-up windows, pop-under windows and/or any other browsing technique used to browse to another website(s). In case the access client 255 is browsing, for example, to the supplier-facing website, the campaign manager 216 may, for example, initiate a JavaScript, a pop-up window and/or a pop-under window to direct the access client 255 to the deception website in which the different cookie(s) and/or the different history log entry(s) may be added to the access client 255. The JavaScripts, the pop-up windows and/or the pop-under windows may maintain a visibility similarity with the supplier-facing website such that they do not significantly alter the browsing experience of the external user(s) using the access client(s) 255.\r
-\r
-Credential object. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install additional fake credentials on the external endpoint 251 from which the RDP is initiated.\r
-\r
-Configuration file. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install a fake remote access configuration file on the external endpoint 251 from which the RDP is initiated.\r
-\r
-Deception file, password and/or the like. In case the external user(s) use the VNC serving as the access client 255, the campaign manager 216 may install additional fake credentials, files, password(s) and/or the like on the external endpoint 251from which the VNC is initiated.\r
-\r
-In some cases, the access client 255 may be offered with automatic password completion when accessing a resource, a service and/or an application at the remote network. In such case(s), the campaign manager 216 may manipulate the automatic password completion and provide fake password(s) to the access client 255 accessing the protected network 235.\r
-\r
-Archive files, for example, zip, rar, tar.gz and/or the like. In case the external user(s) using the access client 255 performs a backup and/or retrieves data from the protected network 235, the campaign manager 216 may insert one or more deception data objects 214 into one or more of the created archive files.\r
-\r
+        """Section header did not match either 'MITRE Analysis' or 'Document Abstract' (possible typo?):  Additional Information from Document
+The deception data objects 214 may include, for example, one or more of the following:
+
+Cookies and/or history log entries. In case the access client 255 is browsing, for example, to a supplier-facing website (an exemplary resource 222) of the protected network 235, typically, a cookie is added to the to be added to the access client 255 and the website's address added to the history log of the access client 255. In such a case, the campaign manager 216 may, for example, open an iframe to a deception website (an exemplary deception resource 210 corresponding to the exemplary resource 222) in which different cookie(s) and/or different history log entry(s) may be added to the access client 255. The different cookie(s) and/or history log entry(s) may point to the deception environment, for example, a false website, an identical system that is not used by real users (internal and/or external), a proxy that redirects to a real system within the protected network 235, a different service, such as, for example, email, SharePoint and/or the like.
+
+JavaScripts, pop-up windows, pop-under windows and/or any other browsing technique used to browse to another website(s). In case the access client 255 is browsing, for example, to the supplier-facing website, the campaign manager 216 may, for example, initiate a JavaScript, a pop-up window and/or a pop-under window to direct the access client 255 to the deception website in which the different cookie(s) and/or the different history log entry(s) may be added to the access client 255. The JavaScripts, the pop-up windows and/or the pop-under windows may maintain a visibility similarity with the supplier-facing website such that they do not significantly alter the browsing experience of the external user(s) using the access client(s) 255.
+
+Credential object. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install additional fake credentials on the external endpoint 251 from which the RDP is initiated.
+
+Configuration file. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install a fake remote access configuration file on the external endpoint 251 from which the RDP is initiated.
+
+Deception file, password and/or the like. In case the external user(s) use the VNC serving as the access client 255, the campaign manager 216 may install additional fake credentials, files, password(s) and/or the like on the external endpoint 251from which the VNC is initiated.
+
+In some cases, the access client 255 may be offered with automatic password completion when accessing a resource, a service and/or an application at the remote network. In such case(s), the campaign manager 216 may manipulate the automatic password completion and provide fake password(s) to the access client 255 accessing the protected network 235.
+
+Archive files, for example, zip, rar, tar.gz and/or the like. In case the external user(s) using the access client 255 performs a backup and/or retrieves data from the protected network 235, the campaign manager 216 may insert one or more deception data objects 214 into one or more of the created archive files.
+
 An account. The campaign manager 216 may provide the external user(s) one or more false accounts for accessing one of more of the deception applications 212. The campaign manager 216 may configure each of the deception data objects 214 to interact with one or more of the deception resources 210. The campaign manager 216 may configure the deception data objects 214 and define their relationships according to a deception policy and/or methods defined for the deception campaign. Naturally, the campaign manager 216 creates and configures the deception data objects 214 according to the resource(s) 222 accessed by the access client(s) 255. The campaign manager 216 also defines the interaction with the deception resource(s) 210 which map the accessed resource(s) 222. For example, the deceptive data object 214 of type "browser cookie" may be created to interact with one or more deception resources 210, for example, a fake website and/or a deception application launched using, for example, a deception resource 210 of type "browser" created during the deception campaign. As another example, a deceptive data object 214 of type "compressed file" may be created for external user(s) using a certain one of the external endpoints 251. As another example, a deceptive data object 214 of type "credentials" may be created for users accessing a certain application 212 of type "ERP". Optionally, the campaign manager 216 periodically and/or dynamically updates one or more of the deception data objects 214 to impersonate an active real (valid) processing environment such that the deception data objects 214 appear to be valid data objects to lead the potential attacker to believe the emulated deception environment is a real one.""" .
 
 <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc> a owl:NamedIndividual,
@@ -23866,17 +23866,17 @@ An account. The campaign manager 216 may provide the external user(s) one or mor
     :has-link "https://patents.google.com/patent/US20190034641A1"^^xsd:anyURI ;
     :kb-abstract "The present disclosure is directed to a system, method, and computer program for detecting and assessing security risks in an enterprise's computer network. A behavior model is built for a user in the network based on the user's interactions with the network, wherein a behavior model for a user indicates client device(s), server(s), and resources used by the user. The user's behavior during a period of time is compared to the user's behavior model. A risk assessment is calculated for the period of time based at least in part on the comparison between the user's behavior and the user's behavior model, wherein any one of certain anomalies between the user's behavior and the user's behavior model increase the risk assessment." ;
     :kb-author "Sylvain Gil; Domingo Mihovilovic; Nir Polak; Magnus Stensmo; Sing Yip" ;
-    :kb-mitre-analysis """This patent describes calculating a risk score to detect anomalies in user activity based on comparing a user's current session with a user behavior model. The user behavior model is comprised of a number of histograms including:\r
-\r
-* client devices from which the user logs in\r
-* servers accessed\r
-* data accessed\r
-* applications accessed\r
-* session duration\r
-* logon time of day\r
-* logon day of week\r
-* geo - location of logon origination\r
-\r
+    :kb-mitre-analysis """This patent describes calculating a risk score to detect anomalies in user activity based on comparing a user's current session with a user behavior model. The user behavior model is comprised of a number of histograms including:
+
+* client devices from which the user logs in
+* servers accessed
+* data accessed
+* applications accessed
+* session duration
+* logon time of day
+* logon day of week
+* geo - location of logon origination
+
 The system has an initial training period with x number of days (e. g., 90 days) in which session data is recorded in behavior models before behavior analysis begins.The histograms are then used to determine anomalies between current session activity and a user's behavior model. Values for a histogram category are along one axis and the number of times the value is received for the category is along another axis. If a data point value associated with the current user session is over an anomaly threshold, an alert is generated.""" ;
     :kb-organization "Exabeam Inc" ;
     :kb-reference-of :AuthenticationEventThresholding,
@@ -23890,8 +23890,8 @@ The system has an initial training period with x number of days (e. g., 90 days)
         :SpecificationReference ;
     rdfs:label "Reference - TPM 2.0 Library Specification - Trusted Computing Group, Incorporated" ;
     :has-link "https://trustedcomputinggroup.org/resource/tpm-library-specification/"^^xsd:anyURI ;
-    :kb-abstract """This specification defines the Trusted Platform Module (TPM) a device that enables trust in computing\r
-platforms in general. It is broken into parts to make the role of each part clear. All parts are required in\r
+    :kb-abstract """This specification defines the Trusted Platform Module (TPM) a device that enables trust in computing
+platforms in general. It is broken into parts to make the role of each part clear. All parts are required in
 order to constitute a complete standard. For a complete definition of all requirements necessary to build a TPM, the designer will need to use the appropriate platform-specific specification to understand all of the requirements for a TPM in a specific application or make appropriate choices as an implementer. Those wishing to create a TPM need to be aware that this specification does not provide a complete picture of the options and commands necessary to implement a TPM. To implement a TPM the designer needs to refer to the relevant platform-specific specification to understand the options and settings required for a TPM in a specific type of platform or make appropriate choices as an implementer.""" ;
     :kb-author "Trusted Computing Group" ;
     :kb-mitre-analysis " " ;
@@ -24372,7 +24372,7 @@ order to constitute a complete standard. For a complete definition of all requir
         :PatentReference ;
     rdfs:label "Reference - Advanced device matching system" ;
     :has-link "https://patents.google.com/patent/US10892951B2/"^^xsd:anyURI ;
-    :kb-abstract """Disclosed is a device management system for discovery and management of components added to computer systems and sub-systems. The device management system provides for recognizing a newly added component, and determining if the newly added component is already a part of the system inventory. The newly added component is matched with a component currently on the system, based on at least one matching attribute. A point total is calculated for each match level and a final match score is provided. The match score is compared with an aggressiveness level to determine if a match does indeed exist.\r
+    :kb-abstract """Disclosed is a device management system for discovery and management of components added to computer systems and sub-systems. The device management system provides for recognizing a newly added component, and determining if the newly added component is already a part of the system inventory. The newly added component is matched with a component currently on the system, based on at least one matching attribute. A point total is calculated for each match level and a final match score is provided. The match score is compared with an aggressiveness level to determine if a match does indeed exist.
 """ ;
     :kb-author "Rajneesh Jalan, Joseph M. Schmitt, and Marco Simoes" ;
     :kb-organization "Device42 Inc" ;
@@ -24383,8 +24383,8 @@ order to constitute a complete standard. For a complete definition of all requir
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2015-07-001: All Logins Since Last Boot - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2015-07-001/"^^xsd:anyURI ;
-    :kb-abstract """Once a credential dumper like mimikatz runs, every user logged on since boot is potentially compromised, because the credentials were accessed via the memory of lsass.exe. When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.\r
-\r
+    :kb-abstract """Once a credential dumper like mimikatz runs, every user logged on since boot is potentially compromised, because the credentials were accessed via the memory of lsass.exe. When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.
+
 The time field indicates the first and last time a system reported a user logged into a given system. This means that activity could be intermittent between the times given and should not be considered a duration.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -24413,14 +24413,14 @@ The time field indicates the first and last time a system reported a user logged
     :has-link "https://patents.google.com/patent/US20160226901A1"^^xsd:anyURI ;
     :kb-abstract "The invention provides a system and method for automatic creation of adaptive behavioral profiles for observables associated with resource states and events in a computer network (IT) infrastructure of an enterprise and for detecting anomalies that represent potential malicious activity and threats as deviations from normal behavior. Separate profiles may be created for each behavioral indicator, as well as for each time series of measurements, and aggregated to create an overall behavioral profile. An anomaly probability is determined from the behavioral profile and used to evaluate the data values of observables. Outlier data values which deviate from normal behavior by more than a predetermined probability threshold are identified for risk analysis as possible threats while inliers within the range of normal behavior are used to update the behavioral profile. Behavioral profiles are created for behavioral indicators based upon observables measured over predetermined time periods using algorithms employing statistical analysis approaches that work for any type of data distribution, and profiles are adapted over time using data aging to more closely represent current behavior. Algorithm parameters for creating profiles are based on the type of data, i.e., its metadata." ;
     :kb-author "Igor A. Baikalov; Tanuj Gulati; Sachin Nayyar; Anjaneya Shenoy; Ganpatrao H. Patwardhan" ;
-    :kb-mitre-analysis """The patent describes a technique for detecting anomalous activity within an organization's IT infrastructure to identify threats. Behavioral profiles can be grouped by peer groups that identify functionally similar groups of actors (users or resources) based on their attributes and pre-defined grouping rules. For example, users can be grouped by their job title, organizational hierarchy, or location and can be observed for similarities in access patterns, based on granted access entitlements or actual logged resource access.\r
-\r
-Behavioral profiles are created from measurements of events over a time period for example:\r
-\r
-* Transaction counts\r
-* Concurrent users per hour\r
-* Daily volume of data\r
-\r
+    :kb-mitre-analysis """The patent describes a technique for detecting anomalous activity within an organization's IT infrastructure to identify threats. Behavioral profiles can be grouped by peer groups that identify functionally similar groups of actors (users or resources) based on their attributes and pre-defined grouping rules. For example, users can be grouped by their job title, organizational hierarchy, or location and can be observed for similarities in access patterns, based on granted access entitlements or actual logged resource access.
+
+Behavioral profiles are created from measurements of events over a time period for example:
+
+* Transaction counts
+* Concurrent users per hour
+* Daily volume of data
+
 Outlier data values which deviate from behavioral profile by more than a predetermined probability threshold are identified for risk analysis as possible threats.""" ;
     :kb-organization "Securonix Inc" ;
     :kb-reference-of :JobFunctionAccessPatternAnalysis ;
@@ -24510,8 +24510,8 @@ Outlier data values which deviate from behavioral profile by more than a predete
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-01-002: Autorun Differences - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-01-002/"^^xsd:anyURI ;
-    :kb-abstract """The Sysinternals tool Autoruns checks the registry and file system for known identify persistence mechanisms. It will output any tools identified, including built-in or added-on Microsoft functionality and third party software. Many of these locations are known by adversaries and used to obtain Persistence. Running Autoruns periodically in an environment makes it possible to collect and monitor its output for differences, which may include the removal or addition of persistent tools. Depending on the persistence mechanism and location, legitimate software may be more likely to make changes than an adversary tool. Thus, this analytic may result in significant noise in a highly dynamic environment. While Autoruns is a convenient method to scan for programs using persistence mechanisms its scanning nature does not conform well to streaming based analytics. This analytic could be replaced with one that draws from sensors that collect registry and file information if streaming analytics are desired.\r
-\r
+    :kb-abstract """The Sysinternals tool Autoruns checks the registry and file system for known identify persistence mechanisms. It will output any tools identified, including built-in or added-on Microsoft functionality and third party software. Many of these locations are known by adversaries and used to obtain Persistence. Running Autoruns periodically in an environment makes it possible to collect and monitor its output for differences, which may include the removal or addition of persistent tools. Depending on the persistence mechanism and location, legitimate software may be more likely to make changes than an adversary tool. Thus, this analytic may result in significant noise in a highly dynamic environment. While Autoruns is a convenient method to scan for programs using persistence mechanisms its scanning nature does not conform well to streaming based analytics. This analytic could be replaced with one that draws from sensors that collect registry and file information if streaming analytics are desired.
+
 Utilizes the Sysinternals autoruns tool (ignoring validated Microsoft entries). Primarily not a detection analytic by itself but through analysis of results by an analyst can be used for such. Building another analytic on top of this one identifying unusual entries would likely be a beneficial alternative.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -24524,8 +24524,8 @@ Utilizes the Sysinternals autoruns tool (ignoring validated Microsoft entries). 
         :PatentReference ;
     rdfs:label "Reference - Biometric Challenge-Response Authentication - Accenture" ;
     :has-link "https://www.patentguru.com/US2021110015A1"^^xsd:anyURI ;
-    :kb-abstract """Secret biometric responses to authentication challenges for MFA.\r
-\r
+    :kb-abstract """Secret biometric responses to authentication challenges for MFA.
+
 Methods, systems, and apparatus, including computer programs encoded on computer storage media, for authenticating users based on a sequence of biometric authentication challenges. In one aspect, a process includes receiving a first image of the face of the user and processing the first image according to a first authentication process to determine whether the face of the user shown in the first image matches the face of an authorized user. A second authentication process including a sequence of biometric authentication challenges is identified. The sequence includes at least one facial expression challenge. The user is authenticated in response to determining that the first authentication process is satisfied based on the face of the user shown in the first image matching the face of the authorized user and the second authentication process is satisfied based on the user providing a valid biometric response to each biometric authentication challenge.""" ;
     :kb-author "Ben McCarty, Ellie Daw" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -24549,10 +24549,10 @@ Methods, systems, and apparatus, including computer programs encoded on computer
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-05-001: RPC Activity - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-05-001/"^^xsd:anyURI ;
-    :kb-abstract """Microsoft Windows uses its implementation of Distributed Computing Environment/Remote Procedure Call (DCE/RPC), which it calls Microsoft RPC, to call certain APIs remotely.\r
-\r
-A Remote Procedure Call is initiated by communicating to the RPC Endpoint Mapper, which exists as the Windows service RpcEptMapper and listens on the port 135/tcp. The endpoint mapper resolves a requested endpoint/interface and responds to the client with the port that the service is listening on. Since the RPC endpoints are assigned ports when the services start, these ports are dynamically assigned from 49152 to 65535. The connection to the endpoint mapper then terminates and the client program can communicate directly with the requested service.\r
-\r
+    :kb-abstract """Microsoft Windows uses its implementation of Distributed Computing Environment/Remote Procedure Call (DCE/RPC), which it calls Microsoft RPC, to call certain APIs remotely.
+
+A Remote Procedure Call is initiated by communicating to the RPC Endpoint Mapper, which exists as the Windows service RpcEptMapper and listens on the port 135/tcp. The endpoint mapper resolves a requested endpoint/interface and responds to the client with the port that the service is listening on. Since the RPC endpoints are assigned ports when the services start, these ports are dynamically assigned from 49152 to 65535. The connection to the endpoint mapper then terminates and the client program can communicate directly with the requested service.
+
 RPC is a legitimate functionality of Windows that allows remote interaction with a variety of services. For a Windows environment to be properly configured, several programs use RPC to communicate legitimately with servers. The background and benign RPC activity may be enormous, but must be learned, especially peer-to-peer RPC between workstations, which is often indicative of Lateral Movement.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24564,8 +24564,8 @@ RPC is a legitimate functionality of Windows that allows remote interaction with
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-007: Remote Windows Management Instrumentation (WMI) over RPC - MITRE" ;
     :has-link ""^^xsd:anyURI ;
-    :kb-abstract """As described in ATT&CK, an adversary can use Windows Management Instrumentation (WMI) to view or manipulate objects on a remote host. It can be used to remotely edit configuration, start services, query files, and anything that can be done with a WMI class. When remote WMI requests are over RPC (CAR-2014-05-001), it connects to a DCOM interface within the RPC group netsvcs. To detect this activity, a sensor is needed at the network level that can decode RPC traffic or on the host where the communication can be detected more natively, such as Event Tracing for Windows. Using wireshark/tshark decoders, the WMI interfaces can be extracted so that WMI activity over RPC can be detected.\r
-\r
+    :kb-abstract """As described in ATT&CK, an adversary can use Windows Management Instrumentation (WMI) to view or manipulate objects on a remote host. It can be used to remotely edit configuration, start services, query files, and anything that can be done with a WMI class. When remote WMI requests are over RPC (CAR-2014-05-001), it connects to a DCOM interface within the RPC group netsvcs. To detect this activity, a sensor is needed at the network level that can decode RPC traffic or on the host where the communication can be detected more natively, such as Event Tracing for Windows. Using wireshark/tshark decoders, the WMI interfaces can be extracted so that WMI activity over RPC can be detected.
+
 Although the description details how to detect remote WMI precisely, a decent estimate has been to look for the string RPCSS within the initial RPC connection on 135/tcp. It returns a superset of this activity, and will trigger on all DCOM-related services running within RPC, which is likely to also be activity that should be detected between hosts. More about RPCSS at : rpcss_dcom_interfaces.html""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -24580,8 +24580,8 @@ Although the description details how to detect remote WMI precisely, a decent es
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2015-04-001: Remotely Scheduled Tasks via AT - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2015-04-001/"^^xsd:anyURI ;
-    :kb-abstract """When AT.exe is used to remotely schedule tasks, Windows uses named pipes over SMB to communicate with the API on the remote machine. After authentication over SMB, the Named Pipe “ATSVC” is opened, over which the JobAdd function is called. On the remote host, the job files are created by the Task Scheduler and follow the convention C:\\Windows\\System32\\AT<job\\_id>. Unlike CAR-2013-05-004, this analytic specifically focuses on uses of AT that can be detected between hosts, indicating remotely gained execution.\r
-\r
+    :kb-abstract """When AT.exe is used to remotely schedule tasks, Windows uses named pipes over SMB to communicate with the API on the remote machine. After authentication over SMB, the Named Pipe “ATSVC” is opened, over which the JobAdd function is called. On the remote host, the job files are created by the Task Scheduler and follow the convention C:\\Windows\\System32\\AT<job\\_id>. Unlike CAR-2013-05-004, this analytic specifically focuses on uses of AT that can be detected between hosts, indicating remotely gained execution.
+
 This pipe activity could be discovered with a network decoder, such as that in wireshark, that can inspect SMB traffic to identify the use of pipes. It could also be detected by looking for raw packet capture streams or from a custom sensor on the host that hooks the appropriate API functions. If no network or API level of visibility is possible, this traffic may inferred by looking at SMB connections over 445/tcp followed by the creation of files matching the pattern C:\\Windows\\System32\\AT\\<job_id\\>.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24600,8 +24600,8 @@ This pipe activity could be discovered with a network decoder, such as that in w
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2020-04-001: Shadow Copy Deletion - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2020-04-001/"^^xsd:anyURI ;
-    :kb-abstract """The Windows Volume Shadow Copy Service is a built-in OS feature that can be used to create backup copies of files and volumes.\r
-\r
+    :kb-abstract """The Windows Volume Shadow Copy Service is a built-in OS feature that can be used to create backup copies of files and volumes.
+
 Adversaries may delete these shadow copies, typically through the usage of system utilities such as vssadmin.exe or wmic.exe, in order prevent file and data recovery. This technique is commonly employed for this purpose by ransomware.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24613,10 +24613,10 @@ Adversaries may delete these shadow copies, typically through the usage of syste
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2020-05-001: MiniDump of LSASS - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2020-05-001/"^^xsd:anyURI ;
-    :kb-abstract """This analytic detects the minidump variant of credential dumping where a process opens lsass.exe in order to extract credentials using the Win32 API call MiniDumpWriteDump. Tools like SafetyKatz, SafetyDump, and Outflank-Dumpert default to this variant and may be detected by this analytic, though keep in mind that not all options for using those tools will result in this specific behavior.\r
-\r
-The analytic is based on a Sigma analytic contributed by Samir Bousseaden and written up in a blog on MENASEC. It looks for a call trace that includes either dbghelp.dll or dbgcore.dll, which export the relevant functions/permissions to perform the dump. It also detects using the Windows Task Manager (taskmgr.exe) to dump lsass, which is described in CAR-2019-08-001. In this iteration of the Sigma analytic, the GrantedAccess filter isn’t included because it didn’t seem to filter out any false positives and introduces the potential for evasion.\r
-\r
+    :kb-abstract """This analytic detects the minidump variant of credential dumping where a process opens lsass.exe in order to extract credentials using the Win32 API call MiniDumpWriteDump. Tools like SafetyKatz, SafetyDump, and Outflank-Dumpert default to this variant and may be detected by this analytic, though keep in mind that not all options for using those tools will result in this specific behavior.
+
+The analytic is based on a Sigma analytic contributed by Samir Bousseaden and written up in a blog on MENASEC. It looks for a call trace that includes either dbghelp.dll or dbgcore.dll, which export the relevant functions/permissions to perform the dump. It also detects using the Windows Task Manager (taskmgr.exe) to dump lsass, which is described in CAR-2019-08-001. In this iteration of the Sigma analytic, the GrantedAccess filter isn’t included because it didn’t seem to filter out any false positives and introduces the potential for evasion.
+
 This analytic was tested both in a lab and in a production environment with a very low false-positive rate. werfault.exe and tasklist.exe, both standard Windows processes, showed up multiple times as false positives.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24629,10 +24629,10 @@ This analytic was tested both in a lab and in a production environment with a ve
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2020-05-003: Rare LolBAS Command Lines - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2020-05-003/"^^xsd:anyURI ;
-    :kb-abstract """LoLBAS are binaries and scripts that are built in to Windows, frequently are signed by Microsoft, and may be used by an attacker. Some LoLBAS are used very rarely and it might be possible to alert every time they’re used (this would depend on your environment), but many others are very common and can’t be simply alerted on.\r
-\r
-This analytic takes all instances of LoLBAS execution and then looks for instances of command lines that are not normal in the environment. This can detect attackers (which will tend to need the binaries for something different than normal usage) but will also tend to have false positives.\r
-\r
+    :kb-abstract """LoLBAS are binaries and scripts that are built in to Windows, frequently are signed by Microsoft, and may be used by an attacker. Some LoLBAS are used very rarely and it might be possible to alert every time they’re used (this would depend on your environment), but many others are very common and can’t be simply alerted on.
+
+This analytic takes all instances of LoLBAS execution and then looks for instances of command lines that are not normal in the environment. This can detect attackers (which will tend to need the binaries for something different than normal usage) but will also tend to have false positives.
+
 The analytic needs to be tuned. The 1.5 in the query is the number of standard deviations away to look. It can be tuned up to filter out more noise and tuned down to get more results. This means it is probably best as a hunting analytic when you have analysts looking at the screen and able to tune the analytic up and down, because the threshold may not be stable for very long.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24930,12 +24930,12 @@ The analytic needs to be tuned. The 1.5 in the query is the number of standard d
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2021-04-001: Common Windows Process Masquerading - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2021-04-001/"^^xsd:anyURI ;
-    :kb-abstract """Masquerading (T1036) is defined by ATT&CK as follows:\r
-\r
-“Masquerading occurs when the name or location of an object, legitimate or malicious, is manipulated or abused for the sake of evading defenses and observation. This may include manipulating file metadata, tricking users into misidentifying the file type, and giving legitimate task or service names.”\r
-\r
-Malware authors often use this technique to hide malicious executables behind legitimate Windows executable names (e.g. lsass.exe, svchost.exe, etc).\r
-\r
+    :kb-abstract """Masquerading (T1036) is defined by ATT&CK as follows:
+
+“Masquerading occurs when the name or location of an object, legitimate or malicious, is manipulated or abused for the sake of evading defenses and observation. This may include manipulating file metadata, tricking users into misidentifying the file type, and giving legitimate task or service names.”
+
+Malware authors often use this technique to hide malicious executables behind legitimate Windows executable names (e.g. lsass.exe, svchost.exe, etc).
+
 There are several sub-techniques, but this analytic focuses on Match Legitimate Name or Location only.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -25089,8 +25089,8 @@ There are several sub-techniques, but this analytic focuses on Match Legitimate 
         :TechniqueReference ;
     rdfs:label "Reference - Certificate Transparency" ;
     :has-link "https://www.certificate-transparency.org/"^^xsd:anyURI ;
-    :kb-abstract """Google's Certificate Transparency project fixes several structural flaws in the SSL certificate system, which is the main cryptographic system that underlies all HTTPS connections.\r
-\r
+    :kb-abstract """Google's Certificate Transparency project fixes several structural flaws in the SSL certificate system, which is the main cryptographic system that underlies all HTTPS connections.
+
 These flaws weaken the reliability and effectiveness of encrypted Internet connections and can compromise critical TLS/SSL mechanisms, including domain validation, end-to-end encryption, and the chains of trust set up by certificate authorities.""" ;
     :kb-author "Google" ;
     :kb-organization "Google" ;
@@ -25122,8 +25122,8 @@ These flaws weaken the reliability and effectiveness of encrypted Internet conne
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-07-005: Command Line Usage of Archiving Software - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-07-005/"^^xsd:anyURI ;
-    :kb-abstract """Before exfiltrating data that an adversary has collected, it is very likely that a compressed archive will be created, so that transfer times are minimized and fewer files are transmitted. There is variety between the tools used to compress data, but the command line usage and context of archiving tools, such as ZIP, RAR, and 7ZIP, should be monitored.\r
-\r
+    :kb-abstract """Before exfiltrating data that an adversary has collected, it is very likely that a compressed archive will be created, so that transfer times are minimized and fewer files are transmitted. There is variety between the tools used to compress data, but the command line usage and context of archiving tools, such as ZIP, RAR, and 7ZIP, should be monitored.
+
 In addition to looking for RAR or 7z program names, command line usage of 7Zip or RAR can be detected with the flag usage of "\\* a \\*". This is helpful, as adversaries may change program names.""" ;
     :kb-author "" ;
     :kb-mitre-analysis " " ;
@@ -25191,8 +25191,8 @@ In addition to looking for RAR or 7z program names, command line usage of 7Zip o
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2016-03-002: Create Remote Process via WMIC - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2016-03-002/"^^xsd:anyURI ;
-    :kb-abstract """Adversaries may use Windows Management Instrumentation (WMI) to move laterally, by launching executables remotely.The analytic CAR-2014-12-001 describes how to detect these processes with network traffic monitoring and process monitoring on the target host. However, if the command line utility wmic.exe is used on the source host, then it can additionally be detected on an analytic. The command line on the source host is constructed into something like wmic.exe /node:"\\<hostname\\>" process call create "\\<command line\\>". It is possible to also connect via IP address, in which case the string "\\<hostname\\>" would instead look like IP Address.\r
-\r
+    :kb-abstract """Adversaries may use Windows Management Instrumentation (WMI) to move laterally, by launching executables remotely.The analytic CAR-2014-12-001 describes how to detect these processes with network traffic monitoring and process monitoring on the target host. However, if the command line utility wmic.exe is used on the source host, then it can additionally be detected on an analytic. The command line on the source host is constructed into something like wmic.exe /node:"\\<hostname\\>" process call create "\\<command line\\>". It is possible to also connect via IP address, in which case the string "\\<hostname\\>" would instead look like IP Address.
+
 Although this analytic was created after CAR-2014-12-001, it is a much simpler (although more limited) approach. Processes can be created remotely via WMI in a few other ways, such as more direct API access or the built-in utility PowerShell.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25219,8 +25219,8 @@ Although this analytic was created after CAR-2014-12-001, it is a much simpler (
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2019-08-001: Credential Dumping via Windows Task Manager - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2019-08-001/"^^xsd:anyURI ;
-    :kb-abstract """The Windows Task Manager may be used to dump the memory space of lsass.exe to disk for processing with a credential access tool such as Mimikatz. This is performed by launching Task Manager as a privileged user, selecting lsass.exe, and clicking "Create dump file". This saves a dump file to disk with a deterministic name that includes the name of the process being dumped.\r
-\r
+    :kb-abstract """The Windows Task Manager may be used to dump the memory space of lsass.exe to disk for processing with a credential access tool such as Mimikatz. This is performed by launching Task Manager as a privileged user, selecting lsass.exe, and clicking "Create dump file". This saves a dump file to disk with a deterministic name that includes the name of the process being dumped.
+
 This requires filesystem data to determine whether files have been created.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25272,8 +25272,8 @@ This requires filesystem data to determine whether files have been created.""" ;
         :UserManualReference ;
     rdfs:label "Reference - Mitigate threats by using Windows 10 security features: Data Execution Prevention - Microsoft" ;
     :has-link "https://docs.microsoft.com/en-us/windows/security/threat-protection/overview-of-threat-mitigations-in-windows-10#data-execution-prevention"^^xsd:anyURI ;
-    :kb-abstract """Malware depends on its ability to insert a malicious payload into memory with the hope that it will be executed later. Wouldn't it be great if you could prevent malware from running if it wrote to an area that has been allocated solely for the storage of information?\r
-\r
+    :kb-abstract """Malware depends on its ability to insert a malicious payload into memory with the hope that it will be executed later. Wouldn't it be great if you could prevent malware from running if it wrote to an area that has been allocated solely for the storage of information?
+
 Data Execution Prevention (DEP) does exactly that, by substantially reducing the range of memory that malicious code can use for its benefit. DEP uses the No eXecute bit on modern CPUs to mark blocks of memory as read-only so that those blocks can't be used to execute malicious code that may be inserted by means of a vulnerability exploit.""" ;
     :kb-author "Nick Schonning, Daniel Simpson, Marty Hernandez Avedon, Trond B. Krokli, jreeds, jcaparas, Andres Mariano Gorzelany, Tina Burden, Thomas Raya, Justin Hall, justanotheranonymoususer, Liza Poggemeyer, Dani Halfin, imba-tjd (Authors for entire page)" ;
     :kb-mitre-analysis " " ;
@@ -25306,8 +25306,8 @@ Data Execution Prevention (DEP) does exactly that, by substantially reducing the
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-003: Debuggers for Accessibility Applications - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-11-006/"^^xsd:anyURI ;
-    :kb-abstract """The Windows Registry location HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options allows for parameters to be set for applications during execution. One feature used by malicious actors is the "Debugger" option. When a key has this value enabled, a Debugging command line can be specified. Windows will launch the Debugging command line, and pass the original command line in as an argument. Adversaries can set a Debugger for Accessibility Applications. The analytic looks for the original command line as an argument to the Debugger. When the strings "sethc.exe", "utilman.exe", "osk.exe", "narrator.exe", and "Magnify.exe" are detected in the arguments, but not as the main executable, it is very likely that a Debugger is set.\r
-\r
+    :kb-abstract """The Windows Registry location HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options allows for parameters to be set for applications during execution. One feature used by malicious actors is the "Debugger" option. When a key has this value enabled, a Debugging command line can be specified. Windows will launch the Debugging command line, and pass the original command line in as an argument. Adversaries can set a Debugger for Accessibility Applications. The analytic looks for the original command line as an argument to the Debugger. When the strings "sethc.exe", "utilman.exe", "osk.exe", "narrator.exe", and "Magnify.exe" are detected in the arguments, but not as the main executable, it is very likely that a Debugger is set.
+
 This analytic could depend on the possibility of the known strings used as arguments for other applications used in the day-to-day environment. Although the chance of the string "sethc.exe" being used as an argument for another application is unlikely, it still is a possibility.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25359,18 +25359,18 @@ This analytic could depend on the possibility of the known strings used as argum
         owl:NamedIndividual ;
     rdfs:label "Reference - Decoy Personas for Safeguarding Online Identity Using Deception - MITRE" ;
     :has-link "https://web.archive.org/web/20180407204216/https://isc.sans.edu/diary/Decoy+Personas+for+Safeguarding+Online+Identity+Using+Deception/16159"^^xsd:anyURI ;
-    :kb-abstract """What if online scammers weren't sure whether the user account they are targeting is really yours, or whether the information they compiled about you is real? It's worth considering whether decoy online personas might help in the quest to safeguard our digital identities and data.\r
-\r
-I believe deception tactics, such as selective and careful use of honeypots, holds promise for defending enterprise IT resources. Some forms of deception could also protect individuals against online scammers and other attackers. This approach might not be quite practical today for most people, but in the future we might find it both necessary and achievable.\r
-\r
-Human attackers and malicious software pursue user accounts and data on-line through harvesting, phishing, password-guessing, software vulnerabilities, and various other means. How might we use decoys to confuse, misdirect, slow down and detect adversaries engaged in such activities?\r
-\r
-...\r
-\r
-The wealth of personal details available on social networking sites allows attackers to target individuals using social engineering, secret question-guessing and other techniques. For some examples of such approaches, see The Use of Fake or Fraudulent LinkedIn Profiles and Data Mining Resumes for Computer Attack Reconnaissance.\r
-\r
-Setting up one or more fake social network profiles (e.g., on Facebook) that use the person's real name can help the individual deflect the attack or can act as an early warning of an impending attack. A decoy profile could purposefully expose some inaccurate information, while the person's real profile would be more carefully concealed using the site's privacy settings. Decoy profiles would be associated with spamtrap email addresses.\r
-\r
+    :kb-abstract """What if online scammers weren't sure whether the user account they are targeting is really yours, or whether the information they compiled about you is real? It's worth considering whether decoy online personas might help in the quest to safeguard our digital identities and data.
+
+I believe deception tactics, such as selective and careful use of honeypots, holds promise for defending enterprise IT resources. Some forms of deception could also protect individuals against online scammers and other attackers. This approach might not be quite practical today for most people, but in the future we might find it both necessary and achievable.
+
+Human attackers and malicious software pursue user accounts and data on-line through harvesting, phishing, password-guessing, software vulnerabilities, and various other means. How might we use decoys to confuse, misdirect, slow down and detect adversaries engaged in such activities?
+
+...
+
+The wealth of personal details available on social networking sites allows attackers to target individuals using social engineering, secret question-guessing and other techniques. For some examples of such approaches, see The Use of Fake or Fraudulent LinkedIn Profiles and Data Mining Resumes for Computer Attack Reconnaissance.
+
+Setting up one or more fake social network profiles (e.g., on Facebook) that use the person's real name can help the individual deflect the attack or can act as an early warning of an impending attack. A decoy profile could purposefully expose some inaccurate information, while the person's real profile would be more carefully concealed using the site's privacy settings. Decoy profiles would be associated with spamtrap email addresses.
+
 Similarly, the person could expose decoy profiles on other sites, for instance those reveal shopping habits (e.g., Amazon), musings (e.g., Twitter), skills (e.g., GitHub), travel (e.g., TripIt), affections (e.g., Pinterest), music taste (e.g., Pandora) and so on. The person's decoy identities could also have fake resumes available on sites such as Indeed and Monster.com.""" ;
     :kb-author "Lenny Zeltser" ;
     :kb-mitre-analysis " " ;
@@ -25408,12 +25408,12 @@ Similarly, the person could expose decoy profiles on other sites, for instance t
     :has-link "https://patents.google.com/patent/US20190188384A1"^^xsd:anyURI ;
     :kb-abstract "Described herein are systems, techniques, and computer program products for preventing execution, by a scripting engine, of harmful commands that may be introduced by computer malware or other mechanisms. The system identifies certain host processes that may attempt to utilize a hosted scripting engine. An unmanaged interface module is injected into an identified host process. The unmanaged interface module is configured to detect certain conditions indicating the likelihood that a scripting engine will be instantiated, and in response to inject a managed interface module into the host process. The managed interface module hooks into certain methods of the scripting engine to intercept commands before they are executed by the scripting engine. The managed and unmanaged interface components then communicate with a kernel-mode threat detection component to determine whether any commands should be blocked." ;
     :kb-author "Ion-Alexandru IONESCU; Satoshi Tanda" ;
-    :kb-mitre-analysis """The patent describes techniques that can be implemented to detect and block malicious commands and command scripts from being executed by scripting engines.\r
-\r
-### Script Execution Monitoring explanation\r
-This patent describes software installed on the host system that hooks into methods of a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. For example regular expression checking may be used to identify commands having malicious patterns. Expression checking may be used for script files as well as interactively - typed commands.\r
-\r
-### File Content Signatures explanation\r
+    :kb-mitre-analysis """The patent describes techniques that can be implemented to detect and block malicious commands and command scripts from being executed by scripting engines.
+
+### Script Execution Monitoring explanation
+This patent describes software installed on the host system that hooks into methods of a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. For example regular expression checking may be used to identify commands having malicious patterns. Expression checking may be used for script files as well as interactively - typed commands.
+
+### File Content Signatures explanation
 This patent includes File Content Signatures because in the case of a script file, a hash of the file is compared against hashes of known malicious script files to determine whether the script file is malicious.""" ;
     :kb-organization "Crowdstrike Inc" ;
     :kb-reference-of :FileContentRules,
@@ -25456,11 +25456,11 @@ This patent includes File Content Signatures because in the case of a script fil
     :has-link "https://patents.google.com/patent/US20070028302A1/en?oq=US-2007028302-A1"^^xsd:anyURI ;
     :kb-abstract "A security system provides a defense from known and unknown viruses, worms, spyware, hackers, and social engineering attacks. The system can implement centralized policies that allow an administrator to approve, block, quarantine, and log file activities. A server associated with a number of hosts can provide a query for host computers to access security-related meta-information in local host stores. The query is pulled from the server by the hosts. The results of the distributed host query are stored and merged on the server, and exported for display, reports, or security response." ;
     :kb-author "Todd Brennan; John Hanratty" ;
-    :kb-mitre-analysis """Provides a mechanism to detect, monitor, locate, and control files installed on host computers. Each host has a host agent that analyzes file system activity and takes action based on policies configured on a server. The policies identify whether to block, log, allow, or quarantine actions such as file accesses and execution of executables. Examples of policies include:\r
-\r
-* Block/log execution of new executables and detached scripts (e.g., .exe or .bat)\r
-* Block/log reading/execution of new embedded content (e.g., macros in .doc)\r
-* Block/log installation/modification of Web content (alteration of content in .html or .cgi files)\r
+    :kb-mitre-analysis """Provides a mechanism to detect, monitor, locate, and control files installed on host computers. Each host has a host agent that analyzes file system activity and takes action based on policies configured on a server. The policies identify whether to block, log, allow, or quarantine actions such as file accesses and execution of executables. Examples of policies include:
+
+* Block/log execution of new executables and detached scripts (e.g., .exe or .bat)
+* Block/log reading/execution of new embedded content (e.g., macros in .doc)
+* Block/log installation/modification of Web content (alteration of content in .html or .cgi files)
 * Block/log execution of new files in an administratively defined 'class'; e.g., an administrator might want to block screen savers .scr, but not the entire class of executables .exe, .dll, .sys, etc . . .""" ;
     :kb-organization "Bit 9 Inc" ;
     :kb-reference-of :FileContentRules ;
@@ -25470,11 +25470,11 @@ This patent includes File Content Signatures because in the case of a script fil
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-10-002: DLL Injection via Load Library - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-10-002/"^^xsd:anyURI ;
-    :kb-abstract """Microsoft Windows allows for processes to remotely create threads within other processes of the same privilege level. This functionality is provided via the Windows API CreateRemoteThread. Both Windows and third-party software use this ability for legitimate purposes. For example, the Windows process csrss.exe creates threads in programs to send signals to registered callback routines. Both adversaries and host-based security software use this functionality to inject DLLs, but for very different purposes. An adversary is likely to inject into a program to evade defenses or bypass User Account Control, but a security program might do this to gain increased monitoring of API calls. One of the most common methods of DLL Injection is through the Windows API LoadLibrary.\r
-\r
-Allocate memory in the target program with VirtualAllocEx\r
-Write the name of the DLL to inject into this program with WriteProcessMemory\r
-Create a new thread and set its entry point to LoadLibrary using the API CreateRemoteThread.\r
+    :kb-abstract """Microsoft Windows allows for processes to remotely create threads within other processes of the same privilege level. This functionality is provided via the Windows API CreateRemoteThread. Both Windows and third-party software use this ability for legitimate purposes. For example, the Windows process csrss.exe creates threads in programs to send signals to registered callback routines. Both adversaries and host-based security software use this functionality to inject DLLs, but for very different purposes. An adversary is likely to inject into a program to evade defenses or bypass User Account Control, but a security program might do this to gain increased monitoring of API calls. One of the most common methods of DLL Injection is through the Windows API LoadLibrary.
+
+Allocate memory in the target program with VirtualAllocEx
+Write the name of the DLL to inject into this program with WriteProcessMemory
+Create a new thread and set its entry point to LoadLibrary using the API CreateRemoteThread.
 This behavior can be detected by looking for thread creations across processes, and resolving the entry point to determine the function name. If the function is LoadLibraryA or LoadLibraryW, then the intent of the remote thread is clearly to inject a DLL. When this is the case, the source process must be examined so that it can be ignored when it is both expected and a trusted process.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25506,8 +25506,8 @@ This behavior can be detected by looking for thread creations across processes, 
         :SpecificationReference ;
     rdfs:label "Reference - RFC 6376: DomainKeys Identified Mail (DKIM) Signatures - IETF" ;
     :has-link "https://tools.ietf.org/html/rfc6376"^^xsd:anyURI ;
-    :kb-abstract """DomainKeys Identified Mail (DKIM) permits a person, role, or organization that owns the signing domain to claim some responsibility for a message by associating the domain with the message.  This can be an author's organization, an operational relay, or one of their agents.  DKIM separates the question of the identity of the Signer of the message from the purported author of the message.  Assertion of responsibility is validated through a\r
-cryptographic signature and by querying the Signer's domain directly\r
+    :kb-abstract """DomainKeys Identified Mail (DKIM) permits a person, role, or organization that owns the signing domain to claim some responsibility for a message by associating the domain with the message.  This can be an author's organization, an operational relay, or one of their agents.  DKIM separates the question of the identity of the Signer of the message from the purported author of the message.  Assertion of responsibility is validated through a
+cryptographic signature and by querying the Signer's domain directly
 to retrieve the appropriate public key.  Message transit from author to recipient is through relays that typically make no substantive change to the message content and thus preserve the DKIM signature.""" ;
     :kb-author "D. Crocker, T. Hansen, M. Kucherawy" ;
     :kb-organization "Internet Engineering Task Force (IETF)" ;
@@ -25544,8 +25544,8 @@ to retrieve the appropriate public key.  Message transit from author to recipien
         :PatentReference ;
     rdfs:label "Reference - Embedding contexts for on-line threats into response policy zones - Verisign Inc" ;
     :has-link "https://patents.google.com/patent/US10440059B1"^^xsd:anyURI ;
-    :kb-abstract """Hierarchical threat intelligence embedded in subdomain CNAMEs of a DNS denylist.\r
-\r
+    :kb-abstract """Hierarchical threat intelligence embedded in subdomain CNAMEs of a DNS denylist.
+
 In one embodiment, a response policy zone (RPZ) application generates an RPZ that includes contexts for the on-line threats that are associated with domain names. For a domain name that is associated with an on-line threat, the RPZ application determines a threat specification that describes a characteristic of the on-line threat. The RPZ application then generates an alias based on the domain name and the threat specification. Subsequently, the RPZ application generates a domain name system (DNS) resource record that maps the domain name to the alias, includes the resource record in the RPZ, and transmits the RPZ to a DNS name server that implements the RPZ. Upon receiving a DNS query associated with the domain name, the DNS name server generates a DNS response based on the alias. Because the domain name and the threat specification is reflected in the alias, the DNS response automatically provides a relevant context.""" ;
     :kb-author "Ben McCarty" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -25608,17 +25608,17 @@ In one embodiment, a response policy zone (RPZ) application generates an RPZ tha
     :has-link "https://patents.google.com/patent/US20180121650A1/en?oq=US-2018121650-A1"^^xsd:anyURI ;
     :kb-abstract "A security agent implemented on a computing device is described herein. The security agent is configured to detect file-modifying malware by detecting that a process is traversing a directory of the memory of the computing device and detecting that the process is accessing files in the memory according to specified file access patterns. The security agent can also be configured to correlate actions of multiple processes that correspond to a specified file access pattern and detect that one or more of the multiple processes are malware by correlating their behavior." ;
     :kb-author "Daniel W. Brown" ;
-    :kb-mitre-analysis """This patent describes a technique for detecting file modifying malware such as wipers and ransomware that overwrite portions of files and encrypt portions of a computer's memory, respectively. Processes that are traversing a directory are identified along with file access patterns. Processes executing on a computing device that are traversing a directory include:\r
-\r
-* changing a directory of a process (e.g., iteratively, systematically, repeatedly)\r
-* detecting that a process is conducting an "open directory" operation repeatedly\r
-* the same process traversing through a directory and recording the locations of data files encountered in each sub - directory\r
-\r
-In addition to identifying processes traversing a directory, particular file access patterns are also detected that may be indicative of malicious behavior including:\r
-* multiple file types being accessed\r
-* accessing a large number of files\r
-* files located in multiple locations in the directory being accessed\r
-\r
+    :kb-mitre-analysis """This patent describes a technique for detecting file modifying malware such as wipers and ransomware that overwrite portions of files and encrypt portions of a computer's memory, respectively. Processes that are traversing a directory are identified along with file access patterns. Processes executing on a computing device that are traversing a directory include:
+
+* changing a directory of a process (e.g., iteratively, systematically, repeatedly)
+* detecting that a process is conducting an "open directory" operation repeatedly
+* the same process traversing through a directory and recording the locations of data files encountered in each sub - directory
+
+In addition to identifying processes traversing a directory, particular file access patterns are also detected that may be indicative of malicious behavior including:
+* multiple file types being accessed
+* accessing a large number of files
+* files located in multiple locations in the directory being accessed
+
 If a process is conducting a traversal of the directory and accessing files according to a defined access pattern associated with malicious behavior, a preventative action is performed.""" ;
     :kb-organization "Crowdstrike Inc" ;
     :kb-reference-of :FileAccessPatternAnalysis ;
@@ -25706,18 +25706,18 @@ If a process is conducting a traversal of the directory and accessing files acco
         owl:NamedIndividual ;
     rdfs:label "Reference - Firmware Behavior Analysis ConFirm" ;
     :has-link "http://sites.nyuad.nyu.edu/moma/pdfs/pubs/C22.pdf"^^xsd:anyURI ;
-    :kb-abstract """The modernization of various critical infrastructure components has dictated the use of microprocessor-based\r
-embedded control systems in critical applications. It is often\r
-infeasible, however, to employ the same level of security measures used in general purpose computing systems, due to the stringent\r
-performance and resource constraints of embedded devices. Furthermore, as software relies on the firmware for proper operation,\r
-no software-level technique can detect malicious behavior of\r
-the firmware. In this work, we propose ConFirm, a low-cost\r
-technique to detect malicious modifications in the firmware\r
+    :kb-abstract """The modernization of various critical infrastructure components has dictated the use of microprocessor-based
+embedded control systems in critical applications. It is often
+infeasible, however, to employ the same level of security measures used in general purpose computing systems, due to the stringent
+performance and resource constraints of embedded devices. Furthermore, as software relies on the firmware for proper operation,
+no software-level technique can detect malicious behavior of
+the firmware. In this work, we propose ConFirm, a low-cost
+technique to detect malicious modifications in the firmware
 of embedded systems by measuring the number of low-level hardware events that occur during the execution of the firmware.""" ;
     :kb-author "Xueyang Wang, Charalambos Konstantinou, Michail Maniatakos, Ramesh Karri" ;
     :kb-organization "Department of Electrical and Computer Engineering, Polytechnic School of Engineering, New York University and Department of Electrical and Computer Engineering, New York University Abu Dhabi" ;
     :kb-reference-of :FirmwareBehaviorAnalysis ;
-    :kb-reference-title """ConFirm: Detecting Firmware Modifications in Embedded Systems\r
+    :kb-reference-title """ConFirm: Detecting Firmware Modifications in Embedded Systems
 using Hardware Performance Counters""" .
 
 :Reference-FirmwareBehaviorAnalysisVIPER a :AcademicPaperReference,
@@ -25744,8 +25744,8 @@ using Hardware Performance Counters""" .
         owl:NamedIndividual ;
     rdfs:label "Reference - Firmware Embedded Monitoring Code Symbiotes" ;
     :has-link "http://nsl.cs.columbia.edu/projects/minestrone/papers/Symbiotes.pdf"^^xsd:anyURI ;
-    :kb-abstract """A large number of embedded devices on the internet, such as\r
-routers and VOIP phones, are typically ripe for exploitation. Little to no defensive technology, such as AV scanners or IDS's, are available to protect these devices. We propose a host-based defense mechanism, which we call Symbiotic Embedded Machines (SEM), that is specifically designed\r
+    :kb-abstract """A large number of embedded devices on the internet, such as
+routers and VOIP phones, are typically ripe for exploitation. Little to no defensive technology, such as AV scanners or IDS's, are available to protect these devices. We propose a host-based defense mechanism, which we call Symbiotic Embedded Machines (SEM), that is specifically designed
 to inject intrusion detection functionality into the firmware of the device.""" ;
     :kb-author "Ang Cui, Salvatore J. Stolfo" ;
     :kb-organization "Department of Computer Science Columbia University" ;
@@ -25803,10 +25803,10 @@ to inject intrusion detection functionality into the firmware of the device.""" 
         :TechniqueReference ;
     rdfs:label "Reference - FWTK Documentation - fwtk.org" ;
     :has-link "https://web.archive.org/web/20070510153306/http://www.fwtk.org/fwtk/docs/documentation.html#1.1"^^xsd:anyURI ;
-    :kb-abstract """In case you don't already know, FWTK stands for the FireW all Tool Kit. It is used as a base to create a secure firewall system. If you need good documentation, please read the source code. If you are not familiar with C or do not feel comfortable with performing the configuration and security verification yourself, then I would suggest that you purchase a commercial firewall from a vendor (such as TIS, Checkpoint, Raptor, etc.).\r
-\r
-A machine needs other tools to secure it, including, but hardly limited to, tools to check files (tripwire), audit tools (tiger/cops), secure access methods (kerberos/ssh), something to watch logs and machine states (swatch/watcher some to mind) and filtering and routing tools such as screend/ipfilterd/ipacl.\r
-\r
+    :kb-abstract """In case you don't already know, FWTK stands for the FireW all Tool Kit. It is used as a base to create a secure firewall system. If you need good documentation, please read the source code. If you are not familiar with C or do not feel comfortable with performing the configuration and security verification yourself, then I would suggest that you purchase a commercial firewall from a vendor (such as TIS, Checkpoint, Raptor, etc.).
+
+A machine needs other tools to secure it, including, but hardly limited to, tools to check files (tripwire), audit tools (tiger/cops), secure access methods (kerberos/ssh), something to watch logs and machine states (swatch/watcher some to mind) and filtering and routing tools such as screend/ipfilterd/ipacl.
+
 Again, I would recommend that you do not proceed to build a production FWTK firewall unless you are familiar with UNIX security.""" ;
     :kb-author "fwtk.org" ;
     :kb-organization "fwtk.org" ;
@@ -25861,16 +25861,16 @@ Again, I would recommend that you do not proceed to build a production FWTK fire
     :has-link "https://patents.google.com/patent/US20180032728A1/en?oq=US20180032728-A1"^^xsd:anyURI ;
     :kb-abstract "The present disclosure relates to a system and method for monitoring system calls to an operating system kernel. A performance monitoring unit is used to monitor system calls and to gather information about each system call. The information is gathered upon interrupting the system call and can include system call type, parameters, and information about the calling thread/process, in order to determine whether the system call was generated by malicious software code. Potentially malicious software code is nullified by a malicious code counter-attack module." ;
     :kb-author "Matthew D. Spisak" ;
-    :kb-mitre-analysis """This patent describes a technique for monitoring system calls to detect malicious software code. A system call monitoring module operates at the kernel level and traps system calls.\r
-Monitoring data includes:\r
-\r
-* information about the path to the file to be accessed by a system call.\r
-* the memory address or range of addresses to be accessed by a system call.\r
-* the context for the thread within operating system that will be interrupted by a system call.\r
-* the type of system call information about the socket that is being used by system call in order to send or receive data.\r
-* the history of system calls in order to monitor for specific sequences of system calls.\r
-* the frequency or periodicity of a particular system call or set of systems calls.\r
-\r
+    :kb-mitre-analysis """This patent describes a technique for monitoring system calls to detect malicious software code. A system call monitoring module operates at the kernel level and traps system calls.
+Monitoring data includes:
+
+* information about the path to the file to be accessed by a system call.
+* the memory address or range of addresses to be accessed by a system call.
+* the context for the thread within operating system that will be interrupted by a system call.
+* the type of system call information about the socket that is being used by system call in order to send or receive data.
+* the history of system calls in order to monitor for specific sequences of system calls.
+* the frequency or periodicity of a particular system call or set of systems calls.
+
 Captured system call data is analyzed using data analysis algorithms such as machine learning algorithms, artificial intelligence algorithms, pattern recognition algorithms, or other known data analysis techniques. An alert is generated if it is likely that the system call was generated by malicious software code.""" ;
     :kb-organization "Endgame Inc" ;
     :kb-reference-of :SystemCallAnalysis ;
@@ -25882,12 +25882,12 @@ Captured system call data is analyzed using data analysis algorithms such as mac
     :has-link "https://patents.google.com/patent/US20160156644A1"^^xsd:anyURI ;
     :kb-abstract "In some embodiments, heuristic botnet detection is provided. In some embodiments, heuristic botnet detection includes monitoring network traffic to identify suspicious network traffic; and detecting a bot based on a heuristic analysis of the suspicious network traffic behavior using a processor, in which the suspicious network traffic behavior includes command and control traffic associated with a bot master. In some embodiments, heuristic botnet detection further includes assigning a score to the monitored network traffic, in which the score corresponds to a botnet risk characterization of the monitored network traffic (e.g., based on one or more heuristic botnet detection techniques); increasing the score based on a correlation of additional suspicious behaviors associated with the monitored network traffic (e.g., based on one or more heuristic botnet detection techniques); and determining the suspicious behavior is associated with a botnet based on the score." ;
     :kb-author "Xinran Wang; Huagang Xie" ;
-    :kb-mitre-analysis """This patent describes detecting botnets using heuristic analysis techniques on collected network flows. The heuristic techniques include:\r
-\r
-* Identifying suspicious traffic patterns to detect command and control traffic ex. periodically visiting a known malware URL, a host visiting a malware domain twice every 5 hour and 14 minutes (this is a specific pattern for a variant of Swizzor botnets).\r
-* Identifying non-standard behaviors such as connecting to a non-standard HTTP port for HTTP traffic, visiting a non-existent domain, downloading executable files with non-standard executable file extensions, communicating using HTTP header with a shorter than common length\r
-* Analyzing visited domain information to identify the following: visiting a domain with a domain name that is longer than a common domain name length, visiting a dynamic DNS domain, visiting a fast-flux domain, and visiting a recently created domain.\r
-\r
+    :kb-mitre-analysis """This patent describes detecting botnets using heuristic analysis techniques on collected network flows. The heuristic techniques include:
+
+* Identifying suspicious traffic patterns to detect command and control traffic ex. periodically visiting a known malware URL, a host visiting a malware domain twice every 5 hour and 14 minutes (this is a specific pattern for a variant of Swizzor botnets).
+* Identifying non-standard behaviors such as connecting to a non-standard HTTP port for HTTP traffic, visiting a non-existent domain, downloading executable files with non-standard executable file extensions, communicating using HTTP header with a shorter than common length
+* Analyzing visited domain information to identify the following: visiting a domain with a domain name that is longer than a common domain name length, visiting a dynamic DNS domain, visiting a fast-flux domain, and visiting a recently created domain.
+
 A score is determined based on these factors and if the score is over a threshold, a responsive action is performed.""" ;
     :kb-organization "Palo Alto Networks Inc" ;
     :kb-reference-of :DNSTrafficAnalysis ;
@@ -25897,8 +25897,8 @@ A score is determined based on these factors and if the score is over a threshol
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2016-03-001: Host Discovery Commands - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2016-03-001/"^^xsd:anyURI ;
-    :kb-abstract """When entering on a host for the first time, an adversary may try to discover information about the host. There are several built-in Windows commands that can be used to learn about the software configurations, active users, administrators, and networking configuration. These commands should be monitored to identify when an adversary is learning information about the system and environment. The information returned may impact choices an adversary can make when establishing persistence, escalating privileges, or moving laterally.\r
-\r
+    :kb-abstract """When entering on a host for the first time, an adversary may try to discover information about the host. There are several built-in Windows commands that can be used to learn about the software configurations, active users, administrators, and networking configuration. These commands should be monitored to identify when an adversary is learning information about the system and environment. The information returned may impact choices an adversary can make when establishing persistence, escalating privileges, or moving laterally.
+
 Because these commands are built in, they may be run frequently by power users or even by normal users. Thus, an analytic looking at this information should have well-defined white- or blacklists, and should consider looking at an anomaly detection approach, so that this information can be learned dynamically.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25914,25 +25914,25 @@ Because these commands are built in, they may be run frequently by power users o
     :has-link "https://patents.google.com/patent/US20110023115A1"^^xsd:anyURI ;
     :kb-abstract "In embodiments of the present invention improved capabilities are described for threat detection using a behavioral-based host-intrusion prevention method and system for monitoring a user interaction with a computer, software application, operating system, graphic user interface, or some other component or client of a computer network, and performing an action to protect the computer network based at least in part on the user interaction and a computer code process executing during or in association with a computer usage session." ;
     :kb-author "Clifford C. Wright" ;
-    :kb-mitre-analysis """The patent describes a technique for performing behavior based threat detection. User and code behavior data is collected and stored to create baseline user and code behavior profiles. User behavior data collected over a user session or over multiple sessions can include a user:\r
-\r
-* clicking on a link\r
-* scrolling down a page\r
-* opening or closing a window\r
-* downloading a file\r
-* saving a file\r
-* running a file\r
-* typing a keyword\r
-\r
-Code behavior monitored includes code:\r
-\r
-* copying itself to a system folder\r
-* setting a run key to itself in the registry\r
-* setting a second runkey to itself in the registry in\r
-a different location\r
-* disabling OS tools in the registry\r
-* opening a hidden file\r
-\r
+    :kb-mitre-analysis """The patent describes a technique for performing behavior based threat detection. User and code behavior data is collected and stored to create baseline user and code behavior profiles. User behavior data collected over a user session or over multiple sessions can include a user:
+
+* clicking on a link
+* scrolling down a page
+* opening or closing a window
+* downloading a file
+* saving a file
+* running a file
+* typing a keyword
+
+Code behavior monitored includes code:
+
+* copying itself to a system folder
+* setting a run key to itself in the registry
+* setting a second runkey to itself in the registry in
+a different location
+* disabling OS tools in the registry
+* opening a hidden file
+
 The user interaction and the code process executed during the user session are monitored and compared with predetermined malicious behavior profiles that are typically present in a malicious user session.  The predetermined collection of malicious behaviors are created based on analysis of families of malware in run time in a threat research facility. If a match is made an action is taken that can include isolating the computer on which the user interaction occurs and limiting network access to or from the computer.""" ;
     :kb-organization "Sophos Ltd" ;
     :kb-reference-of :ResourceAccessPatternAnalysis,
@@ -25965,9 +25965,9 @@ The user interaction and the code process executed during the user session are m
         owl:NamedIndividual ;
     rdfs:label "Reference - How to change registry values or permissions from a command line or a script" ;
     :has-link "https://docs.microsoft.com/en-us/troubleshoot/windows-client/application-management/change-registry-values-permissions"^^xsd:anyURI ;
-    :kb-abstract """This article describes how to change registry values or permissions from a command line or a script.\r
-\r
-Applies to:   Windows 10 - all editions, Windows Server 2012 R2\r
+    :kb-abstract """This article describes how to change registry values or permissions from a command line or a script.
+
+Applies to:   Windows 10 - all editions, Windows Server 2012 R2
 Original KB number:   264584""" ;
     :kb-organization "Microsoft" ;
     :kb-reference-title "How to change registry values or permissions from a command line or a script" .
@@ -26002,8 +26002,8 @@ Original KB number:   264584""" ;
         :PatentReference ;
     rdfs:label "Reference - Identification of visual international domain name collisions - Verisign Inc" ;
     :has-link "https://patents.google.com/patent/US10599836B2/en"^^xsd:anyURI ;
-    :kb-abstract """Fuzzy OCR to detect domain name homoglyph attacks.\r
-\r
+    :kb-abstract """Fuzzy OCR to detect domain name homoglyph attacks.
+
 Various embodiments of the invention disclosed herein provide techniques for detecting a homograph attack. An IDN collision detection server retrieves a first domain name that includes a punycode element. The IDN collision detection server converts the first domain into a second domain name that includes a Unicode character corresponding to the punycode element. The IDN collision detection server converts the second domain name into an image. The IDN collision detection server performs one or more optical character recognition operations on the image to generate a textual string associated with the image. The IDN collision detection server determines that the textual string matches at least a portion of a third domain name.""" ;
     :kb-author "Ben McCarty, Preston Zeh" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -26033,24 +26033,24 @@ Various embodiments of the invention disclosed herein provide techniques for det
         owl:NamedIndividual ;
     rdfs:label "Reference - Indirect Branching Calls" ;
     :has-link "https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.1048.1241&rep=rep1&type=pdf"^^xsd:anyURI ;
-    :kb-abstract """Return-oriented programming (ROP) has become the\r
-primary exploitation technique for system compromise\r
-in the presence of non-executable page protections. ROP\r
-exploits are facilitated mainly by the lack of complete\r
-address space randomization coverage or the presence\r
-of memory disclosure vulnerabilities, necessitating additional ROP-specific mitigations.\r
-In this paper we present a practical runtime ROP exploit prevention technique for the protection of thirdparty applications. Our approach is based on the detection of abnormal control transfers that take place during\r
-ROP code execution. This is achieved using hardware\r
-features of commodity processors, which incur negligible runtime overhead and allow for completely transparent operation without requiring any modifications to\r
-the protected applications. Our implementation for Windows 7, named kBouncer, can be selectively enabled for\r
-installed programs in the same fashion as user-friendly\r
-mitigation toolkits like Microsoft's EMET. The results of\r
-our evaluation demonstrate that kBouncer has low runtime overhead of up to 4%, when stressed with specially\r
-crafted workloads that continuously trigger its core detection component, while it has negligible overhead for\r
-actual user applications. In our experiments with in-thewild ROP exploits, kBouncer successfully protected all\r
-tested applications, including Internet Explorer, Adobe\r
+    :kb-abstract """Return-oriented programming (ROP) has become the
+primary exploitation technique for system compromise
+in the presence of non-executable page protections. ROP
+exploits are facilitated mainly by the lack of complete
+address space randomization coverage or the presence
+of memory disclosure vulnerabilities, necessitating additional ROP-specific mitigations.
+In this paper we present a practical runtime ROP exploit prevention technique for the protection of thirdparty applications. Our approach is based on the detection of abnormal control transfers that take place during
+ROP code execution. This is achieved using hardware
+features of commodity processors, which incur negligible runtime overhead and allow for completely transparent operation without requiring any modifications to
+the protected applications. Our implementation for Windows 7, named kBouncer, can be selectively enabled for
+installed programs in the same fashion as user-friendly
+mitigation toolkits like Microsoft's EMET. The results of
+our evaluation demonstrate that kBouncer has low runtime overhead of up to 4%, when stressed with specially
+crafted workloads that continuously trigger its core detection component, while it has negligible overhead for
+actual user applications. In our experiments with in-thewild ROP exploits, kBouncer successfully protected all
+tested applications, including Internet Explorer, Adobe
 Flash Player, and Adobe Reader.""" ;
-    :kb-author """Vasilis Pappas, Michalis Polychronakis, Angelos D. Keromytis\r
+    :kb-author """Vasilis Pappas, Michalis Polychronakis, Angelos D. Keromytis
 Columbia University""" ;
     :kb-organization "Columbia University" ;
     :kb-reference-of :IndirectBranchCallAnalysis ;
@@ -26060,10 +26060,10 @@ Columbia University""" ;
         :PatentReference ;
     rdfs:label "Reference - Inferential exploit attempt detection - Crowdstrike Inc" ;
     :has-link "https://patents.google.com/patent/US10216934B2/en?oq=US-10216934-B2"^^xsd:anyURI ;
-    :kb-abstract """A security agent implemented on a monitored computing device is described herein. The security agent is configured to detect an action of interest (AoI) that may be probative of a security exploit and to determine a context in which that AoI occurred. Based on that context, the security agent is further configured to decide whether the AoI is a security exploit and can take preventative action to prevent the exploit from being completed.\r
-\r
-Determining that the AoI includes the security exploit is based at least in part on one or more of: determining that the return address is outside memory previously allocated for an object; determining that the object identifier is associated with a vulnerable object; determining that permissions of the memory region include two or more of read, write, and execute; or determining that the memory region is one page in length.\r
-\r
+    :kb-abstract """A security agent implemented on a monitored computing device is described herein. The security agent is configured to detect an action of interest (AoI) that may be probative of a security exploit and to determine a context in which that AoI occurred. Based on that context, the security agent is further configured to decide whether the AoI is a security exploit and can take preventative action to prevent the exploit from being completed.
+
+Determining that the AoI includes the security exploit is based at least in part on one or more of: determining that the return address is outside memory previously allocated for an object; determining that the object identifier is associated with a vulnerable object; determining that permissions of the memory region include two or more of read, write, and execute; or determining that the memory region is one page in length.
+
 Determining that the return address is outside memory previously allocated for an object and the method further including treating code that the return address points to as malicious code.""" ;
     :kb-author "Daniel W. Brown; Ion-Alexandru Ionescu; Loren C. Robinson" ;
     :kb-mitre-analysis " " ;
@@ -26090,8 +26090,8 @@ Determining that the return address is outside memory previously allocated for a
     :has-link "https://patents.google.com/patent/US20170061127A1"^^xsd:anyURI ;
     :kb-abstract "Techniques utilizing library and pre-boot components to ensure that a driver associated with a kernel-mode component is initialized before other drivers during a boot phase are described herein. The library component is processed during a boot phase; the pre-boot component, which may be an alternative to the library component, is processed during a pre-boot phase. By ensuring that the driver is the first driver initialized, the components enable the driver to launch the kernel-mode component before other drivers are initialized. The library component may also determine whether another driver is to be initialized before the kernel-mode component driver, may ensure that kernel-mode component driver is initialized first, and may alert the kernel-mode component. Also, the library component may retrieve information that is to be deleted by the operating system before initialization of drivers and may provide that information to the kernel-mode component." ;
     :kb-author "Ion-Alexandru Ionescu" ;
-    :kb-mitre-analysis """To compromise software or to gain control of a host device, a security exploit can modify driver initialization order used by an operating system and place a driver associated with the security exploit first in a list of drivers initialized by the operating system.\r
-\r
+    :kb-mitre-analysis """To compromise software or to gain control of a host device, a security exploit can modify driver initialization order used by an operating system and place a driver associated with the security exploit first in a list of drivers initialized by the operating system.
+
 This patent describes ensuring that a driver associated with the agent is initialized first. To ensure the driver is initialized first, a dependent DLL associated with the driver is configured to be processed before other dependent DLLs. The dependent DLL can be configured to be processed first by various methods, for example if processing is done in alphabetical order, changing its name to be processed first. The dependent DLL, once processed, executes a number of operations to ensure the driver associated with the agent is initialized first. Furthermore, if the initialization order is modified, an alert is provided to the kernel-mode component that notifies the kernel-mode component it was not first and the order had to be altered. It can then take additional actions such as additional monitoring or remediation.""" ;
     :kb-organization "Crowdstrike Inc" ;
     :kb-reference-of :DriverLoadIntegrityChecking ;
@@ -26103,13 +26103,13 @@ This patent describes ensuring that a driver associated with the agent is initia
     :has-link "https://patents.google.com/patent/US20180191752A1"^^xsd:anyURI ;
     :kb-abstract "A variety of techniques are disclosed for detection of advanced persistent threats and similar malware. In one aspect, the detection of certain network traffic at a gateway is used to trigger a query of an originating endpoint, which can use internal logs to identify a local process that is sourcing the network traffic. In another aspect, an endpoint is configured to periodically generate and transmit a secure heartbeat, so that an interruption of the heartbeat can be used to signal the possible presence of malware. In another aspect, other information such as local and global reputation information is used to provide context for more accurate malware detection." ;
     :kb-author "Kenneth D. Ray" ;
-    :kb-mitre-analysis """This patent describes a health monitor deployed on an endpoint that uses a heartbeat to periodically communicate status to a gateway's remote health monitor. The endpoint health monitor issues a heartbeat for satisfactory status of the endpoint using factors such as:\r
-\r
-* checking the status of individual software items executing on the endpoint\r
-* checking that antivirus and other security software is up to date (e. g., with current virus definition files) and running correctly\r
-* checking the integrity of cryptographic key stores\r
-* checking other hardware or software components of the endpoint as necessary or helpful for health monitoring\r
-\r
+    :kb-mitre-analysis """This patent describes a health monitor deployed on an endpoint that uses a heartbeat to periodically communicate status to a gateway's remote health monitor. The endpoint health monitor issues a heartbeat for satisfactory status of the endpoint using factors such as:
+
+* checking the status of individual software items executing on the endpoint
+* checking that antivirus and other security software is up to date (e. g., with current virus definition files) and running correctly
+* checking the integrity of cryptographic key stores
+* checking other hardware or software components of the endpoint as necessary or helpful for health monitoring
+
 A disappearance of the heartbeat from the endpoint may indicate that the endpoint has been compromised.""" ;
     :kb-organization "Sophos Ltd" ;
     :kb-reference-of :EndpointHealthBeacon ;
@@ -26119,8 +26119,8 @@ A disappearance of the heartbeat from the endpoint may indicate that the endpoin
         :UserManualReference ;
     rdfs:label "Reference - Libre NMS - Network Map Extension" ;
     :has-link "https://docs.librenms.org/Extensions/Network-Map/"^^xsd:anyURI ;
-    :kb-abstract """LibreNMS has the ability to show you a network map based on:\r
-* xDP Discovery\r
+    :kb-abstract """LibreNMS has the ability to show you a network map based on:
+* xDP Discovery
 * MAC addresses""" ;
     :kb-organization "LibreNMS.org" ;
     :kb-reference-of :NetworkMapping ;
@@ -26130,10 +26130,10 @@ A disappearance of the heartbeat from the endpoint may indicate that the endpoin
         :UserManualReference ;
     rdfs:label "Reference - Libre NMS - Oxidized Extension" ;
     :has-link "https://docs.librenms.org/Extensions/Oxidized/"^^xsd:anyURI ;
-    :kb-abstract """Integrating LibreNMS with Oxidized brings the following benefits:\r
-\r
-* Config viewing: Current, History, and Diffs all under the Configs tab of each device\r
-* Automatic addition of devices to Oxidized: Including filtering and grouping to ease credential management\r
+    :kb-abstract """Integrating LibreNMS with Oxidized brings the following benefits:
+
+* Config viewing: Current, History, and Diffs all under the Configs tab of each device
+* Automatic addition of devices to Oxidized: Including filtering and grouping to ease credential management
 * Configuration searching""" ;
     :kb-organization "LibreNMS.org" ;
     :kb-reference-of :DiskEncryption ;
@@ -26143,8 +26143,8 @@ A disappearance of the heartbeat from the endpoint may indicate that the endpoin
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2019-07-002: Lsass Process Dump via Procdump - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2019-07-002/"^^xsd:anyURI ;
-    :kb-abstract """ProcDump is a sysinternal command-line utility whose primary purpose is monitoring an application for CPU spikes and generating crash dumps during a spike that an administrator or developer can use to determine the cause of the spike.\r
-\r
+    :kb-abstract """ProcDump is a sysinternal command-line utility whose primary purpose is monitoring an application for CPU spikes and generating crash dumps during a spike that an administrator or developer can use to determine the cause of the spike.
+
 ProcDump may be used to dump the memory space of lsass.exe to disk for processing with a credential access tool such as Mimikatz. This is performed by launching procdump.exe as a privileged user with command line options indicating that lsass.exe should be dumped to a file with an arbitrary name.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26215,14 +26215,14 @@ ProcDump may be used to dump the memory space of lsass.exe to disk for processin
     :has-link "https://patents.google.com/patent/US20140331319A1"^^xsd:anyURI ;
     :kb-abstract "A method and apparatus for detecting malicious websites is disclosed." ;
     :kb-author "John Burnet MUNRO, IV; Jason Aaron Trost; Zachary Daniel HANIF" ;
-    :kb-mitre-analysis """This patent describes a domain classification engine on the host computer that analyzes URLs clicked by a user or entered into a web browser to visit a website. URL analysis is done by using a combination of techniques:\r
-\r
-* Feature extraction: A URL is analyzed against features associated with suspicious URLs such as % of longest consecutive digits in a subdomain, % of longest repeated characters in a subdomain, % of vowels in a high level domain.\r
-\r
-* Markov analysis: The probability of a digit occurring in normal language given the preceding two digits is determined. For example, if the received URL is google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an "o' occurring after a 'g' and "o, and so forth will be determined. The probability of each digit is then multiplied to get a probability for the whole domain name. Probabilities are determined based on a database of existing usage, such as a dictionary, or a list of known good domain names\r
-\r
-* Domain names are compared against an existing dataset of known unauthorized domain names.\r
-\r
+    :kb-mitre-analysis """This patent describes a domain classification engine on the host computer that analyzes URLs clicked by a user or entered into a web browser to visit a website. URL analysis is done by using a combination of techniques:
+
+* Feature extraction: A URL is analyzed against features associated with suspicious URLs such as % of longest consecutive digits in a subdomain, % of longest repeated characters in a subdomain, % of vowels in a high level domain.
+
+* Markov analysis: The probability of a digit occurring in normal language given the preceding two digits is determined. For example, if the received URL is google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an "o' occurring after a 'g' and "o, and so forth will be determined. The probability of each digit is then multiplied to get a probability for the whole domain name. Probabilities are determined based on a database of existing usage, such as a dictionary, or a list of known good domain names
+
+* Domain names are compared against an existing dataset of known unauthorized domain names.
+
 A rating is developed based on the results of these techniques, and if the rating is over a set threshold, an action is taken such as blocking access or generating an alert.""" ;
     :kb-organization "Endgame Inc" ;
     :kb-reference-of :URLAnalysis ;
@@ -26246,14 +26246,14 @@ A rating is developed based on the results of these techniques, and if the ratin
     :has-link "https://patents.google.com/patent/US20190081968A1/en"^^xsd:anyURI ;
     :kb-abstract "A system and method for assessing the identity fraud risk of an entity's (a user's, computer process's, or device's) behavior within a computer network and then to take appropriate action. The system uses real-time machine learning for its assessment. It records the entity's log-in behavior (conditions at log-in) and behavior once logged in to create an entity profile that helps identify behavior patterns. The system compares new entity behavior with the entity profile to determine a risk score and a confidence level for the behavior. If the risk score and confidence level indicate a credible identity fraud risk at log-in, the system can require more factors of authentication before log-in succeeds. If the system detects risky behavior after log-in, it can take remedial action such as ending the entity's session, curtailing the entity's privileges, or notifying a human administrator." ;
     :kb-author "Yanlin Wang; Weizhi Li" ;
-    :kb-mitre-analysis """This patent describes determining a confidence score to detect anomalies in user activity based on comparing a user's behavior profile with current user activity events.  The following types of events are used to develop a user entity profile:\r
-\r
-* logon and logoff times and locations\r
-* starting or ending applications\r
-* reading or writing files\r
-* changing an entity 's authorization\r
-* monitoring network traffic\r
-\r
+    :kb-mitre-analysis """This patent describes determining a confidence score to detect anomalies in user activity based on comparing a user's behavior profile with current user activity events.  The following types of events are used to develop a user entity profile:
+
+* logon and logoff times and locations
+* starting or ending applications
+* reading or writing files
+* changing an entity 's authorization
+* monitoring network traffic
+
 User events that deviate from the entity profile over a certain threshold trigger a remedial action.""" ;
     :kb-organization "Idaptive LLC" ;
     :kb-reference-of :AuthenticationEventThresholding,
@@ -26291,12 +26291,12 @@ User events that deviate from the entity profile over a certain threshold trigge
     :has-link "https://patents.google.com/patent/US20150264070A1"^^xsd:anyURI ;
     :kb-abstract "A method and system for detecting algorithm-generated domains (AGDs) is disclosed wherein domain names requested by an internal host are categorized or classified using curated data sets, active services (e.g. Internet services), and certainty scores to match domain names to domain names or IP addresses used by command and control servers." ;
     :kb-author "James Patrick HARLACHER; Aditya Sood; Oskar Ibatullin" ;
-    :kb-mitre-analysis """This patent describes detecting algorithm generated domains (AGD). DNS requests and responses are analyzed by first checking whether the domain matches existing data sets that specify different types of AGDs with known characteristics, such as Evil Twin Domains, Sinkholed domains, sleeper cells, ghost domains, parked domains, and/or bulk-registered domains. In addition to comparing domains against known data sets, the following information is collected to perform analysis:\r
-\r
-* IP Information: checks for information known about the IP addresses returned in the DNS response, including the number of IP addresses returned, the registered owners of the IP addresses, or different IP addresses returned for the same domain (IP fluxing)\r
-* Domain Registration: examines the domain registration date, domain update date, domain expiration date, registrant identity, and authorized name servers associated with a specific domain name.\r
-* Domain Popularity: provides information on the popularity of a domain name.\r
-\r
+    :kb-mitre-analysis """This patent describes detecting algorithm generated domains (AGD). DNS requests and responses are analyzed by first checking whether the domain matches existing data sets that specify different types of AGDs with known characteristics, such as Evil Twin Domains, Sinkholed domains, sleeper cells, ghost domains, parked domains, and/or bulk-registered domains. In addition to comparing domains against known data sets, the following information is collected to perform analysis:
+
+* IP Information: checks for information known about the IP addresses returned in the DNS response, including the number of IP addresses returned, the registered owners of the IP addresses, or different IP addresses returned for the same domain (IP fluxing)
+* Domain Registration: examines the domain registration date, domain update date, domain expiration date, registrant identity, and authorized name servers associated with a specific domain name.
+* Domain Popularity: provides information on the popularity of a domain name.
+
 Based on analysis of these factors a score is developed; if the score is above a certain threshold, an alert is generated.""" ;
     :kb-organization "VECTRA NETWORKS Inc" ;
     :kb-reference-of :DNSTrafficAnalysis ;
@@ -26317,13 +26317,13 @@ Based on analysis of these factors a score is developed; if the score is above a
         :PatentReference ;
     rdfs:label "Reference - Method and system for detecting malicious payloads - Vectra Networks Inc" ;
     :has-link "https://patents.google.com/patent/EP3293937A1/en?oq=EP-3293937-A1"^^xsd:anyURI ;
-    :kb-abstract """Disclosed is an improved method, system, and computer program product for identifying malicious payloads. The disclosed approach identifies potentially malicious payload exchanges which may be associated with payload injection or root-kit magic key usage.\r
-\r
-Some examples of data inputs:\r
-    Information for clients and servers, such as IP address and host information\r
-    Payloads for both clients and servers\r
-    Amount of data being transferred\r
-    Duration of communications\r
+    :kb-abstract """Disclosed is an improved method, system, and computer program product for identifying malicious payloads. The disclosed approach identifies potentially malicious payload exchanges which may be associated with payload injection or root-kit magic key usage.
+
+Some examples of data inputs:
+    Information for clients and servers, such as IP address and host information
+    Payloads for both clients and servers
+    Amount of data being transferred
+    Duration of communications
     Length of time delay between client request and server response""" ;
     :kb-author "Nicolas Beauchesne; John Steven Mancini" ;
     :kb-mitre-analysis "Extraction of network flow data and using unsupervised machine learning to create a standard baseline. During the monitoring phase, abnormal network metadata will result in an alert." ;
@@ -26493,17 +26493,17 @@ Some examples of data inputs:\r
         owl:NamedIndividual ;
     rdfs:label "Reference - Network-Based Buffer Overflow Detection by Exploit Code Analysis - Information Security Research Centre" ;
     :has-link "https://eprints.qut.edu.au/21172/1/21172.pdf"^^xsd:anyURI ;
-    :kb-abstract """Buffer overflow attacks continue to be a major security problem and detecting attacks of this nature\r
-is therefore crucial to network security. Signature based network based intrusion detection systems (NIDS)\r
-compare network traffic to signatures modelling suspicious or attack traffic to detect network attacks. Since\r
-detection is based on pattern matching, a signature modelling the attack must exist for the NIDS to detect it, and\r
-it is therefore only capable of detecting known attacks. This paper proposes a method to detect buffer overflow\r
-attacks by parsing the payload of network packets in search of shellcode which is the remotely executable\r
-component of a buffer overflow attack. By analysing the shellcode it is possible to determine which system\r
-calls the exploit uses, and hence the operation of the exploit. Current NIDS-based buffer overflow detection\r
-techniques mainly rely upon specific signatures for each new attack. Our approach is able to detect previously\r
-unseen buffer overflow attacks, in addition to existing ones, without the need for specific signatures for each\r
-new attack. The method has been implemented and tested for buffer overflow attacks on Linux on the Intel x86\r
+    :kb-abstract """Buffer overflow attacks continue to be a major security problem and detecting attacks of this nature
+is therefore crucial to network security. Signature based network based intrusion detection systems (NIDS)
+compare network traffic to signatures modelling suspicious or attack traffic to detect network attacks. Since
+detection is based on pattern matching, a signature modelling the attack must exist for the NIDS to detect it, and
+it is therefore only capable of detecting known attacks. This paper proposes a method to detect buffer overflow
+attacks by parsing the payload of network packets in search of shellcode which is the remotely executable
+component of a buffer overflow attack. By analysing the shellcode it is possible to determine which system
+calls the exploit uses, and hence the operation of the exploit. Current NIDS-based buffer overflow detection
+techniques mainly rely upon specific signatures for each new attack. Our approach is able to detect previously
+unseen buffer overflow attacks, in addition to existing ones, without the need for specific signatures for each
+new attack. The method has been implemented and tested for buffer overflow attacks on Linux on the Intel x86
 architecture using the Snort NIDS.""" ;
     :kb-author "Stig Andersson, Andrew Clark, and George Mohay" ;
     :kb-mitre-analysis " " ;
@@ -26610,8 +26610,8 @@ architecture using the Snort NIDS.""" ;
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-002: Outlier Parents of Cmd - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-11-002/"^^xsd:anyURI ;
-    :kb-abstract """Many programs create command prompts as part of their normal operation including malware used by attackers. This analytic attempts to identify suspicious programs spawning cmd.exe by looking for programs that do not normally create cmd.exe.\r
-\r
+    :kb-abstract """Many programs create command prompts as part of their normal operation including malware used by attackers. This analytic attempts to identify suspicious programs spawning cmd.exe by looking for programs that do not normally create cmd.exe.
+
 While this analytic does not take the user into account, doing so could generate further interesting results. It is very common for some programs to spawn cmd.exe as a subprocess, for example to run batch files or windows commands. However many process don't routinely launch a command prompt - for example Microsoft Outlook. A command prompt being launched from a process that normally doesn't launch command prompts could be the result of malicious code being injected into that process, or of an attacker replacing a legitimate program with a malicious one.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26674,8 +26674,8 @@ While this analytic does not take the user into account, doing so could generate
     :has-link "https://patents.google.com/patent/US20190138715A1/"^^xsd:anyURI ;
     :kb-abstract "In one aspect, a method useful for monitoring and validating execution of executable binary code, includes the step of disassembling an executable binary code of an application. The method includes the step of detecting and obtaining location and type of an application programming interface (API) call, system call, and privileged instruction that is executed by the executable binary code. The method includes the step of detecting and obtaining return address from an Al call and system call. The method includes the step of validating location of the API call system call, and privileged instruction. The method includes the step of validating return from the API call and system call." ;
     :kb-author "Jayant Shukla" ;
-    :kb-mitre-analysis """The patent describes a technique for monitoring API calls. Executable binary code of an application is first disassembled and scanned for API calls. Based on the recorded API calls, a rule list is generated. Software hooks are placed in the code for monitoring API calls during program execution and then each API call is validated using the generated rule list to permit or deny execution of API calls.\r
-\r
+    :kb-mitre-analysis """The patent describes a technique for monitoring API calls. Executable binary code of an application is first disassembled and scanned for API calls. Based on the recorded API calls, a rule list is generated. Software hooks are placed in the code for monitoring API calls during program execution and then each API call is validated using the generated rule list to permit or deny execution of API calls.
+
 Rules are created that specify the type and location of the API call. For example, data collected for an application can show an API call to libc at address 0x43e0 and an API call by libc at address 0xlfb47. Accordingly, two rules are generated. The first rule specifies the location type and target of the API call at address 0x43e0, as well as the return address. The second rule is for the API call to the kernel and states the target address, return address, instruction, and target type.""" ;
     :kb-organization "K2 Cyber Security Inc" ;
     :kb-reference-of :SystemCallAnalysis ;
@@ -26685,11 +26685,11 @@ Rules are created that specify the type and location of the API call. For exampl
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-04-003: Powershell Execution - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-04-003/"^^xsd:anyURI ;
-    :kb-abstract """PowerShell is a scripting environment included with Windows that is used by both attackers and administrators. Execution of PowerShell scripts in most Windows versions is opaque and not typically secured by antivirus which makes using PowerShell an easy way to circumvent security measures. This analytic detects execution of PowerShell scripts.\r
-\r
-Powershell can be used to hide monitored command line execution such as:\r
-\r
-* net use\r
+    :kb-abstract """PowerShell is a scripting environment included with Windows that is used by both attackers and administrators. Execution of PowerShell scripts in most Windows versions is opaque and not typically secured by antivirus which makes using PowerShell an easy way to circumvent security measures. This analytic detects execution of PowerShell scripts.
+
+Powershell can be used to hide monitored command line execution such as:
+
+* net use
 * sc start""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26881,10 +26881,10 @@ Powershell can be used to hide monitored command line execution such as:\r
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-03-005: Remotely Launched Executables via Services - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-03-005/"^^xsd:anyURI ;
-    :kb-abstract """There are several ways to cause code to execute on a remote host. One of the most common methods is via the Windows Service Control Manager (SCM), which allows authorized users to remotely create and modify services. Several tools, such as PsExec, use this functionality.\r
-\r
-When a client remotely communicates with the Service Control Manager, there are two observable behaviors. First, the client connects to the RPC Endpoint Mapper over 135/tcp. This handles authentication, and tells the client what port the endpoint--in this case the SCM--is listening on. Then, the client connects directly to the listening port on services.exe. If the request is to start an existing service with a known command line, the the SCM process will run the corresponding command.\r
-\r
+    :kb-abstract """There are several ways to cause code to execute on a remote host. One of the most common methods is via the Windows Service Control Manager (SCM), which allows authorized users to remotely create and modify services. Several tools, such as PsExec, use this functionality.
+
+When a client remotely communicates with the Service Control Manager, there are two observable behaviors. First, the client connects to the RPC Endpoint Mapper over 135/tcp. This handles authentication, and tells the client what port the endpoint--in this case the SCM--is listening on. Then, the client connects directly to the listening port on services.exe. If the request is to start an existing service with a known command line, the the SCM process will run the corresponding command.
+
 This compound behavior can be detected by looking for services.exe receiving a network connection and immediately spawning a child process.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26897,12 +26897,12 @@ This compound behavior can be detected by looking for services.exe receiving a n
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-12-001: Remotely Launched Executables via WMI - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-12-001/"^^xsd:anyURI ;
-    :kb-abstract """Adversaries can use Windows Management Instrumentation (WMI) to move laterally by launching executables remotely. For adversaries to achieve this, they must open a WMI connection to a remote host. This RPC activity is currently detected by CAR-2014-11-007. After the WMI connection has been initialized, a process can be remotely launched using the command: wmic /node:"<hostname>" process call create "<command line>", which is detected via CAR-2016-03-002.\r
-\r
-This leaves artifacts at both a network (RPC) and process (command line) level. When wmic.exe (or the schtasks API) is used to remotely create processes, Windows uses RPC (135/tcp) to communicate with the the remote machine.\r
-\r
-After RPC authenticates, the RPC endpoint mapper opens a high port connection, through which the schtasks Remote Procedure Call is actually implemented. With the right packet decoders, or by looking for certain byte streams in raw data, these functions can be identified.\r
-\r
+    :kb-abstract """Adversaries can use Windows Management Instrumentation (WMI) to move laterally by launching executables remotely. For adversaries to achieve this, they must open a WMI connection to a remote host. This RPC activity is currently detected by CAR-2014-11-007. After the WMI connection has been initialized, a process can be remotely launched using the command: wmic /node:"<hostname>" process call create "<command line>", which is detected via CAR-2016-03-002.
+
+This leaves artifacts at both a network (RPC) and process (command line) level. When wmic.exe (or the schtasks API) is used to remotely create processes, Windows uses RPC (135/tcp) to communicate with the the remote machine.
+
+After RPC authenticates, the RPC endpoint mapper opens a high port connection, through which the schtasks Remote Procedure Call is actually implemented. With the right packet decoders, or by looking for certain byte streams in raw data, these functions can be identified.
+
 When the command line is executed, it has the parent process of C:\\windows\\system32\\wbem\\WmiPrvSE.exe. This analytic looks for these two events happening in sequence, so that the network connection and target process are output.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26916,14 +26916,14 @@ When the command line is executed, it has the parent process of C:\\windows\\sys
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2015-04-002: Remotely Scheduled Tasks via Schtasks - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2015-04-002/"^^xsd:anyURI ;
-    :kb-abstract """An adversary can move laterally using the schtasks command to remotely schedule tasks. Although these events can be detected with command line analytics CAR-2013-08-001, it is possible for an adversary to use the API directly, via the Task Scheduler GUI or with a scripting language such as PowerShell. In this cases, an additional source of data becomes necessary to detect adversarial behavior. When scheduled tasks are created remotely, Windows uses RPC (135/tcp) to communicate with the Task Scheduler on the remote machine. Once an RPC connection is established (CAR-2014-05-001), the client communicates with the Scheduled Tasks endpoint, which runs within the service group netsvcs. With packet capture and the right packet decoders or byte-stream based signatures, remote invocations of these functions can be identified.\r
-\r
-Certain strings can be identifiers of the schtasks, by looking up the interface UUID of ITaskSchedulerService in different formats\r
-\r
-* UUID 86d35949-83c9-4044-b424-db363231fd0c (decoded)\r
-* Hex 49 59 d3 86 c9 83 44 40 b4 24 db 36 32 31 fd 0c (raw)\r
-* ASCII IYD@$621 (printable bytes only)\r
-\r
+    :kb-abstract """An adversary can move laterally using the schtasks command to remotely schedule tasks. Although these events can be detected with command line analytics CAR-2013-08-001, it is possible for an adversary to use the API directly, via the Task Scheduler GUI or with a scripting language such as PowerShell. In this cases, an additional source of data becomes necessary to detect adversarial behavior. When scheduled tasks are created remotely, Windows uses RPC (135/tcp) to communicate with the Task Scheduler on the remote machine. Once an RPC connection is established (CAR-2014-05-001), the client communicates with the Scheduled Tasks endpoint, which runs within the service group netsvcs. With packet capture and the right packet decoders or byte-stream based signatures, remote invocations of these functions can be identified.
+
+Certain strings can be identifiers of the schtasks, by looking up the interface UUID of ITaskSchedulerService in different formats
+
+* UUID 86d35949-83c9-4044-b424-db363231fd0c (decoded)
+* Hex 49 59 d3 86 c9 83 44 40 b4 24 db 36 32 31 fd 0c (raw)
+* ASCII IYD@$621 (printable bytes only)
+
 This identifier is present three times during the RPC request phase. Any sensor that has access to the byte code as raw, decoded, or ASCII could implement this analytic.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26936,14 +26936,14 @@ This identifier is present three times during the RPC request phase. Any sensor 
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-005: Remote Registry - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-11-005/"^^xsd:anyURI ;
-    :kb-abstract """An adversary can remotely manipulate the registry of another machine if the RemoteRegistry service is enabled and valid credentials are obtained. While the registry is remotely accessed, it can be used to prepare a Lateral Movement technique, discover the configuration of a host, achieve Persistence, or anything that aids an adversary in achieving the mission. Like most ATT&CK techniques, this behavior can be used legitimately, and the reliability of an analytic depends on the proper identification of the pre-existing legitimate behaviors. Although this behavior is disabled in many Windows configurations, it is possible to remotely enable the RemoteRegistry service, which can be detected with CAR-2014-03-005.\r
-\r
-Remote access to the registry can be achieved via\r
-\r
-* Windows API function RegConnectRegistry\r
-* command line via reg.exe\r
-* graphically via regedit.exe\r
-\r
+    :kb-abstract """An adversary can remotely manipulate the registry of another machine if the RemoteRegistry service is enabled and valid credentials are obtained. While the registry is remotely accessed, it can be used to prepare a Lateral Movement technique, discover the configuration of a host, achieve Persistence, or anything that aids an adversary in achieving the mission. Like most ATT&CK techniques, this behavior can be used legitimately, and the reliability of an analytic depends on the proper identification of the pre-existing legitimate behaviors. Although this behavior is disabled in many Windows configurations, it is possible to remotely enable the RemoteRegistry service, which can be detected with CAR-2014-03-005.
+
+Remote access to the registry can be achieved via
+
+* Windows API function RegConnectRegistry
+* command line via reg.exe
+* graphically via regedit.exe
+
 All of these behaviors call into the Windows API, which uses the NamedPipe WINREG over SMB to handle the protocol information. This network can be decoded with wireshark or a similar sensor, and can also be detected by hooking the API function.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27010,11 +27010,11 @@ All of these behaviors call into the Windows API, which uses the NamedPipe WINRE
         :SpecificationReference ;
     rdfs:label "Reference - RFC 7489: Domain-based Message Authentication, Reporting, and Conformance (DMARC) - IETF" ;
     :has-link "https://tools.ietf.org/html/rfc7489"^^xsd:anyURI ;
-    :kb-abstract """Domain-based Message Authentication, Reporting, and Conformance(DMARC) is a scalable mechanism by which a mail-originating organization can express domain-level policies and preferences for message validation, disposition, and reporting, that a mail-receiving organization can use to improve mail handling.\r
-\r
-Originators of Internet Mail need to be able to associate reliable and authenticated domain identifiers with messages, communicate policies about messages that use those identifiers, and report about mail using those identifiers.  These abilities have several benefits: Receivers can provide feedback to Domain Owners about the use of their domains; this feedback can provide valuable insight about the management of internal operations and the presence of external domain name abuse.\r
-\r
-DMARC does not produce or encourage elevated delivery privilege of authenticated email. DMARC is a mechanism for policy distribution that enables increasingly strict handling of messages that fail authentication checks, ranging from no action, through altered\r
+    :kb-abstract """Domain-based Message Authentication, Reporting, and Conformance(DMARC) is a scalable mechanism by which a mail-originating organization can express domain-level policies and preferences for message validation, disposition, and reporting, that a mail-receiving organization can use to improve mail handling.
+
+Originators of Internet Mail need to be able to associate reliable and authenticated domain identifiers with messages, communicate policies about messages that use those identifiers, and report about mail using those identifiers.  These abilities have several benefits: Receivers can provide feedback to Domain Owners about the use of their domains; this feedback can provide valuable insight about the management of internal operations and the presence of external domain name abuse.
+
+DMARC does not produce or encourage elevated delivery privilege of authenticated email. DMARC is a mechanism for policy distribution that enables increasingly strict handling of messages that fail authentication checks, ranging from no action, through altered
 delivery, up to message rejection.""" ;
     :kb-author "M. Kucherawy, E. Zwicky" ;
     :kb-organization "Internet Engineering Task Force (IETF)" ;
@@ -27102,11 +27102,11 @@ delivery, up to message rejection.""" ;
         owl:NamedIndividual ;
     rdfs:label "Reference - Securing Web Transactions" ;
     :has-link "https://www.nccoe.nist.gov/sites/default/files/library/sp1800/tls-serv-cert-mgt-nist-sp1800-16b-final.pdf"^^xsd:anyURI ;
-    :kb-abstract """Organizations risk losing revenue, customers, and reputation, and exposing internal or customer data to\r
-attackers if they do not properly manage Transport Layer Security (TLS) server certificates. TLS is the\r
-most widely used security protocol to secure web transactions and other communications on the\r
-internet and internal networks. TLS server certificates are central to the security and operation of\r
-internet-facing and internal web services. Improper TLS server certificate management results in\r
+    :kb-abstract """Organizations risk losing revenue, customers, and reputation, and exposing internal or customer data to
+attackers if they do not properly manage Transport Layer Security (TLS) server certificates. TLS is the
+most widely used security protocol to secure web transactions and other communications on the
+internet and internal networks. TLS server certificates are central to the security and operation of
+internet-facing and internal web services. Improper TLS server certificate management results in
 significant outages to web applications and services-such as government services, online banking, flight operations, and mission-critical services within an organization-and increased risk of security breaches.""" ;
     :kb-author "William Haag, Murugiah Souppaya, Paul Turner, William C. Barker, Brett Pleasant, Susan Symington" ;
     :kb-organization "NIST" ;
@@ -27117,12 +27117,12 @@ significant outages to web applications and services-such as government services
         :SpecificationReference ;
     rdfs:label "Reference - Security Architecture for the Internet Protocol" ;
     :has-link "https://datatracker.ietf.org/doc/html/rfc1825"^^xsd:anyURI ;
-    :kb-abstract """This memo describes the security mechanisms for IP version 4 (IPv4)\r
-   and IP version 6 (IPv6) and the services that they provide.  Each\r
-   security mechanism is specified in a separate document.  This\r
-   document also describes key management requirements for systems\r
-   implementing those security mechanisms.  This document is not an\r
-   overall Security Architecture for the Internet and is instead focused\r
+    :kb-abstract """This memo describes the security mechanisms for IP version 4 (IPv4)
+   and IP version 6 (IPv6) and the services that they provide.  Each
+   security mechanism is specified in a separate document.  This
+   document also describes key management requirements for systems
+   implementing those security mechanisms.  This document is not an
+   overall Security Architecture for the Internet and is instead focused
    on IP-layer security.""" ;
     :kb-author "Randall Atkinson" ;
     :kb-reference-of :EncryptedTunnels ;
@@ -27193,8 +27193,8 @@ significant outages to web applications and services-such as government services
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-05-002: Services launching Cmd - MITRE" ;
     :has-link ""^^xsd:anyURI ;
-    :kb-abstract """Windows runs the Service Control Manager (SCM) within the process services.exe. Windows launches services as independent processes or DLL loads within a svchost.exe group. To be a legitimate service, a process (or DLL) must have the appropriate service entry point SvcMain. If an application does not have the entry point, then it will timeout (default is 30 seconds) and the process will be killed.\r
-\r
+    :kb-abstract """Windows runs the Service Control Manager (SCM) within the process services.exe. Windows launches services as independent processes or DLL loads within a svchost.exe group. To be a legitimate service, a process (or DLL) must have the appropriate service entry point SvcMain. If an application does not have the entry point, then it will timeout (default is 30 seconds) and the process will be killed.
+
 To survive the timeout, adversaries and red teams can create services that direct to cmd.exe with the flag /c, followed by the desired command. The /c flag causes the command shell to run a command and immediately exit. As a result, the desired program will remain running and it will report an error starting the service. This analytic will catch that command prompt instance that is used to launch the actual malicious executable. Additionally, the children and descendants of services.exe will run as a SYSTEM user by default. Thus, services are a convenient way for an adversary to gain Persistence and Privilege Escalation.""" ;
     :kb-author "" ;
     :kb-mitre-analysis " " ;
@@ -27212,8 +27212,8 @@ To survive the timeout, adversaries and red teams can create services that direc
     rdfs:label "Reference - CAR-2013-02-008: Simultaneous Logins on a Host - MITRE" ;
     :comment "The reference only lists pre-Vista event IDs; current (2020) ones are found at: https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-audit-logon-events" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-02-008/"^^xsd:anyURI ;
-    :kb-abstract """Multiple users logged into a single machine at the same time, or even within the same hour, do not typically occur in networks we have observed.\r
-\r
+    :kb-abstract """Multiple users logged into a single machine at the same time, or even within the same hour, do not typically occur in networks we have observed.
+
 Logon events are Windows Event Code 4624 for Windows Vista and above, 518 for pre-Vista. Logoff events are 4634 for Windows Vista and above, 538 for pre-Vista. Logon types 2, 3, 9 and 10 are of interest. For more details see the Logon Types table on Microsoft's Audit Logon Events page.""" ;
     :kb-author "MITRE" ;
     :kb-reference-of :AuthenticationEventThresholding ;
@@ -27234,8 +27234,8 @@ Logon events are Windows Event Code 4624 for Windows Vista and above, 518 for pr
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-05-005: SMB Copy and Execution - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-05-005/"^^xsd:anyURI ;
-    :kb-abstract """An adversary needs to gain access to other hosts to move throughout an environment. In many cases, this is a twofold process. First, a file is remotely written to a host via an SMB share (detected by CAR-2013-05-003). Then, a variety of Execution techniques can be used to remotely establish execution of the file or script. To detect this behavior, look for files that are written to a host over SMB and then later run directly as a process or in the command line arguments. SMB File Writes and Remote Execution may happen normally in an environment, but the combination of the two behaviors is less frequent and more likely to indicate adversarial activity.\r
-\r
+    :kb-abstract """An adversary needs to gain access to other hosts to move throughout an environment. In many cases, this is a twofold process. First, a file is remotely written to a host via an SMB share (detected by CAR-2013-05-003). Then, a variety of Execution techniques can be used to remotely establish execution of the file or script. To detect this behavior, look for files that are written to a host over SMB and then later run directly as a process or in the command line arguments. SMB File Writes and Remote Execution may happen normally in an environment, but the combination of the two behaviors is less frequent and more likely to indicate adversarial activity.
+
 This can possibly extend to more copy protocols in order to widen its reach, or it could be tuned more finely to focus on specific program run locations (e.g. %SYSTEMROOT%\\system32) to gain a higher detection rate.""" ;
     :kb-author "" ;
     :kb-mitre-analysis " " ;
@@ -27251,9 +27251,9 @@ This can possibly extend to more copy protocols in order to widen its reach, or 
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-01-003: SMB Events Monitoring - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-01-003/"^^xsd:anyURI ;
-    :kb-abstract """Server Message Block (SMB) is used by Windows to allow for file, pipe, and printer sharing over port 445/tcp. It allows for enumerating, and reading from and writing to file shares for a remote computer. Although it is heavily used by Windows servers for legitimate purposes and by users for file and printer sharing, many adversaries also use SMB to achieve Lateral Movement. Looking at this activity more closely to obtain an adequate sense of situational awareness may make it possible to detect adversaries moving between hosts in a way that deviates from normal activity. Because SMB traffic is heavy in many environments, this analytic may be difficult to turn into something that can be used to quickly detect an APT. In some cases, it may make more sense to run this analytic in a forensic fashion. Looking through and filtering its output after an intrusion has been discovered may be helpful in identifying the scope of compromise.\r
-\r
-Output Description:\r
+    :kb-abstract """Server Message Block (SMB) is used by Windows to allow for file, pipe, and printer sharing over port 445/tcp. It allows for enumerating, and reading from and writing to file shares for a remote computer. Although it is heavily used by Windows servers for legitimate purposes and by users for file and printer sharing, many adversaries also use SMB to achieve Lateral Movement. Looking at this activity more closely to obtain an adequate sense of situational awareness may make it possible to detect adversaries moving between hosts in a way that deviates from normal activity. Because SMB traffic is heavy in many environments, this analytic may be difficult to turn into something that can be used to quickly detect an APT. In some cases, it may make more sense to run this analytic in a forensic fashion. Looking through and filtering its output after an intrusion has been discovered may be helpful in identifying the scope of compromise.
+
+Output Description:
 The source, destination, content, and time of each event.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27266,8 +27266,8 @@ The source, destination, content, and time of each event.""" ;
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-09-003: SMB Session Setups - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-09-003/"^^xsd:anyURI ;
-    :kb-abstract """Account usage within SMB can be used to identify compromised credentials, and the hosts accessed with them.\r
-\r
+    :kb-abstract """Account usage within SMB can be used to identify compromised credentials, and the hosts accessed with them.
+
 This analytic monitors SMB activity that deals with user activity rather than file activity.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27282,8 +27282,8 @@ This analytic monitors SMB activity that deals with user activity rather than fi
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-03-001: SMB Write Request - NamedPipes - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-03-001/"^^xsd:anyURI ;
-    :kb-abstract """An SMB write can be an indicator of lateral movement, especially when combined with other information such as execution of that written file. Named pipes are a subset of SMB write requests. Named pipes such as msftewds may not be alarming; however others, such as lsarpc, may.\r
-\r
+    :kb-abstract """An SMB write can be an indicator of lateral movement, especially when combined with other information such as execution of that written file. Named pipes are a subset of SMB write requests. Named pipes such as msftewds may not be alarming; however others, such as lsarpc, may.
+
 Monitoring SMB write requests still creates some noise, particularly with named pipes. As a result, SMB is now split between writing named pipes and writing other files.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27458,7 +27458,7 @@ Monitoring SMB write requests still creates some noise, particularly with named 
     :has-link "https://patents.google.com/patent/US9807114B2/en?oq=US-9807114-B2"^^xsd:anyURI ;
     :kb-abstract "A system for identifying the presence of advanced persistent threats on a network including a plurality of resources, interconnected to form a network, at least one decoy resource, at least one mini-trap installed on at least one of the plurality of resources and functionally associated with at one of the at least one decoy resource, the at least one mini-trap comprising deceptive information directing malware accessing the at least one mini-trap to the decoy resource associated therewith, and a manager node forming part of the network, locally or remotely, and configured to manage placement of the at least one mini-trap on the at least one of the plurality of resources and association between the at least one mini-trap and the decoy resource associated therewith." ;
     :kb-author "Doron Kolton; Rami Mizrahi; Omer Zohar; Benny Ben-Rabi; Alex Barbalat; Shlomi Gabai" ;
-    :kb-mitre-analysis """Questionable or all files (as determined by the enterprise) are forwarded to the decoy network. Using a manager node user interface, you can setup fake information (ex. IP address of a decoy FTP server)\r
+    :kb-mitre-analysis """Questionable or all files (as determined by the enterprise) are forwarded to the decoy network. Using a manager node user interface, you can setup fake information (ex. IP address of a decoy FTP server)
 and deploy decoy physical or virtual endpoints.""" ;
     :kb-organization "Fidelis Cybersecurity Solutions Inc" ;
     :kb-reference-of :DecoyNetworkResource,
@@ -27624,13 +27624,13 @@ and deploy decoy physical or virtual endpoints.""" ;
     :has-link "https://patents.google.com/patent/US20160142424A1"^^xsd:anyURI ;
     :kb-abstract "A system is connected to a plurality of user devices coupled to an enterprise's network. The system continuously collects, stores, and analyzes forensic data related to the enterprise's network. Based on the analysis, the system is able to determine normal behavior of the network and portions thereof and thereby identify abnormal behaviors within the network. Upon identification of an abnormal behavior, the system determines whether the abnormal behavior relates to a security incident. Upon determining a security incident in any portion of the enterprise's network, the system extracts forensic data respective of the security incident and enables further assessment of the security incident as well as identification of the source of the security incident. The system provides real-time damage assessment respective of the security incident as well as the security incident's attributions." ;
     :kb-author "Gil BARAK; Shai MORAG" ;
-    :kb-mitre-analysis """This patent describes detecting abnormal behavior related to a security incident by collecting and analyzing forensic data in real time. Forensic data may include:\r
-\r
-* URLs visited\r
-* data downloaded or streamed\r
-* messages received and sent\r
-* amount of memory used for processing\r
-\r
+    :kb-mitre-analysis """This patent describes detecting abnormal behavior related to a security incident by collecting and analyzing forensic data in real time. Forensic data may include:
+
+* URLs visited
+* data downloaded or streamed
+* messages received and sent
+* amount of memory used for processing
+
 The data is then analyzed according to a set of dynamically created rules to determine normal behavior patterns associated with the network or user devices. Anomalies between current behavior and normal behavior patterns trigger an alert.""" ;
     :kb-organization "Palo Alto Networks Inc" ;
     :kb-reference-of :ResourceAccessPatternAnalysis,
@@ -27644,10 +27644,10 @@ The data is then analyzed according to a set of dynamically created rules to det
     :has-link "https://patents.google.com/patent/US20160191563A1"^^xsd:anyURI ;
     :kb-abstract "Disclosed is an improved approach to implement a system and method for detecting insider threats, where models are constructed that is capable of defining what constitutes the normal behavior for any given hosts and quickly find anomalous behaviors that could constitute a potential threat to an organization. The disclosed approach provides a way to identify abnormal data transfers within and external to an organization without the need for individual monitoring software on each host, by leveraging metadata that describe the data exchange patterns observed in the network." ;
     :kb-author "Nicolas BEAUCHESNE; David Lopes Pegna" ;
-    :kb-mitre-analysis """Determination of anomalous data transfers is performed over a given time period. For example, a check of a pull vs. push data ratio can be established over a specific time period, e.g., over a three-hour period, over a one day period, over a one week period, etc.\r
-\r
-The system can also establish a baseline behavior for data exchange for each host in terms of pull vs. push data ratio for each resource contacted by the host.\r
-\r
+    :kb-mitre-analysis """Determination of anomalous data transfers is performed over a given time period. For example, a check of a pull vs. push data ratio can be established over a specific time period, e.g., over a three-hour period, over a one day period, over a one week period, etc.
+
+The system can also establish a baseline behavior for data exchange for each host in terms of pull vs. push data ratio for each resource contacted by the host.
+
 Network packet capture data is collected and metadata is extracted. Aggregate data push/pull information from the metadata is then analyzed for a given host versus specific client to server relationships. This technique can potentially catch lateral data transfers, and may have filtering on alerting logic to only raise alarms when external hosts receive large data transfers.""" ;
     :kb-organization "VECTRA NETWORKS Inc" ;
     :kb-reference-of :PerHostDownload-UploadRatioAnalysis ;
@@ -27682,34 +27682,34 @@ Network packet capture data is collected and metadata is extracted. Aggregate da
     :has-link "https://patents.google.com/patent/US20170324767A1"^^xsd:anyURI ;
     :kb-abstract "Techniques for detecting and/or handling target attacks in an enterprise's email channel are provided. The techniques include receiving aspects of an incoming email message addressed to a first email account holder, selecting a recipient interaction profile and/or a sender profile from a plurality of predetermined profiles stored in a memory based upon the received properties, determining a message trust rating associated with the incoming email message based upon the incoming email message and the selected recipient interaction profile and/or the sender profile; and generating an alert identifying the incoming email message as including a security risk based upon the determined message trust rating. The recipient interaction profile includes information associating the first email account holder and a plurality of email senders from whom email messages have previously been received for the first email account holder, and the sender profile includes information associating a sender of the incoming email message with characteristics determined from a plurality of email messages previously received from the sender." ;
     :kb-author "Manoj Kumar Srivastava" ;
-    :kb-mitre-analysis """The patent describes using sender trust rating and sender MTA trust rating as an indicator of level of email security risk.\r
-\r
-### Sender Reputation explanation\r
-This patent includes Sender Reputation because it describes sender trust rating being used as an indicator of the level of security risk and/or trust level associated with an email sender. The sender trust rating may be determined based on one or more of:\r
-\r
-* length of time sender has known the enterprise\r
-* number of recipients in the enterprise the sender interacts with\r
-* sender vs. enterprise originated message ratio\r
-* sender messages open vs. not-open ratio\r
-* number of emails received from this sender\r
-* number of emails replied for this sender\r
-* number of emails from this sender not opened\r
-* number of emails from this sender not opened that contain an attachment\r
-* number of emails from this sender not opened that contain a URL\r
-* number of emails sent to this sender\r
-* number of email replies received from this sender\r
-\r
-Based on the trust rating an alert is generated identifying the incoming email message as a security risk.\r
-\r
-### Sender MTA Reputation explanation\r
-This patent includes Sender MTA Reputation because it describes sender MTA trust rating as an indicator of the level of security risk and/or trust level associated with a sender MTA. The trust rating may be determined based on one or more of:\r
-\r
-* length of time MTA has interacted with the enterprise\r
-* number of sender domains sending emails from the MTA\r
-* number of recipients in the enterprise the MTA sends emails to\r
-* number of emails received from this MTA\r
-* number of email replies received from this MTA\r
-\r
+    :kb-mitre-analysis """The patent describes using sender trust rating and sender MTA trust rating as an indicator of level of email security risk.
+
+### Sender Reputation explanation
+This patent includes Sender Reputation because it describes sender trust rating being used as an indicator of the level of security risk and/or trust level associated with an email sender. The sender trust rating may be determined based on one or more of:
+
+* length of time sender has known the enterprise
+* number of recipients in the enterprise the sender interacts with
+* sender vs. enterprise originated message ratio
+* sender messages open vs. not-open ratio
+* number of emails received from this sender
+* number of emails replied for this sender
+* number of emails from this sender not opened
+* number of emails from this sender not opened that contain an attachment
+* number of emails from this sender not opened that contain a URL
+* number of emails sent to this sender
+* number of email replies received from this sender
+
+Based on the trust rating an alert is generated identifying the incoming email message as a security risk.
+
+### Sender MTA Reputation explanation
+This patent includes Sender MTA Reputation because it describes sender MTA trust rating as an indicator of the level of security risk and/or trust level associated with a sender MTA. The trust rating may be determined based on one or more of:
+
+* length of time MTA has interacted with the enterprise
+* number of sender domains sending emails from the MTA
+* number of recipients in the enterprise the MTA sends emails to
+* number of emails received from this MTA
+* number of email replies received from this MTA
+
 Based on the trust rating an alert is generated identifying the incoming email message as a security risk.""" ;
     :kb-organization "Graphus Inc" ;
     :kb-reference-of :SenderMTAReputationAnalysis,
@@ -27758,8 +27758,8 @@ Based on the trust rating an alert is generated identifying the incoming email m
         :PatentReference ;
     rdfs:label "Reference - Techniques for impeding and detecting network threats - Verisign Inc" ;
     :has-link "https://patents.google.com/patent/US10904273B1/"^^xsd:anyURI ;
-    :kb-abstract """Infinite DNS decoy trap resource to catch threats scanning for network resources to attack.\r
-\r
+    :kb-abstract """Infinite DNS decoy trap resource to catch threats scanning for network resources to attack.
+
 In various embodiments, a name server transmits a canonical name as resolution to another canonical name. In operation, when a resource name is requested for resolution, a determination is made that the resource name corresponds to a trap resource name. A first canonical name is transmitted as resolution to the trap resource name. The first canonical name is requested for resolution, and a second canonical name is transmitted as resolution. By providing trap canonical names as resolutions to trap canonical names, unauthorized software making the resolution requests is kept occupied with requesting resolution of canonical name after canonical name, impeding the ability of the unauthorized software from traversing a network.""" ;
     :kb-author "Ben McCarty, James Graham" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -27847,7 +27847,7 @@ In various embodiments, a name server transmits a canonical name as resolution t
         :SpecificationReference ;
     rdfs:label "Reference - Trusted Attestation Protocol Use Cases" ;
     :has-link "https://trustedcomputinggroup.org/wp-content/uploads/TCG_TNC_TAP_Use_Cases_v1r0p35_published.pdf"^^xsd:anyURI ;
-    :kb-article """## Document Abstract\r
+    :kb-article """## Document Abstract
 This specification defines the Trusted Platform Module (TPM) a device that enables trust in computing platforms in general. It is broken into parts to make the role of each part clear. All parts are required in order to constitute a complete standard. For a complete definition of all requirements necessary to build a TPM, the designer will need to use the appropriate platform-specific specification to understand all of the requirements for a TPM in a specific application or make appropriate choices as an implementer. Those wishing to create a TPM need to be aware that this specification does not provide a complete picture of the options and commands necessary to implement a TPM. To implement a TPM the designer needs to refer to the relevant platform-specific specification to understand the options and settings required for a TPM in a specific type of platform or make appropriate choices as an implementer.""" ;
     :kb-reference-title "Trusted Attestation Protocol Use Cases" .
 
@@ -27961,8 +27961,8 @@ This specification defines the Trusted Platform Module (TPM) a device that enabl
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-02-012: User Logged in to Multiple Hosts - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-02-012/"^^xsd:anyURI ;
-    :kb-abstract """Most users use only one or two machines during the normal course of business. User accounts that log in to multiple machines, especially over a short period of time, may be compromised. Remote logins among multiple machines may be an indicator of Lateral Movement.\r
-\r
+    :kb-abstract """Most users use only one or two machines during the normal course of business. User accounts that log in to multiple machines, especially over a short period of time, may be compromised. Remote logins among multiple machines may be an indicator of Lateral Movement.
+
 Certain users will likely appear as being logged into several machines and may need to be "whitelisted." Such users would include network admins or user names that are common to many hosts.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27977,8 +27977,8 @@ Certain users will likely appear as being logged into several machines and may n
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-10-001: User Login Activity Monitoring - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-10-001/"^^xsd:anyURI ;
-    :kb-abstract """Monitoring logon and logoff events for hosts on the network is very important for situational awareness. This information can be used as an indicator of unusual activity as well as to corroborate activity seen elsewhere.\r
-\r
+    :kb-abstract """Monitoring logon and logoff events for hosts on the network is very important for situational awareness. This information can be used as an indicator of unusual activity as well as to corroborate activity seen elsewhere.
+
 Could be applied to a number of different types of monitoring depending on what information is desired. Some use cases include monitoring for all remote connections and building login timelines for users. Logon events are Windows Event Code 4624 for Windows Vista and above, 518 for pre-Vista. Logoff events are 4634 for Windows Vista and above, 538 for pre-Vista.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -28022,24 +28022,24 @@ Could be applied to a number of different types of monitoring depending on what 
 
 :Reference-WebAuthentication_AnAPIForAccessingPublicKeyCredentials%0ALevel2 a owl:NamedIndividual,
         :SpecificationReference ;
-    rdfs:label """Reference - Web Authentication: An API for accessing Public Key Credentials\r
+    rdfs:label """Reference - Web Authentication: An API for accessing Public Key Credentials
 Level 2""" ;
     :has-link "https://www.w3.org/TR/webauthn-2/"^^xsd:anyURI ;
     :kb-abstract "This specification defines an API enabling the creation and use of strong, attested, scoped, public key-based credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more public key credentials, each scoped to a given WebAuthn Relying Party, are created by and bound to authenticators as requested by the web application. The user agent mediates access to authenticators and their public key credentials in order to preserve user privacy. Authenticators are responsible for ensuring that no operation is performed without user consent. Authenticators provide cryptographic proof of their properties to Relying Parties via attestation. This specification also describes the functional model for WebAuthn conformant authenticators, including their signature and attestation functionality." ;
     :kb-author "W3C" ;
     :kb-reference-of :CredentialTransmissionScoping ;
-    :kb-reference-title """Web Authentication: An API for accessing Public Key Credentials\r
+    :kb-reference-title """Web Authentication: An API for accessing Public Key Credentials
 Level 2""" .
 
 :Reference-WhatIsNX_XDFeature_RedHat a :InternetArticleReference,
         owl:NamedIndividual ;
     rdfs:label "Reference - What is NX/XD feature?" ;
     :has-link "https://access.redhat.com/solutions/2936741"^^xsd:anyURI ;
-    :kb-abstract """What is NX/XD feature ?\r
-How to check whether NX/XD is enabled ?\r
-How to enable or disable NX/XD?\r
-\r
-NX/XD is a hardware cpu feature which is provided in almost all the hardware. Some BIOS has advanced option of enabling or disabling it.\r
+    :kb-abstract """What is NX/XD feature ?
+How to check whether NX/XD is enabled ?
+How to enable or disable NX/XD?
+
+NX/XD is a hardware cpu feature which is provided in almost all the hardware. Some BIOS has advanced option of enabling or disabling it.
 NX stands for No eXecute and XD stands for eXecute Disable. Both are same and is a technology used in processors to prevent execution of certain types of code.""" ;
     :kb-author "Red Hat" ;
     :kb-mitre-analysis " " ;
@@ -28098,10 +28098,10 @@ NX stands for No eXecute and XD stands for eXecute Disable. Both are same and is
         owl:NamedIndividual ;
     rdfs:label "Reference - http://www.biometric-solutions.com/keystroke-dynamics.html - biometric-solutions.com" ;
     :has-link "http://www.biometric-solutions.com/keystroke-dynamics.html"^^xsd:anyURI ;
-    :kb-abstract """Keystroke dynamics or typing dynamics refers to the automated method of identifying or confirming the identity of an individual based on the manner and the rhythm of typing on a keyboard. Keystroke dynamics is a behavioral biometric, this means that the biometric factor is 'something you do'.\r
-\r
-Already during the second world war a technique known as The Fist of the Sender was used by military intelligence to distinguish based on the rhythm whether a morse code message was send by ally or enemy. These days each household has at least one computer keyboard, making keystroke dynamics the easiest biometric solution to implement in terms of hardware.\r
-\r
+    :kb-abstract """Keystroke dynamics or typing dynamics refers to the automated method of identifying or confirming the identity of an individual based on the manner and the rhythm of typing on a keyboard. Keystroke dynamics is a behavioral biometric, this means that the biometric factor is 'something you do'.
+
+Already during the second world war a technique known as The Fist of the Sender was used by military intelligence to distinguish based on the rhythm whether a morse code message was send by ally or enemy. These days each household has at least one computer keyboard, making keystroke dynamics the easiest biometric solution to implement in terms of hardware.
+
 With keystroke dynamics the biometric template used to identify an individual is based on the typing pattern, the rhythm and the speed of typing on a keyboard. The raw measurements used for keystroke dynamics are dwell time and flight time.""" ;
     :kb-author "Biometric Solutions" ;
     :kb-organization "Biometric Solutions" ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -176,8 +176,8 @@
     rdfs:subPropertyOf :associated-with,
         :may-contain ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02639021-v> ;
-    :comment """d3fend uses 'contains' for the more ontologically traditional term 'has-part' and thus is transitive.  The concept of containment in other ontologies (e.g., SUMO and OBO's RO) may refer the containment of an object within a space or object defining a space, or may express the containment of subintervals or subsequences of intervals or sequences, respectively.
-
+    :comment """d3fend uses 'contains' for the more ontologically traditional term 'has-part' and thus is transitive.  The concept of containment in other ontologies (e.g., SUMO and OBO's RO) may refer the containment of an object within a space or object defining a space, or may express the containment of subintervals or subsequences of intervals or sequences, respectively.\r
+\r
 Moving forward different distinctions of kinds of has-part (contains) relationships may prove useful or even necessary.  Deferred for future releases""" ;
     :definition "x contains y: A core relation that holds between a whole x and its part y.  Equivalent to relational concept 'has part' and thus transitive." .
 
@@ -1657,20 +1657,20 @@ skos:altLabel a owl:AnnotationProperty ;
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-AL" ;
     :definition "The process of temporarily disabling user accounts on a system or domain." ;
-    :kb-article """## How it works
-Management servers with enterprise policies for account management provide the ability to enable and disable account for given rules. The rules may include specific periods of time (eg. weekend, plant shutdown, leave periods), specific user types or groups, or individual users.
-
-## Considerations
-* Local accounts caches vs centralized account management
-* Single Sign-on
-* Role based vs Attribute based systems
-
-## Examples of account configuration stores
-* Directory Services
-* Active Directory
-* RADIUS
-* LDAP
-* Oracle User Account Management
+    :kb-article """## How it works\r
+Management servers with enterprise policies for account management provide the ability to enable and disable account for given rules. The rules may include specific periods of time (eg. weekend, plant shutdown, leave periods), specific user types or groups, or individual users.\r
+\r
+## Considerations\r
+* Local accounts caches vs centralized account management\r
+* Single Sign-on\r
+* Role based vs Attribute based systems\r
+\r
+## Examples of account configuration stores\r
+* Directory Services\r
+* Active Directory\r
+* RADIUS\r
+* LDAP\r
+* Oracle User Account Management\r
 * JumpCloud""" ;
     :kb-reference :Reference-AccountMonitoring_ForescoutTechnologies,
         :Reference-FrameworkForNotifyingADirectoryServiceOfAuthenticationEventsProcessedOutsideTheDirectoryService_OracleInternationalCorp .
@@ -1684,26 +1684,26 @@ Management servers with enterprise policies for account management provide the a
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-ACA" ;
     :definition "Actively collecting PKI certificates by connecting to the server and downloading its server certificates for analysis." ;
-    :kb-article """## How it works
-Analysis of server certificates using active methods to detect if certificates have been misconfigured or spoofed by using elements of the certificate, certificate authorities and signatures.
-
-### Certificate validity analysis
-This can be accomplished by verifying the digital signature on certificate.
-
-### Certificate path analysis
-The client's browser can perform path verification to ensure that the server's certificate contains a valid trust anchor.
-
-### Certificate configuration analysis
-Some browsers can be configured to implement the key-usage extensions contained certificates. This can help to prevent a certificate from being misused.
-
-### Certificate revocation status analysis
-Using either Certificate Revocation Lists (CRLs) or Online Certificate Status Protocol (OCSP) to determine the revocation status. OCSP Stapling, binding the status with the certificate, helps to mitigate potential delay in status verifications.
-
-## Considerations
-* Management of the PKI across the enterprise typically requires automation to maintain scalability and flexibility
-* If the certificate authority, issuing the certificate, is compromised then all of the certificates issued by the CA are suspect
-* There may be delays associated with updates to certificates
-* Revoked certificates give the appearance of valid certificates until they are published to a trusted revocation service (OCSP or CRL)
+    :kb-article """## How it works\r
+Analysis of server certificates using active methods to detect if certificates have been misconfigured or spoofed by using elements of the certificate, certificate authorities and signatures.\r
+\r
+### Certificate validity analysis\r
+This can be accomplished by verifying the digital signature on certificate.\r
+\r
+### Certificate path analysis\r
+The client's browser can perform path verification to ensure that the server's certificate contains a valid trust anchor.\r
+\r
+### Certificate configuration analysis\r
+Some browsers can be configured to implement the key-usage extensions contained certificates. This can help to prevent a certificate from being misused.\r
+\r
+### Certificate revocation status analysis\r
+Using either Certificate Revocation Lists (CRLs) or Online Certificate Status Protocol (OCSP) to determine the revocation status. OCSP Stapling, binding the status with the certificate, helps to mitigate potential delay in status verifications.\r
+\r
+## Considerations\r
+* Management of the PKI across the enterprise typically requires automation to maintain scalability and flexibility\r
+* If the certificate authority, issuing the certificate, is compromised then all of the certificates issued by the CA are suspect\r
+* There may be delays associated with updates to certificates\r
+* Revoked certificates give the appearance of valid certificates until they are published to a trusted revocation service (OCSP or CRL)\r
 * The revocation service (OCSP or CRL) may be down during our connection and a browser will need to make a decision will need to be made about trusting the connection""" ;
     :kb-reference :Reference-SecuringWebTransactions .
 
@@ -1713,14 +1713,14 @@ Using either Certificate Revocation Lists (CRLs) or Online Certificate Status Pr
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-AL" ;
     :definition "Active learning aims to improve learning efficiency by allowing the learning algorithm to select which data to learn from." ;
-    :kb-article """## How it works
-Traditional supervised learning often requires a large number of labeled instances, which can be costly or time-consuming to obtain. Active learning addresses this labeling bottleneck by asking an oracle (e.g., a human annotator) to label selected unlabeled instances. The goal is to achieve high accuracy with minimal labeling effort.
-
-## Considerations
-Active learning is particularly useful in scenarios where data is abundant but labeled instances are scarce or expensive. Examples include speech recognition, information extraction, and document classification.
-
-## References
-- Wikipedia article on Active Learning (machine learning) [Link](https://en.wikipedia.org/wiki/Active_learning_(machine_learning))
+    :kb-article """## How it works\r
+Traditional supervised learning often requires a large number of labeled instances, which can be costly or time-consuming to obtain. Active learning addresses this labeling bottleneck by asking an oracle (e.g., a human annotator) to label selected unlabeled instances. The goal is to achieve high accuracy with minimal labeling effort.\r
+\r
+## Considerations\r
+Active learning is particularly useful in scenarios where data is abundant but labeled instances are scarce or expensive. Examples include speech recognition, information extraction, and document classification.\r
+\r
+## References\r
+- Wikipedia article on Active Learning (machine learning) [Link](https://en.wikipedia.org/wiki/Active_learning_(machine_learning))\r
 - Settles, B. (2009). Active Learning Literature Survey. [Link](https://burrsettles.com/pub/settles.activelearning.pdf)""" .
 
 :ActiveLogicalLinkMapping a :LogicalLinkMapping,
@@ -1733,18 +1733,18 @@ Active learning is particularly useful in scenarios where data is abundant but l
             owl:someValuesFrom :CollectorAgent ] ;
     :d3fend-id "D3-ALLM" ;
     :definition "Active logical link mapping sends and receives network traffic as a means to map the whole data link layer, where the links represent logical data flows rather than physical connection" ;
-    :kb-article """## How it works
-
-Active logical link mapping establishes awareness of logical links in the network by sending data over the network to gather information about logical connections in the network.
-
-Typically this will be achieved through network telemetry coordinated for network management and monitoring and will use a link layer discovery protocol such as LLDP and the information gathered and aggregated a higher levels using an application protocol such as SNMP.  The information may be polled by network management softare or configured once and then pushed from network sensors (or agents.)
-
-Another means of establishing network connectivity is by means of sendingn traffic through the use of a tool such as traceroute, to determine the logical paths through the network architecture.
-
-## Considerations
-
-* Best practice is to encrypte network monitoring data and require authentication for queries or admin/management functions.
-* Push notifications reduce bandwidth necessary to capture and maintain information if reliable transport is used.
+    :kb-article """## How it works\r
+\r
+Active logical link mapping establishes awareness of logical links in the network by sending data over the network to gather information about logical connections in the network.\r
+\r
+Typically this will be achieved through network telemetry coordinated for network management and monitoring and will use a link layer discovery protocol such as LLDP and the information gathered and aggregated a higher levels using an application protocol such as SNMP.  The information may be polled by network management softare or configured once and then pushed from network sensors (or agents.)\r
+\r
+Another means of establishing network connectivity is by means of sendingn traffic through the use of a tool such as traceroute, to determine the logical paths through the network architecture.\r
+\r
+## Considerations\r
+\r
+* Best practice is to encrypte network monitoring data and require authentication for queries or admin/management functions.\r
+* Push notifications reduce bandwidth necessary to capture and maintain information if reliable transport is used.\r
 * Special consideration should be made before using of active scanning in OT networks and OT-safe options chosen where available.""" ;
     :kb-reference :Reference-IdentificationOfTracerouteNodesAndAssociatedDevices,
         :Reference-SNMPNetworkAutoDiscovery .
@@ -1785,7 +1785,7 @@ Another means of establishing network connectivity is by means of sendingn traff
         :TemporalDifferenceLearning ;
     :d3fend-id "D3A-AC" ;
     :definition "Actor-Critic is a Temporal Difference(TD) version of Policy gradient. It has two networks: Actor and Critic. The actor decided which action should be taken and critic inform the actor how good was the action and how it should adjust. The learning of the actor is based on policy gradient approach. In comparison, critics evaluate the action produced by the actor by computing the value function." ;
-    :kb-article """## References
+    :kb-article """## References\r
 The Actor-Critic Reinforcement Learning Algorithm. Medium. [Link](https://medium.com/intro-to-artificial-intelligence/the-actor-critic-reinforcement-learning-algorithm-c8095a655c14).""" ;
     :todo "The citation suggest (at a very brief glance) this may belong under temporal difference learning" .
 
@@ -1795,7 +1795,7 @@ The Actor-Critic Reinforcement Learning Algorithm. Medium. [Link](https://medium
     rdfs:subClassOf :ANN-basedClustering ;
     :d3fend-id "D3A-ARTC" ;
     :definition "Adaptive Resonance Theory (ART) Clustering is a  neural network algorithm used for clustering data and is open to new learning(i.e. adaptive) without discarding the previous or the old information(i.e. resonance)." ;
-    :kb-article """## References
+    :kb-article """## References\r
 GeeksforGeeks. (n.d.). Adaptive Resonance Theory (ART). [Link](https://www.geeksforgeeks.org/adaptive-resonance-theory-art/)""" .
 
 :AddressSpace a owl:Class ;
@@ -1840,11 +1840,11 @@ GeeksforGeeks. (n.d.). Adaptive Resonance Theory (ART). [Link](https://www.geeks
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-ANAA" ;
     :definition "Detection of unauthorized use of administrative network protocols by analyzing network activity against a baseline." ;
-    :kb-article """## How it works
-Network protocols such as RDP, IPMI, SSH, SNMP, VNC, MOSH, NX, TeamViewer, SPICE, PCoIP, and others are used by system administrators to remotely manage servers. Defenders monitor administrative network activity to determine if the use of remote protocols is malicious. Attackers can abuse administrative protocols and leverage them for initial access to various endpoints. For example, an attacker with valid credentials will remotely SSH or RDP into a server and attempt to blend in with existing traffic from system administrators. By monitoring the traffic activity, it is possible to detect when the protocols are behaving differently from a known baseline of system administration activity.
-
-## Considerations
-* Administrative traffic can be encrypted, making network protocol analysis a challenge
+    :kb-article """## How it works\r
+Network protocols such as RDP, IPMI, SSH, SNMP, VNC, MOSH, NX, TeamViewer, SPICE, PCoIP, and others are used by system administrators to remotely manage servers. Defenders monitor administrative network activity to determine if the use of remote protocols is malicious. Attackers can abuse administrative protocols and leverage them for initial access to various endpoints. For example, an attacker with valid credentials will remotely SSH or RDP into a server and attempt to blend in with existing traffic from system administrators. By monitoring the traffic activity, it is possible to detect when the protocols are behaving differently from a known baseline of system administration activity.\r
+\r
+## Considerations\r
+* Administrative traffic can be encrypted, making network protocol analysis a challenge\r
 * False alarms can be mitigated by integration with inventory management systems""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingSuspiciousAdministrativeActivity_VectraNetworksInc,
         :Reference-RemoteRegistry_MITRE,
@@ -1866,9 +1866,9 @@ Network protocols such as RDP, IPMI, SSH, SNMP, VNC, MOSH, NX, TeamViewer, SPICE
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-AC" ;
     :definition "Recursively merges pair of clusters of sample data; uses linkage distance." ;
-    :kb-article """## References
-scikit-learn. (n.d.). AgglomerativeClustering. [Link](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.
-Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)
+    :kb-article """## References\r
+scikit-learn. (n.d.). AgglomerativeClustering. [Link](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.\r
+Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)\r
 html)""" .
 
 :AlethicLogic a owl:Class,
@@ -1877,7 +1877,7 @@ html)""" .
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-AL" ;
     :definition "Alethic logic is a modal logic that addresses the modalities of necessity and possibility." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Alethic logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Alethic_logic)""" .
 
 :Alias a owl:Class ;
@@ -1923,9 +1923,9 @@ html)""" .
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-ABC" ;
     :definition "Combines the principles of Artificial Neural Networks (ANN) and clustering methods." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Artificial neural network. [Link](https://en.wikipedia.org/wiki/Artificial_neural_network)""" ;
-    :todo """have a gander at this paper for more clustering techniques ?
+    :todo """have a gander at this paper for more clustering techniques ?\r
 https://www.sciencedirect.com/science/article/pii/S089360800900207X?viewFullText=true#sec19""" .
 
 :AnswerSetProgramming a owl:Class,
@@ -1934,12 +1934,12 @@ https://www.sciencedirect.com/science/article/pii/S089360800900207X?viewFullText
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-ASP" ;
     :definition "Answer set programming is a form of declarative programming based on the stable model (answer set) semantics of logic programming." ;
-    :kb-article """## How it works
-Answer set programming (ASP) is oriented towards difficult (primarily NP-hard) search problems. The computational process employed in the design of many answer set solvers is an enhancement of the DPLL algorithm and, in principle, it always terminates (unlike Prolog query evaluation, which may lead to an infinite loop).
-
-In a more general sense, ASP includes all applications of answer sets to knowledge representation and the use of Prolog-style query evaluation for solving problems arising in these applications.
-
-## References
+    :kb-article """## How it works\r
+Answer set programming (ASP) is oriented towards difficult (primarily NP-hard) search problems. The computational process employed in the design of many answer set solvers is an enhancement of the DPLL algorithm and, in principle, it always terminates (unlike Prolog query evaluation, which may lead to an infinite loop).\r
+\r
+In a more general sense, ASP includes all applications of answer sets to knowledge representation and the use of Prolog-style query evaluation for solving problems arising in these applications.\r
+\r
+## References\r
 1. Answer set programming. (2023, April 27). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Answer_set_programming)""" ;
     :synonym "ASP" .
 
@@ -1995,9 +1995,9 @@ In a more general sense, ASP includes all applications of answer sets to knowled
             owl:someValuesFrom :ApplicationConfiguration ] ;
     :d3fend-id "D3-ACH" ;
     :definition "Modifying an application's configuration to reduce its attack surface." ;
-    :kb-article """## How it works
-Application configuration settings can be configured to limit the permissions on an application or disable certain vulnerable application features.
-
+    :kb-article """## How it works\r
+Application configuration settings can be configured to limit the permissions on an application or disable certain vulnerable application features.\r
+\r
 Hardening an application's configuration involves analyzing not only the application but also the environment in which the application is run in for potential vulnerabilities.""" ;
     :kb-reference :Reference-RedHatEnterpriseLinux8SecurityTechnicalImplementationGuide,
         :Reference-Windows10STIG .
@@ -2013,8 +2013,8 @@ Hardening an application's configuration involves analyzing not only the applica
     :d3fend-id "D3-AH" ;
     :definition "Application Hardening makes an executable application more resilient to a class of exploits which either introduce new code or execute unwanted existing code. These techniques may be applied at compile-time or on an application binary." ;
     :enables :Harden ;
-    :kb-article """## Technique Overview
-
+    :kb-article """## Technique Overview\r
+\r
 Exploits may, for example, rely on knowledge of addresses in a process's memory, they may alter memory contents, and they may cause a program to use instructions in a way that they were not intended.  By, for example, including code that dynamically changes the memory address of data or code on each run, introducing logic to validating the memory contents before certain potentially dangerous flows are executed, or monitoring a program for unusual sequence of instructions, this makes it harder for an attacker to craft a working exploit.""" ;
     :synonym "Process Hardening" .
 
@@ -2073,7 +2073,7 @@ Exploits may, for example, rely on knowledge of addresses in a process's memory,
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-ASM" ;
     :definition "Approximate string matching is a form of string matching that allows errrors." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Navarro, G. (2001). A guided tour to approximate string matching. _ACM Computing Surveys_, 33(1), 31-88. [Link](https://doi.org/10.1145/375360.375365)""" .
 
 :ArchiveFile a owl:Class ;
@@ -2088,7 +2088,7 @@ Exploits may, for example, rely on knowledge of addresses in a process's memory,
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3A-AM" ;
     :definition "An autoregressive integrated moving average (ARIMA) model is a generalization of an autoregressive moving average (ARMA) model." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Autoregressive integrated moving average. [Link](https://en.wikipedia.org/wiki/Autoregressive_integrated_moving_average)""" ;
     :synonym "Autoregressive Integrated Moving Average Model" .
 
@@ -2099,7 +2099,7 @@ Wikipedia. (n.d.). Autoregressive integrated moving average. [Link](https://en.w
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3-ARMA" ;
     :definition "Autoregressive-moving-average (ARMA) models provide a parsimonious description of a (weakly) stationary stochastic process in terms of two polynomials, one for the autoregression (AR) and the second for the moving average (MA)." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Autoregressive-moving-average model. [Link](https://en.wikipedia.org/wiki/Autoregressive%E2%80%93moving-average_model)""" ;
     :synonym "Autoregressive moving average model" .
 
@@ -2129,7 +2129,7 @@ Wikipedia. (n.d.). Autoregressive-moving-average model. [Link](https://en.wikipe
     rdfs:subClassOf :Classification ;
     :d3fend-annotation "Classification ANNs seek to classify an observation as belonging to some discrete class as a function of the inputs. The input features (independent variables) can be categorical or numeric types, however, we require a categorical feature as the dependent variable." ;
     :d3fend-id "D3A-ANNC" ;
-    :kb-article """## References
+    :kb-article """## References\r
 ANN Classification. [Link](http://uc-r.github.io/ann_classification).""" .
 
 :Assessment a owl:Class ;
@@ -2186,7 +2186,7 @@ ANN Classification. [Link](http://uc-r.github.io/ann_classification).""" .
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-ARL" ;
     :definition "Association rule learning is a rule-based machine learning method for discovering interesting relations between variables in large databases." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Association rule learning. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wiki/Association_rule_learning)""" .
 
 :AsymmetricFeature-basedTransferLearning a owl:Class,
@@ -2195,7 +2195,7 @@ Association rule learning. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wi
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-AFTL" ;
     :definition "Homogeneous (where the metrics are the same for both source and target) asymmetric transformation mapping transforms the source feature space to align with that of the target or the target to that of the source. This, in effect, bridges the feature space gap and reduces the problem into a homogeneous transfer problem when further distribution differences need to be corrected." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learning. Journal of Big Data, 4(1), 29. [Link](https://doi.org/10.1186/s40537-017-0089-0).""" ;
     :todo "Could use a better definition as this is a slightly modified version of the heterogeneous definition" .
 
@@ -2260,14 +2260,14 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-ANCI" ;
     :definition "Removing tokens or credentials from an authentication cache to prevent further user associated account accesses." ;
-    :kb-article """## How it works
-Applications can locally cache user authentication credentials for certain server connections. An application may attempt to use the cached credential for a connection. If the cached credentials exist then the user will not be typically prompted for new credentials.
-
-
-## Considerations
-Are these cached credentials only on the local host? Can they be persisted to the remote server?
-
-## Examples
+    :kb-article """## How it works\r
+Applications can locally cache user authentication credentials for certain server connections. An application may attempt to use the cached credential for a connection. If the cached credentials exist then the user will not be typically prompted for new credentials.\r
+\r
+\r
+## Considerations\r
+Are these cached credentials only on the local host? Can they be persisted to the remote server?\r
+\r
+## Examples\r
 Windows Credential Management API""" ;
     :kb-reference :Reference-SecureCachingOfServerCredentials_DellProductsLP,
         :Reference-SystemAndMethodForProvidingAnActivelyInvalidatedClient-sideNetworkResourceCache_IMVU .
@@ -2283,26 +2283,26 @@ Windows Credential Management API""" ;
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-ANET" ;
     :definition "Collecting authentication events, creating a baseline user profile, and determining whether authentication events are consistent with the baseline profile." ;
-    :kb-article """## How it works
-Authentication event data is collected (logon information such as device id, time of day, day of week, geo-location, etc.) to create an activity baseline. Then, a threshold is determined either through a manually specified configuration, or a statistical analysis of deviations in historical data. New authentication events are evaluated to determine if a threshold is exceeded. Thresholds can be static or dynamic.
-
-### Actions
-As a result of the analysis, actions taken could include:
-
-* [Account Locking](/technique/d3f:AccountLocking)
-* Raising an alert
-
-### Example data sources
- * Directory server logs
- * VPN Server logs
- * IDAM Capability logs
- * NAC logs
- * Authentication client logs
- * Kerberos network traffic
- * LDAP network traffic
-
-## Considerations
-
+    :kb-article """## How it works\r
+Authentication event data is collected (logon information such as device id, time of day, day of week, geo-location, etc.) to create an activity baseline. Then, a threshold is determined either through a manually specified configuration, or a statistical analysis of deviations in historical data. New authentication events are evaluated to determine if a threshold is exceeded. Thresholds can be static or dynamic.\r
+\r
+### Actions\r
+As a result of the analysis, actions taken could include:\r
+\r
+* [Account Locking](/technique/d3f:AccountLocking)\r
+* Raising an alert\r
+\r
+### Example data sources\r
+ * Directory server logs\r
+ * VPN Server logs\r
+ * IDAM Capability logs\r
+ * NAC logs\r
+ * Authentication client logs\r
+ * Kerberos network traffic\r
+ * LDAP network traffic\r
+\r
+## Considerations\r
+\r
 This technique covers statistical outliers. Though depending on the complexity or dimensionality of the data considered, outliers may not be obvious to a human analyst reviewing events in simplistic analytic views. If the malicious activity is not statistically different from benign activity, an alert threshold will not be met.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC,
@@ -2361,12 +2361,12 @@ This technique covers statistical outliers. Though depending on the complexity o
     :created "2020-08-05T00:00:00"^^xsd:dateTime ;
     :d3fend-id "D3-AZET" ;
     :definition "Collecting authorization events, creating a baseline user profile, and determining whether authorization events are consistent with the baseline profile." ;
-    :kb-article """## How it works
-
-Authorization event data is collected to create a baseline user profile. Authorization events that deviate from the baseline and exceed a static or dynamic threshold are identified for further action. Authorization events can include successful and failed authorization attempts as well as events related to permissions including viewing, editing, deleting, creating files, databases etc.
-
-## Considerations
-
+    :kb-article """## How it works\r
+\r
+Authorization event data is collected to create a baseline user profile. Authorization events that deviate from the baseline and exceed a static or dynamic threshold are identified for further action. Authorization events can include successful and failed authorization attempts as well as events related to permissions including viewing, editing, deleting, creating files, databases etc.\r
+\r
+## Considerations\r
+\r
 Depending on the complexity of the data considered, outliers may not be obvious to a human analyst reviewing events in simplistic analytic views. If malicious activity is not statistically different from benign activity, an alert threshold will not be met.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC,
@@ -2397,7 +2397,7 @@ Depending on the complexity of the data considered, outliers may not be obvious 
     rdfs:subClassOf :DimensionReduction ;
     :d3fend-id "D3A-AUT" ;
     :definition "Autoencoders are specific type of deep learning architecture used for learning representation of data, typically for the purpose of dimensionality reduction. This is achieved by designing deep learning architecture that aims that copying input layer at its output layer." ;
-    :kb-article """## References
+    :kb-article """## References\r
 SOCR. (n.d.). ABIDE Autoencoder. [Link](https://socr.umich.edu/HTML5/ABIDE_Autoencoder/#:~:text=In%20simple%20words%2C%20autoencoders%20are,layer%20at%20its%20output%20layer.)""" .
 
 :AutoregressiveModel a owl:Class,
@@ -2406,7 +2406,7 @@ SOCR. (n.d.). ABIDE Autoencoder. [Link](https://socr.umich.edu/HTML5/ABIDE_Autoe
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3A-AM" ;
     :definition "An autoregressive (AR) model is a representation of a type of random process; as such, it is used to describe certain time-varying processes in nature, economics, behavior, etc." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Autoregressive model. [Link](https://en.wikipedia.org/wiki/Autoregressive_model)""" ;
     :synonym "AR Model" .
 
@@ -2416,7 +2416,7 @@ Wikipedia. (n.d.). Autoregressive model. [Link](https://en.wikipedia.org/wiki/Au
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-AAD" ;
     :definition "The average absolute deviation (AAD) of a data set is the average of the absolute deviations from a central point." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/wiki/Average_absolute_deviation)""" .
 
 :BarcodeScannerInputDevice a owl:Class ;
@@ -2432,7 +2432,7 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :BayesianMethod ;
     :d3fend-id "D3A-BE" ;
     :definition "A Bayes estimator or a Bayes action is an estimator or decision rule that minimizes the posterior expected value of a loss function (i.e., the posterior expected loss)." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Bayes estimator. [Link](https://en.wikipedia.org/wiki/Bayes_estimator)""" .
 
 :BayesianHypothesisTesting a owl:Class,
@@ -2441,10 +2441,10 @@ Wikipedia. (n.d.). Bayes estimator. [Link](https://en.wikipedia.org/wiki/Bayes_e
     rdfs:subClassOf :BayesianMethod ;
     :d3fend-id "D3A-BHT" ;
     :definition "Bayesian hypothesis testing can be framed as a special case of model comparison where a model refers to a likelihood function and a prior distribution." ;
-    :kb-article """## How it works
-Given two competing hypotheses and some relevant data, Bayesian hypothesis testing begins by specifying separate prior distributions to quantitatively describe each hypothesis. The combination of the likelihood function for the observed data with each of the prior distributions yields hypothesis-specific models. For each of the hypothesis-specific models, averaging (ie, integrating) the likelihood with respect to the prior distribution across the entire parameter space yields the probability of the data under the model and, therefore, the corresponding hypothesis. This quantity is more commonly referred to as the marginal likelihood and represents the average fit of the model to the data. The ratio of the marginal likelihoods for both hypothesis-specific models is known as the Bayes factor.
-
-## References
+    :kb-article """## How it works\r
+Given two competing hypotheses and some relevant data, Bayesian hypothesis testing begins by specifying separate prior distributions to quantitatively describe each hypothesis. The combination of the likelihood function for the observed data with each of the prior distributions yields hypothesis-specific models. For each of the hypothesis-specific models, averaging (ie, integrating) the likelihood with respect to the prior distribution across the entire parameter space yields the probability of the data under the model and, therefore, the corresponding hypothesis. This quantity is more commonly referred to as the marginal likelihood and represents the average fit of the model to the data. The ratio of the marginal likelihoods for both hypothesis-specific models is known as the Bayes factor.\r
+\r
+## References\r
 Baig, S. A., PhD. (2020). Bayesian Inference: An Introduction to Hypothesis Testing Using Bayes Factors. Nicotine & Tobacco Research, 22(7), 1244-1246. [Link](https://academic.oup.com/ntr/article/22/7/1244/5613971)""" .
 
 :BayesianLinearRegression a owl:Class,
@@ -2453,7 +2453,7 @@ Baig, S. A., PhD. (2020). Bayesian Inference: An Introduction to Hypothesis Test
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-BLR" ;
     :definition "Bayesian linear regression is a type of conditional modeling in which the mean of one variable is described by a linear combination of other variables, with the goal of obtaining the posterior probability of the regression coefficients." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/wiki/Bayesian_linear_regression)""" .
 
 :BayesianLinearRegressionLearning a owl:Class,
@@ -2462,7 +2462,7 @@ Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-BLRL" ;
     :definition "A supervised learning method that builds a Bayesian linear regression model using training data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/wiki/Bayesian_linear_regression)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#BayesianLinearRegression" .
 
@@ -2472,7 +2472,7 @@ Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-BM" ;
     :definition "Bayesian analysis is a statistical procedure which endeavors to estimate parameters of an underlying distribution based on the observed distribution." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wolfram MathWorld. (n.d.). Bayesian Analysis. [Link](https://mathworld.wolfram.com/BayesianAnalysis.html)""" .
 
 :BayesianModelAveraging a owl:Class,
@@ -2481,9 +2481,9 @@ Wolfram MathWorld. (n.d.). Bayesian Analysis. [Link](https://mathworld.wolfram.c
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BMA" ;
     :definition "A parameter estimate (or a prediction of new observations) obtained by averaging the estimates (or predictions) of the different models under consideration, each weighted by its model probability." ;
-    :kb-article """## References
-Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).
-
+    :kb-article """## References\r
+Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).\r
+\r
 Bayesian model average: A parameter estimation approach to model agnostic ensemble learning. (2019). Journal of Machine Learning for Modeling and Computing, 1(2), 61-70.  [Link](https://journals.sagepub.com/doi/full/10.1177/2515245919898657#:~:text=Bayesian%20model%20average%3A%20A%20parameter,weighted%20by%20its%20model%20probability).""" .
 
 :BayesianModelCombination a owl:Class,
@@ -2492,9 +2492,9 @@ Bayesian model average: A parameter estimation approach to model agnostic ensemb
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BMC" ;
     :definition "Bayesian model combination (BMC) is an algorithmic correction to Bayesian model averaging (BMA). Instead of sampling each model in the ensemble individually, it samples from the space of possible ensembles (with model weights drawn randomly from a Dirichlet distribution having uniform parameters)" ;
-    :kb-article """## References
-Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).
-
+    :kb-article """## References\r
+Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).\r
+\r
 Shultz, K. M., & Peterson, L. E. (2011). Model-averaged confidence intervals for ensemble learning. In *International Joint Conference on Neural Networks* (pp. 2677-2684).  [Link](https://axon.cs.byu.edu/papers/Kristine.ijcnn2011.pdf).""" .
 
 :BayesOptimalClassifier a owl:Class,
@@ -2503,8 +2503,8 @@ Shultz, K. M., & Peterson, L. E. (2011). Model-averaged confidence intervals for
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BOC" ;
     :definition "A probabilistic model that makes the most probable prediction for a new example." ;
-    :kb-article """## References
-Bayes Optimal Classifier. Machine Learning Mastery.  [Link](https://machinelearningmastery.com/bayes-optimal-classifier/).
+    :kb-article """## References\r
+Bayes Optimal Classifier. Machine Learning Mastery.  [Link](https://machinelearningmastery.com/bayes-optimal-classifier/).\r
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :BERT a owl:Class,
@@ -2513,8 +2513,8 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :Transformer-basedLearning ;
     :d3fend-id "D3A-BER" ;
     :definition "Bidirectional Encoder Representations from Transformers (BERT) is based on a deep learning model in which every output element is connected to every input element, and the weightings between them are dynamically calculated based upon their connection." ;
-    :kb-article """## References
-BERT (language model). (n.d.). In TechTarget. [Link](https://www.techtarget.com/searchenterpriseai/definition/BERT-language-model)
+    :kb-article """## References\r
+BERT (language model). (n.d.). In TechTarget. [Link](https://www.techtarget.com/searchenterpriseai/definition/BERT-language-model)\r
 BERT (language model). (n.d.). In Wikipedia. [Link](https://en.wikipedia.org/wiki/BERT_(language_model))""" ;
     :synonym "Bidirectional Encoder Representations from Transformers" .
 
@@ -2573,8 +2573,8 @@ BERT (language model). (n.d.). In Wikipedia. [Link](https://en.wikipedia.org/wik
             owl:onProperty :may-contain ;
             owl:someValuesFrom :Volume ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Device_file#BLOCKDEV> ;
-    :definition """A block device (or block special file) provides buffered access to hardware devices, and provides some abstraction from their specifics.
-
+    :definition """A block device (or block special file) provides buffered access to hardware devices, and provides some abstraction from their specifics.\r
+\r
 IEEE Std 1003.1-2017: A file that refers to a device. A block special file is normally distinguished from a character special file by providing access to the device in a manner such that the hardware characteristics of the device are not visible.""" ;
     rdfs:seeAlso <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_79> .
 
@@ -2589,14 +2589,14 @@ IEEE Std 1003.1-2017: A file that refers to a device. A block special file is no
     rdfs:subClassOf :LogicalRules ;
     :d3fend-id "D3A-BEM" ;
     :definition "Boolean expression matching produces a Boolean truth value for a given boolean expression and assignment of values to variables in the expression." ;
-    :kb-article """## How it works
-A Boolean expression is an expression used in programming languages that produces a Boolean value when evaluated. A Boolean value is either true or false. A Boolean expression may be composed of a combination of the Boolean constants true or false, Boolean-typed variables, Boolean-valued operators, and Boolean-valued functions.
-
-Boolean expressions correspond to propositional formulas in logic and are a special case of Boolean circuits.
-
-## References
-1. Boolean expression. (2022, April 25). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Boolean_expression)
-2. Boolean algebra. (2022, May 19). In _Wikipedia_.
+    :kb-article """## How it works\r
+A Boolean expression is an expression used in programming languages that produces a Boolean value when evaluated. A Boolean value is either true or false. A Boolean expression may be composed of a combination of the Boolean constants true or false, Boolean-typed variables, Boolean-valued operators, and Boolean-valued functions.\r
+\r
+Boolean expressions correspond to propositional formulas in logic and are a special case of Boolean circuits.\r
+\r
+## References\r
+1. Boolean expression. (2022, April 25). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Boolean_expression)\r
+2. Boolean algebra. (2022, May 19). In _Wikipedia_.\r
 [Link](https://en.wikipedia.org/wiki/Boolean_expression)""" .
 
 :Boosting a owl:Class,
@@ -2605,21 +2605,21 @@ Boolean expressions correspond to propositional formulas in logic and are a spec
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BOO" ;
     :definition "Boosting is a sequential process where each subsequent model attempts to correct the errors of the previous model" ;
-    :kb-article """## How it works
-Boosting consists of using sequentially weak learners where each iteration’s training focuses on previously misclassified instances in order to improve on the previous iteration. This process is continued iteratively until the final prediction is made by aggregating the previous predictions.
-
-## Considerations
-Boosting can be computationally expensive, prone to overfitting, and slower to train compared to other ensemble methods.
-
-There are three main types of Boosting algorithms
- - Adaptive Boosting
-Adaptive Boosting (sometimes called AdaBoost) works by adding equal importance to each piece of a dataset and running it through the base learning algorithms. Every algorithm that errors, the boosting algorithm assigns a higher importance to. This continues until an acceptable level of confidence is reached.
- - Gradient Boosting
-Gradient Boosting starts by training multiple models simultaneously to gather a strong estimate of strength to build new base learning algorithms.
- - XGBoosting
-XGBoosting is a scalable tree boosting model. Using decision trees, weight is assigned to each variable and put into a decision tree. Outputs that are classified by the algorithm as wrong or weak are put into a second decision tree and the results form a stronger model.
-
-## References
+    :kb-article """## How it works\r
+Boosting consists of using sequentially weak learners where each iteration’s training focuses on previously misclassified instances in order to improve on the previous iteration. This process is continued iteratively until the final prediction is made by aggregating the previous predictions.\r
+\r
+## Considerations\r
+Boosting can be computationally expensive, prone to overfitting, and slower to train compared to other ensemble methods.\r
+\r
+There are three main types of Boosting algorithms\r
+ - Adaptive Boosting\r
+Adaptive Boosting (sometimes called AdaBoost) works by adding equal importance to each piece of a dataset and running it through the base learning algorithms. Every algorithm that errors, the boosting algorithm assigns a higher importance to. This continues until an acceptable level of confidence is reached.\r
+ - Gradient Boosting\r
+Gradient Boosting starts by training multiple models simultaneously to gather a strong estimate of strength to build new base learning algorithms.\r
+ - XGBoosting\r
+XGBoosting is a scalable tree boosting model. Using decision trees, weight is assigned to each variable and put into a decision tree. Outputs that are classified by the algorithm as wrong or weak are put into a second decision tree and the results form a stronger model.\r
+\r
+## References\r
 Sciencedirect. (n.d.). Semi-supervised learning: An overview. [Link](https://www.sciencedirect.com/science/article/pii/S1319157823000228)""" .
 
 :BootLoader a owl:Class ;
@@ -2659,7 +2659,7 @@ Sciencedirect. (n.d.). Semi-supervised learning: An overview. [Link](https://www
     rdfs:subClassOf :ResamplingEnsemble ;
     :d3fend-id "D3A-BA" ;
     :definition "Bootstrap aggregating, also called bagging (from bootstrap aggregating), is a machine learning ensemble meta-algorithm designed to improve the stability and accuracy of machine learning algorithms used in statistical classification and regression. It also reduces variance and helps to avoid overfitting. Although it is usually applied to decision tree methods, it can be used with any type of method. Bagging is a special case of the model averaging approach." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Bootstrap aggregating. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Bootstrap_aggregating).""" .
 
 :BroadcastDomainIsolation a :NetworkIsolation,
@@ -2672,12 +2672,12 @@ Bootstrap aggregating. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Bootstra
             owl:someValuesFrom :LocalAreaNetworkTraffic ] ;
     :d3fend-id "D3-BDI" ;
     :definition "Broadcast isolation restricts the number of computers a host can contact on their LAN." ;
-    :kb-article """## How it works
-Software Defined Networking, or other network encapsulation technologies intercept host broadcast traffic then route it to a specified destination per a configured policy.
-
-This can be implemented within hypervisors, networking hardware (WAPs, switches, routers), or virutal hardware.
-
-## Considerations
+    :kb-article """## How it works\r
+Software Defined Networking, or other network encapsulation technologies intercept host broadcast traffic then route it to a specified destination per a configured policy.\r
+\r
+This can be implemented within hypervisors, networking hardware (WAPs, switches, routers), or virutal hardware.\r
+\r
+## Considerations\r
 This technique is highly dependent on network infrastructure and networking requirements.""" ;
     :kb-reference :Reference-BroadcastIsolationAndLevel3NetworkSwitch_HewlettPackardEnterpriseDevelopmentLP,
         :Reference-PrivateVirtualLocalAreaNetworkIsolation_CiscoTechnologyInc ;
@@ -2708,7 +2708,7 @@ This technique is highly dependent on network infrastructure and networking requ
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-BOM" ;
     :definition "A \"bucket of models\" is an ensemble technique in which a model selection algorithm is used to choose the best model for each problem. When tested with only one problem, a bucket of models can produce no better results than the best model in the set, but when evaluated across many problems, it will typically produce much better results, on average, than any model in the set." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :BuildTool a owl:Class ;
@@ -2731,31 +2731,31 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :NetworkTrafficAnalysis ;
     :d3fend-id "D3-BSE" ;
     :definition "Analyzing sequences of bytes and determining if they likely represent malicious shellcode." ;
-    :kb-article """## How it works
-
-Bytes are analyzed as if they are machine code instructions, and such instructions that are a common component of known shellcode are noted, such as stack pivots, reads from a Memory Address Table, and system calls for functions that disable protections or execute code.  For example, the x86 instruction `b0 0b: mov $11, %ax`, with no further alterations to the `%ax` register, followed by `cd 80: syscall` executes the system call `execve()` in the Linux kernel, which replaces the current process with another one specified -- this is a common action in shellcode, so this sequence would be flagged.
-
-This technique detects shellcode despite whether or not it would cause a buffer overflow in the target binary.
-
-If the sequence of bytes contains a sequence similar to that used in malicious shellcode, the entire byte sequence is flagged and a follow-on technique may be invoked.
-
-## Considerations
-
-### False Negatives
-If the shellcode instructions are far apart, simple implementations might not detect the shellcode.
-
-Due to the nature of assembly instructions not having a defined start or end, implementations which do not process all start sequences (for example, when they a find byte sequence of interest, continue scanning forwards from the end of it) might not detect the shellcode.
-
-This technique might not detect more complex or obfuscated instructions.  For that purpose, Dynamic Analysis or Emulated File Analysis could assist by analyzing the actual instruction function.
-
-This technique may not detect self-modifying code.  To make it harder for a process to modify itself, Process Segment Execution Prevention should be used, while noting its considerations.
-
-This technique might not detect malicious shellcode which reuses instructions in the target binary for malicious effect, as memory references in the presumed assembly code are not dereferenced.  Dynamic Analysis and Emulated File Analysis, when set up properly to fork from the running target binary, might detect this.  Process Segment Execution Prevention combined with Segment Address Offset Randomization frequently makes introduction of shellcode through overwriting a saved return pointer more difficult.  Call stack depth analysis might detect excessive reuse of instructions in the target binary.  Shadow Stack Frames might detect that a stack frame's return address has changed and Stack Frame Canary Verification might detect that the stack frame's return address was overwritten.  Other heuristic methods might detect jump-oriented programming shellcode.
-
-With inserting code directly, that it is not a buffer overflow, and just some place where code is executed either to a file or a write-what-where, the buffer overflow mitigations do not help.  Behavioral analysis could detect this, or proper access control could mitigate this.
-
-### False Positives
-
+    :kb-article """## How it works\r
+\r
+Bytes are analyzed as if they are machine code instructions, and such instructions that are a common component of known shellcode are noted, such as stack pivots, reads from a Memory Address Table, and system calls for functions that disable protections or execute code.  For example, the x86 instruction `b0 0b: mov $11, %ax`, with no further alterations to the `%ax` register, followed by `cd 80: syscall` executes the system call `execve()` in the Linux kernel, which replaces the current process with another one specified -- this is a common action in shellcode, so this sequence would be flagged.\r
+\r
+This technique detects shellcode despite whether or not it would cause a buffer overflow in the target binary.\r
+\r
+If the sequence of bytes contains a sequence similar to that used in malicious shellcode, the entire byte sequence is flagged and a follow-on technique may be invoked.\r
+\r
+## Considerations\r
+\r
+### False Negatives\r
+If the shellcode instructions are far apart, simple implementations might not detect the shellcode.\r
+\r
+Due to the nature of assembly instructions not having a defined start or end, implementations which do not process all start sequences (for example, when they a find byte sequence of interest, continue scanning forwards from the end of it) might not detect the shellcode.\r
+\r
+This technique might not detect more complex or obfuscated instructions.  For that purpose, Dynamic Analysis or Emulated File Analysis could assist by analyzing the actual instruction function.\r
+\r
+This technique may not detect self-modifying code.  To make it harder for a process to modify itself, Process Segment Execution Prevention should be used, while noting its considerations.\r
+\r
+This technique might not detect malicious shellcode which reuses instructions in the target binary for malicious effect, as memory references in the presumed assembly code are not dereferenced.  Dynamic Analysis and Emulated File Analysis, when set up properly to fork from the running target binary, might detect this.  Process Segment Execution Prevention combined with Segment Address Offset Randomization frequently makes introduction of shellcode through overwriting a saved return pointer more difficult.  Call stack depth analysis might detect excessive reuse of instructions in the target binary.  Shadow Stack Frames might detect that a stack frame's return address has changed and Stack Frame Canary Verification might detect that the stack frame's return address was overwritten.  Other heuristic methods might detect jump-oriented programming shellcode.\r
+\r
+With inserting code directly, that it is not a buffer overflow, and just some place where code is executed either to a file or a write-what-where, the buffer overflow mitigations do not help.  Behavioral analysis could detect this, or proper access control could mitigate this.\r
+\r
+### False Positives\r
+\r
 Byte sequences containing code that is never used as machine code are still analyzed and flagged for anomalies, and [eventually](http://mathforum.org/library/drmath/view/55871.html), it is likely that an attack sequence will arise from the sheer volume of bytes transmitted.""" ;
     :kb-reference :Reference-Network-BasedBufferOverflowDetectionByExploitCodeAnalysis_InformationSecurityResearchCentre,
         :Reference-Network-levelPolymorphicShellcodeDetectionUsingEmulation ;
@@ -2767,7 +2767,7 @@ Byte sequences containing code that is never used as machine code are still anal
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-C4." ;
     :definition "C4.5 is an algorithm that is strongly based off ID3. It creates decision trees the same way as ID3. C4.5 improves on several aspects of ID3, including handling discreet variables, handling training data with missing values, and has the ability to automatically prune the decision trees it creates." ;
-    :kb-article """## References
+    :kb-article """## References\r
 C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).""" ;
     :todo "Review: Definition" .
 
@@ -2777,7 +2777,7 @@ C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-C5." ;
     :definition "C5.0 is the next version of C4.5, which in turn is the upgrade from ID3. The only difference between C5.0 and C4.5 is some improvements made to C5.0." ;
-    :kb-article """## References
+    :kb-article """## References\r
 C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).""" .
 
 :CACertificateFile a owl:Class ;
@@ -2818,7 +2818,7 @@ C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-CC" ;
     :definition "The canopy clustering algorithm is an unsupervised pre-clustering algorithm  often used as preprocessing step for the K-means algorithm or the Hierarchical clustering algorithm. It is intended to speed up clustering operations on large data sets." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Canopy clustering algorithm. [Link](https://en.wikipedia.org/wiki/Canopy_clustering_algorithm)""" .
 
 :Capability a owl:Class ;
@@ -2831,25 +2831,25 @@ Wikipedia. (n.d.). Canopy clustering algorithm. [Link](https://en.wikipedia.org/
             owl:onProperty :has-feature ;
             owl:someValuesFrom :CapabilityFeature ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Capability_(systems_engineering)> ;
-    :comment """Source Definitions for DoDAF-DM2 Term: "(JCIDS):  The ability to achieve a desired effect under specified standards and conditions through combinations of means and ways to perform a set of tasks.
-(DoDAF/CADM):  An ability to achieve an objective. (DDDS Counter (333/1)(A))
-(JC3IEDM):  The potential ability to do work, perform a function or mission, achieve an objective, or provide a service.
-(MODAF):  Capabilities in the MODAF sense are specifically not about equipment but are a high level specification of the enterprise’s ability. A capability is a classification of some ability - and can be specified regardless of whether the enterprise is currently able to achieve it. For example, one could define a capability “Manned Interplanetary Travel” which no-one can currently achieve, but which may be planned or aspired to. Capabilities in MODAF are not time-dependent - once defined they are persistent. It is only the Capability Requirement that changes.
-(NAF):  The ability of one or more resources to deliver a specified type of effect or a specified course of action. (GEN TERM)
-(NAF):  A high level specification of the enterprise's ability. (MM)
-(JCS 1-02):  The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)
-(Webster's):  1. The quality of being capable; ability.  2. A talent or ability that has potential for development or use.  3. The capacity to be used, treated, or developed for a specific purpose.
-(Merriam-Webster's Eleventh Collegiate Dictionary): A feature or factor capable of development: POTENTIALITY.    3. The facility or potential for an indicated use or deployment.
-(Joint Publication 1-02, Dictionary of Military and Associated Terms, 12 Apr 2001 (as amended trhough 30 May 2008) ): The ability to exercise a specified course of action (A capability may or may not be accompanied by an intention)
-(Dictionary.com): The quality of being capable; capacity; ability: His capability was unquestionable. The ability to undergo or be affected by a given treatment or action: the capability of glass in resisting heat. Usually, capabilities. qualities, abilities, features, etc., that can be used or developed; potential: Though dilapidated, the house has great capabilities
-(Wiktionary): The power or ability to generate an outcome
-(www.staffordshireprepared.gov.uk/glossary/): Originally a military term which includes the aspects of personnel, equipment, training, planning and operational doctrine. Now used to mean a demonstrable capacity or ability to respond to and recover from a particular threat or hazard."
-
-CJCS Guide 3401D: https://www.jcs.mil/Portals/36/Documents/Library/Handbooks/g3401.pdf?ver=2016-02-05-175742-457 : "capability. The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)"
-
-USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423 "capability - means to accomplish a mission, function, or objective." DHS, DHS Lexicon, Terms, Mar 17;
-
-USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423  "capability - Provides the means to accomplish a mission or function resulting from the performance of one or more critical tasks, under specified conditions, to target levels of performance. A capability may be delivered with any combination of properly planned, organized, equipped, trained, and exercised personnel that achieves the desired outcome."
+    :comment """Source Definitions for DoDAF-DM2 Term: "(JCIDS):  The ability to achieve a desired effect under specified standards and conditions through combinations of means and ways to perform a set of tasks.\r
+(DoDAF/CADM):  An ability to achieve an objective. (DDDS Counter (333/1)(A))\r
+(JC3IEDM):  The potential ability to do work, perform a function or mission, achieve an objective, or provide a service.\r
+(MODAF):  Capabilities in the MODAF sense are specifically not about equipment but are a high level specification of the enterprise’s ability. A capability is a classification of some ability - and can be specified regardless of whether the enterprise is currently able to achieve it. For example, one could define a capability “Manned Interplanetary Travel” which no-one can currently achieve, but which may be planned or aspired to. Capabilities in MODAF are not time-dependent - once defined they are persistent. It is only the Capability Requirement that changes.\r
+(NAF):  The ability of one or more resources to deliver a specified type of effect or a specified course of action. (GEN TERM)\r
+(NAF):  A high level specification of the enterprise's ability. (MM)\r
+(JCS 1-02):  The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)\r
+(Webster's):  1. The quality of being capable; ability.  2. A talent or ability that has potential for development or use.  3. The capacity to be used, treated, or developed for a specific purpose.\r
+(Merriam-Webster's Eleventh Collegiate Dictionary): A feature or factor capable of development: POTENTIALITY.    3. The facility or potential for an indicated use or deployment.\r
+(Joint Publication 1-02, Dictionary of Military and Associated Terms, 12 Apr 2001 (as amended trhough 30 May 2008) ): The ability to exercise a specified course of action (A capability may or may not be accompanied by an intention)\r
+(Dictionary.com): The quality of being capable; capacity; ability: His capability was unquestionable. The ability to undergo or be affected by a given treatment or action: the capability of glass in resisting heat. Usually, capabilities. qualities, abilities, features, etc., that can be used or developed; potential: Though dilapidated, the house has great capabilities\r
+(Wiktionary): The power or ability to generate an outcome\r
+(www.staffordshireprepared.gov.uk/glossary/): Originally a military term which includes the aspects of personnel, equipment, training, planning and operational doctrine. Now used to mean a demonstrable capacity or ability to respond to and recover from a particular threat or hazard."\r
+\r
+CJCS Guide 3401D: https://www.jcs.mil/Portals/36/Documents/Library/Handbooks/g3401.pdf?ver=2016-02-05-175742-457 : "capability. The ability to execute a specified course of action. (A capability may or may not be accompanied by an intention.)"\r
+\r
+USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423 "capability - means to accomplish a mission, function, or objective." DHS, DHS Lexicon, Terms, Mar 17;\r
+\r
+USG Compendium of Interagency and Associated Terms: https://www.jcs.mil/Portals/36/Documents/Doctrine/dictionary/repository/usg_compendium.pdf?ver=2019-11-04-174229-423  "capability - Provides the means to accomplish a mission or function resulting from the performance of one or more critical tasks, under specified conditions, to target levels of performance. A capability may be delivered with any combination of properly planned, organized, equipped, trained, and exercised personnel that achieves the desired outcome."\r
 DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
     rdfs:seeAlso <https://web.archive.org/web/20081123014953/http://www.dtic.mil/doctrine/jel/new_pubs/jp1_02.pdf> .
 
@@ -2931,7 +2931,7 @@ DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-CAR" ;
     :definition "The CART algorithm is a type of classification algorithm that is required to build a decision tree on the basis of Gini’s impurity index." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Classification and Regression Tree (CART) Algorithm. Analytics Steps. [Link](https://www.analyticssteps.com/blogs/classification-and-regression-tree-cart-algorithm).""" .
 
 :Catalog a owl:Class ;
@@ -2980,9 +2980,9 @@ Classification and Regression Tree (CART) Algorithm. Analytics Steps. [Link](htt
     rdfs:subClassOf :DescriptiveStatistics ;
     :d3fend-id "D3A-CT" ;
     :definition "A measure of central tendency ) is a summary measure that attempts to describe a whole set of data with a single value that represents the middle or centre of its distribution." ;
-    :kb-article """## References
-Australian Bureau of Statistics. (n.d.). Measures of Central Tendency. [Link](https://www.abs.gov.au/statistics/understanding-statistics/statistical-terms-and-concepts/measures-central-tendency)
-
+    :kb-article """## References\r
+Australian Bureau of Statistics. (n.d.). Measures of Central Tendency. [Link](https://www.abs.gov.au/statistics/understanding-statistics/statistical-terms-and-concepts/measures-central-tendency)\r
+\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :Centroid-basedClustering a owl:Class,
@@ -2991,7 +2991,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-CBC" ;
     :definition "Centroid-based clustering organizes the data into non-hierarchical clusters, in contrast to hierarchical clustering defined below. K-means is the most widely-used centroid-based clustering algorithm. Centroid-based algorithms are efficient but sensitive to initial conditions and outliers." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Google Developers. (n.d.). Clustering Algorithms. [Link](https://developers.google.com/machine-learning/clustering/clustering-algorithms)""" .
 
 :Certificate a owl:Class ;
@@ -3029,9 +3029,9 @@ Google Developers. (n.d.). Clustering Algorithms. [Link](https://developers.goog
             owl:someValuesFrom :CertificateFile ] ;
     :d3fend-id "D3-CA" ;
     :definition "Analyzing Public Key Infrastructure certificates to detect if they have been misconfigured or spoofed using both network traffic, certificate fields and third-party logs." ;
-    :kb-article """## How it works
-Certificate Analysis ensures that the data elements of the certificate are current and anchored in a known trust model. Certificate authorities, revocation lists, and third-party secure logs are used in the analysis. Analysis includes detection of server impersonation, phishing domains, and forged certificates.
-
+    :kb-article """## How it works\r
+Certificate Analysis ensures that the data elements of the certificate are current and anchored in a known trust model. Certificate authorities, revocation lists, and third-party secure logs are used in the analysis. Analysis includes detection of server impersonation, phishing domains, and forged certificates.\r
+\r
 TLS certificates are designed to expire to ensure that the cryptographic keys are forced to be changed on a regular basis. The certificates in the trust path also expire and can cause a break in the trust chain. This means that even if a server certificate is updated correctly, intermediate certificates can expire and the trust chain is not maintained. This can cause services to become unavailable.""" ;
     :kb-reference :Reference-SecuringWebTransactions .
 
@@ -3054,25 +3054,25 @@ TLS certificates are designed to expire to ensure that the cryptographic keys ar
             owl:someValuesFrom :PublicKey ] ;
     :d3fend-id "D3-CP" ;
     :definition "Persisting either a server's X509 certificate or their public key and comparing that to server's presented identity to allow for greater client confidence in the remote server's identity for SSL connections." ;
-    :kb-article """## How it works
-Pinning allows for a trusted copy of a certificate or public key to be associated with a server and thus reducing the likelihood of frequently visited sites being subjected to man-in-the-middle attacks. Certificates or public keys can be pinned after a trusted connection has been established or the pinning can be preloaded in an application, which is the preferred method for mobile applications.
-
-Pinning can take the form of certificate pinning or public key pinning.
-
-## Forms of Pinning
-* Certificate Pinning
-Certificate Pinning (CP) allows for the client to verify the X509 certificate with a preloaded certificate. Typically, this is involves storing a hash of the certificate and using the stored hash for comparison to the hash of the certificate submitted during the SSL handshake.
-
-* Public Key Pinning
-Public Key Pinning (PKP) requires the extraction of a public key from server's certificate. The stored public key is compared to the server's presented public key. A public key is expected to rotate less frequently than an X509 certificate and is generally favored over certificate pinning.
-
-An extension of PKP is Subject Public Key Information Pinning (SPKI) includes public key pinning plus additional information for SSL connections. The additional information can include preferred algorithms.
-
-## Considerations
-
-* With pinned certificates whenever a server updates its certificate, the pinned certificates will also need to be updated
-* With pinned public keys the extracted key may be subject to key refresh policies but much less frequently
-* Servers can become unavailable if pinned objects are set and not updated with the rotated identities. This may require a pinning strategy to be developed.
+    :kb-article """## How it works\r
+Pinning allows for a trusted copy of a certificate or public key to be associated with a server and thus reducing the likelihood of frequently visited sites being subjected to man-in-the-middle attacks. Certificates or public keys can be pinned after a trusted connection has been established or the pinning can be preloaded in an application, which is the preferred method for mobile applications.\r
+\r
+Pinning can take the form of certificate pinning or public key pinning.\r
+\r
+## Forms of Pinning\r
+* Certificate Pinning\r
+Certificate Pinning (CP) allows for the client to verify the X509 certificate with a preloaded certificate. Typically, this is involves storing a hash of the certificate and using the stored hash for comparison to the hash of the certificate submitted during the SSL handshake.\r
+\r
+* Public Key Pinning\r
+Public Key Pinning (PKP) requires the extraction of a public key from server's certificate. The stored public key is compared to the server's presented public key. A public key is expected to rotate less frequently than an X509 certificate and is generally favored over certificate pinning.\r
+\r
+An extension of PKP is Subject Public Key Information Pinning (SPKI) includes public key pinning plus additional information for SSL connections. The additional information can include preferred algorithms.\r
+\r
+## Considerations\r
+\r
+* With pinned certificates whenever a server updates its certificate, the pinned certificates will also need to be updated\r
+* With pinned public keys the extracted key may be subject to key refresh policies but much less frequently\r
+* Servers can become unavailable if pinned objects are set and not updated with the rotated identities. This may require a pinning strategy to be developed.\r
 * The application of this technique within web browser applications has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning) by  popular web browser developers. They now favor certificate analysis via public certificate transparency logs, and the EXPECT-CT HTTP header.""" ;
     :kb-reference :Reference-CertificateAndPublicKeyPinning,
         :Reference-End-to-endCertificatePinning .
@@ -3107,13 +3107,13 @@ An extension of PKP is Subject Public Key Information Pinning (SPKI) includes pu
     rdfs:subClassOf :SupervisedLearning ;
     :d3fend-id "D3A-CLA" ;
     :definition "Classification uses an algorithm to accurately assign test data into specific categories." ;
-    :kb-article """## How it works
-Classification recognizes specific entities within the dataset and attempts to draw some conclusions on how those entities should be labeled or defined. Common classification algorithms are linear classifiers, support vector machines (SVM), decision trees, k-nearest neighbor, and random forest, which are described in more detail below.
-
-
-## References
-Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning).
-
+    :kb-article """## How it works\r
+Classification recognizes specific entities within the dataset and attempts to draw some conclusions on how those entities should be labeled or defined. Common classification algorithms are linear classifiers, support vector machines (SVM), decision trees, k-nearest neighbor, and random forest, which are described in more detail below.\r
+\r
+\r
+## References\r
+Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning).\r
+\r
 Types of Classification in Machine Learning. Machine Learning Mastery. [Link](https://machinelearningmastery.com/types-of-classification-in-machine-learning/).""" .
 
 :Classifying a owl:Class ;
@@ -3130,14 +3130,14 @@ Types of Classification in Machine Learning. Machine Learning Mastery. [Link](ht
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-CSPP" ;
     :definition "Comparing client-server request and response payloads to a baseline profile to identify outliers." ;
-    :kb-article """## How it works
-Profiling request and response payloads across multiple clients to a single server to develop a baseline of their characteristics. May take into account request/response sizes, entropy, frequency, and rhythm. Finally, identify outliers as they may indicate a malicious payload delivery and subsequent server exploitation.
-
-
-## Considerations
-* Collecting metrics to establish a profile can be challenging since user behavior can change easily.
-* Employees may work different hours or inconsistent schedules which will cause false positives.
-* Collection of network activity to generate metrics is a computationally intensive process.
+    :kb-article """## How it works\r
+Profiling request and response payloads across multiple clients to a single server to develop a baseline of their characteristics. May take into account request/response sizes, entropy, frequency, and rhythm. Finally, identify outliers as they may indicate a malicious payload delivery and subsequent server exploitation.\r
+\r
+\r
+## Considerations\r
+* Collecting metrics to establish a profile can be challenging since user behavior can change easily.\r
+* Employees may work different hours or inconsistent schedules which will cause false positives.\r
+* Collection of network activity to generate metrics is a computationally intensive process.\r
 * Users may log into different workstations which may cause false positives.""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingMaliciousPayloads_VectraNetworksInc .
 
@@ -3212,7 +3212,7 @@ Profiling request and response payloads across multiple clients to a single serv
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-CA" ;
     :definition "Cluster analysis or clustering is the task of grouping a set of objects in such a way that objects in the same group (called a cluster) are more similar (in some sense) to each other than to those in other groups (clusters)." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Cluster analysis. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wiki/Cluster_analysis)""" .
 
 :Clustering a owl:Class ;
@@ -3243,10 +3243,10 @@ Cluster analysis. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wiki/Cluste
     rdfs:label "Coefficient of Variation" ;
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-COV" ;
-    :definition """The coefficient of variation (CV), also known as relative standard deviation (RSD), is a standardized measure of dispersion of a probability distribution or frequency distribution.
-
+    :definition """The coefficient of variation (CV), also known as relative standard deviation (RSD), is a standardized measure of dispersion of a probability distribution or frequency distribution.\r
+\r
 The coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean .""" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Coefficient of variation. [Link](https://en.wikipedia.org/wiki/Coefficient_of_variation)""" ;
     :synonym "Relative Standard Deviation",
         "RSD" .
@@ -3387,8 +3387,8 @@ Wikipedia. (n.d.). Coefficient of variation. [Link](https://en.wikipedia.org/wik
             owl:someValuesFrom :ConfigurationResource ] ;
     :d3fend-id "D3-CI" ;
     :definition "Configuration inventory identifies and records the configuration of software and hardware and their components throughout the organization." ;
-    :kb-article """## How it works
-
+    :kb-article """## How it works\r
+\r
 The organization retrieves configuration information through means of SNMP (MIB records), WBEM (CIM records), other protocols, or custom scripts and captures that information in a repository, typically known as a Configuration Management Database (CMDB).\"""" ;
     :kb-reference :Reference-Web-BasedEnterpriseManagement,
         :Reference-Windows-Management-Infrastructure,
@@ -3418,10 +3418,10 @@ The organization retrieves configuration information through means of SNMP (MIB 
             owl:someValuesFrom :LocalAreaNetwork ] ;
     :d3fend-id "D3-CHN" ;
     :definition "A decoy service, system, or environment, that is connected to the enterprise network, and simulates or emulates certain functionality to the network, without exposing full access to a production system." ;
-    :kb-article """## How it works
-Decoy honeypots are deployed within the enterprise environment that emulate certain services or portions of an OS to attract attackers.
-
-## Considerations
+    :kb-article """## How it works\r
+Decoy honeypots are deployed within the enterprise environment that emulate certain services or portions of an OS to attract attackers.\r
+\r
+## Considerations\r
 A connected honeynet provides a tradeoff between emulating certain functionality but not being as sophisticated as an integrated honeynet. The connected honeynet may not provide enough functionality to detect new attack patterns or zero day exploits but could provide enough functionality for specific known vulnerabilities.""" ;
     :kb-reference :Reference-ModificationOfAServerToMimicADeceptionMechanism_AcalvioTechnologiesInc .
 
@@ -3431,7 +3431,7 @@ A connected honeynet provides a tradeoff between emulating certain functionality
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-CBC" ;
     :definition "Connectivity-based clustering is based on connectivity between the elements Clusters are created by building a hierarchical tree-type structure." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Connectivity-Based Clustering. Sarang, P. (2023) in Thinking Data Science. The Springer Series in Applied Machine Learning. Springer, Cham. [Link](https://doi.org/10.1007/978-3-031-02363-7_10)""" ;
     :todo "Should this be connectivity based clustering ?" .
 
@@ -3445,19 +3445,19 @@ Connectivity-Based Clustering. Sarang, P. (2023) in Thinking Data Science. The S
             owl:someValuesFrom :IntranetNetworkTraffic ] ;
     :d3fend-id "D3-CAA" ;
     :definition "Analyzing failed connections in a network to detect unauthorized activity." ;
-    :kb-article """## How it works
-Connection Attempt Analysis in multiple ways.
-
-### Monitoring traffic to unallocated IP space
-One approach looks for failed connection attempts against unallocated IP space. First, network traffic is captured to map out the network to identify network assets as well as unallocated IP space. The map is then used to determine if connection attempts are being made to the unallocated IP space.
-
-### Monitoring for sequentially transmitted traffic
-Another approach passively inspects network traffic with application protocol analyzers observing network activity characteristics such as volume of packets sent/ received, TCP session attributes, and connection information between hosts (start time, source/destination host, services, etc.). Then using pattern matching to identify traffic which appears to be probing for network hosts.
-
-## Considerations
-
-* Implementations that rely on analysis of unallocated IP address space increase in their complexity with network size and decentralized network infrastructure.
-* Inventory of unallocated IP space should should be continuously updated to mitigate the risk of false positives.
+    :kb-article """## How it works\r
+Connection Attempt Analysis in multiple ways.\r
+\r
+### Monitoring traffic to unallocated IP space\r
+One approach looks for failed connection attempts against unallocated IP space. First, network traffic is captured to map out the network to identify network assets as well as unallocated IP space. The map is then used to determine if connection attempts are being made to the unallocated IP space.\r
+\r
+### Monitoring for sequentially transmitted traffic\r
+Another approach passively inspects network traffic with application protocol analyzers observing network activity characteristics such as volume of packets sent/ received, TCP session attributes, and connection information between hosts (start time, source/destination host, services, etc.). Then using pattern matching to identify traffic which appears to be probing for network hosts.\r
+\r
+## Considerations\r
+\r
+* Implementations that rely on analysis of unallocated IP address space increase in their complexity with network size and decentralized network infrastructure.\r
+* Inventory of unallocated IP space should should be continuously updated to mitigate the risk of false positives.\r
 * IPv6 also introduces challenges including IPv6 traffic bypassing IPv4 specific protection systems (ex. firewalls and IDS) and complexity in managing both IPv6 and IPv4 addresses.""" ;
     :kb-reference :Reference-DetectingNetworkReconnaissanceByTrackingIntranetDark-netCommunications_VECTRANETWORKSInc ;
     :synonym "Network Scan Detection" .
@@ -3486,8 +3486,8 @@ Another approach passively inspects network traffic with application protocol an
     rdfs:subClassOf :File,
         :SoftwarePackage ;
     rdfs:isDefinedBy <https://www.docker.com/resources/what-container> ;
-    :definition """A container is a standard unit of software that packages up code and all its dependencies so the application runs quickly and reliably from one computing environment to another. A Docker container image is a lightweight, standalone, executable package of software that includes everything needed to run an application: code, runtime, system tools, system libraries and settings.
-
+    :definition """A container is a standard unit of software that packages up code and all its dependencies so the application runs quickly and reliably from one computing environment to another. A Docker container image is a lightweight, standalone, executable package of software that includes everything needed to run an application: code, runtime, system tools, system libraries and settings.\r
+\r
 Container images become containers at runtime and in the case of Docker containers - images become containers when they run on Docker Engine. Available for both Linux and Windows-based applications, containerized software will always run the same, regardless of the infrastructure. Containers isolate software from its environment and ensure that it works uniformly despite differences for instance between development and staging.""" ;
     rdfs:seeAlso "https://schema.ocsf.io/objects/image" .
 
@@ -3548,7 +3548,7 @@ Container images become containers at runtime and in the case of Docker containe
     rdfs:subClassOf :DeepNeuralNetClassification ;
     :d3fend-id "D3A-CNN" ;
     :definition "A class of artificial neural network most commonly applied to analyze visual imagery.CNNs use a mathematical operation called convolution in place of general matrix multiplication in at least one of their layers." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Convolutional neural network. [Link](https://en.wikipedia.org/wiki/Convolutional_neural_network)""" .
 
 :CopyMemoryFunction a owl:Class ;
@@ -3582,7 +3582,7 @@ Wikipedia. (n.d.). Convolutional neural network. [Link](https://en.wikipedia.org
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-CC" ;
     :definition "Correlation clustering provides a method for clustering a set of objects into the optimum number of clusters without specifying that number in advance." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Correlation clustering. [Link](https://en.wikipedia.org/wiki/Correlation_clustering)""" .
 
 :CramersV a owl:Class,
@@ -3591,7 +3591,7 @@ Wikipedia. (n.d.). Correlation clustering. [Link](https://en.wikipedia.org/wiki/
     rdfs:subClassOf :Correlation ;
     :d3fend-id "D3A-CV" ;
     :definition "Cramér's V (sometimes referred to as Cramér's phi and denoted as φc) is a measure of association between two nominal variables, giving a value between 0 and +1 (inclusive) and is based on Pearson's chi-squared statistic." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Cramér's V. [Link](https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V)""" ;
     :synonym "Cramer's Phi" .
 
@@ -3677,34 +3677,34 @@ Wikipedia. (n.d.). Cramér's V. [Link](https://en.wikipedia.org/wiki/Cram%C3%A9r
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-CCSA" ;
     :definition "Determining which credentials may have been compromised by analyzing the user logon history of a particular system." ;
-    :kb-article """## How it works
-
-#### Memory
-Credentials may be stored in memory for a variety of reasons; on Windows, they may be stored in lsass.exe.  Once a credential dumper like mimikatz runs and dumps the memory of lsass.exe, the credentials of every account logged on since boot are potentially compromised.
-When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.
-
-
-#### Hard disk
-Operating System may cache a certain number of credentials onto the hard disk to use as a source of truth if it cannot contact the credential server.  In many versions of Microsoft Windows, the 10 most recent are cached by default; this setting can be changed in the Microsoft Management Console's Local Security Policy: ```Computer Configuration -> Windows Settings -> Local Policy -> Security Options -> Interactive Logon: Number of previous logons to cache -> 0```  Here we are not concerned with the alteration of the credentials but the fact that they might be read.  If the attacker has physical access to the machine they are unlikely to be stopped from reading files on the filesystem.
-"In the event that the domain controller is unavailable Windows will check the last password hashes that has been cached in order to authenticate the user with the system. These password hashes are cached in the following registry setting:
-HKEY_LOCAL_MACHINE\\SECURITY\\Cache
-Mimikatz can retrieve these hashes if the following command is executed:
-lsadump::cache" [1]
-
-The Registry Hive, HKEY_LOCAL_MACHINE\\SAM, which is stored in the supporting files %systemroot%\\System32\\Config\\{Sam,sam.log,sam.sav}, contains the SAM file.
-
-DC: This is stored in %systemroot%\\ntds\\ntds.dit. (https://www.ultimatewindowssecurity.com/blog/default.aspx?d=10/2017)
-
-Sometimes memory, which contains credentials, could get on the hard disk. Like with hiberfil.sys in Windows.  Equivalent on Linux
-
-
-In Linux, an attacker could read the /etc/shadow file.
-
-Reading from /proc directory: mimipenguin, many others.
-
-## Considerations
-Effective implementation requires identifying any location that could end up containing credentials, and detecting an method of potential access to a source of credential data.
-
+    :kb-article """## How it works\r
+\r
+#### Memory\r
+Credentials may be stored in memory for a variety of reasons; on Windows, they may be stored in lsass.exe.  Once a credential dumper like mimikatz runs and dumps the memory of lsass.exe, the credentials of every account logged on since boot are potentially compromised.\r
+When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.\r
+\r
+\r
+#### Hard disk\r
+Operating System may cache a certain number of credentials onto the hard disk to use as a source of truth if it cannot contact the credential server.  In many versions of Microsoft Windows, the 10 most recent are cached by default; this setting can be changed in the Microsoft Management Console's Local Security Policy: ```Computer Configuration -> Windows Settings -> Local Policy -> Security Options -> Interactive Logon: Number of previous logons to cache -> 0```  Here we are not concerned with the alteration of the credentials but the fact that they might be read.  If the attacker has physical access to the machine they are unlikely to be stopped from reading files on the filesystem.\r
+"In the event that the domain controller is unavailable Windows will check the last password hashes that has been cached in order to authenticate the user with the system. These password hashes are cached in the following registry setting:\r
+HKEY_LOCAL_MACHINE\\SECURITY\\Cache\r
+Mimikatz can retrieve these hashes if the following command is executed:\r
+lsadump::cache" [1]\r
+\r
+The Registry Hive, HKEY_LOCAL_MACHINE\\SAM, which is stored in the supporting files %systemroot%\\System32\\Config\\{Sam,sam.log,sam.sav}, contains the SAM file.\r
+\r
+DC: This is stored in %systemroot%\\ntds\\ntds.dit. (https://www.ultimatewindowssecurity.com/blog/default.aspx?d=10/2017)\r
+\r
+Sometimes memory, which contains credentials, could get on the hard disk. Like with hiberfil.sys in Windows.  Equivalent on Linux\r
+\r
+\r
+In Linux, an attacker could read the /etc/shadow file.\r
+\r
+Reading from /proc directory: mimipenguin, many others.\r
+\r
+## Considerations\r
+Effective implementation requires identifying any location that could end up containing credentials, and detecting an method of potential access to a source of credential data.\r
+\r
 1. https://medium.com/blue-team/preventing-mimikatz-attacks-ed283e7ebdd5""" ;
     :kb-reference :Reference-AllLoginsSinceLastBoot_MITRE,
         :Reference-SystemsAndMethodsForDetectingCredentialTheft_SymantecCorp .
@@ -3749,8 +3749,8 @@ Effective implementation requires identifying any location that could end up con
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-CR" ;
     :definition "Deleting a set of credentials permanently to prevent them from being used to authenticate." ;
-    :kb-article """## How it works
-
+    :kb-article """## How it works\r
+\r
 Management servers with enterprise policies for account management provide the ability remove permissions, accounts, or credentials. Compromised credentials should be revoked to prevent further malicious activity.""" ;
     :kb-reference :Reference-RevokingaPreviouslyIssuedVerifiableCredential-Microsoft .
 
@@ -3764,13 +3764,13 @@ Management servers with enterprise policies for account management provide the a
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-CRO" ;
     :definition "Expiring an existing set of credentials and reissuing a new valid set" ;
-    :kb-article """## How it works
-
-Management servers with enterprise policies for account management provide the ability to change or reset passwords for accounts. Some organizations rotate credentials periodically to limit the risk of stolen credentials.
-
-## Considerations
-
-- When responding to an incident, severity of compromise should be considered to determine what credentials to what accounts should be regenerated
+    :kb-article """## How it works\r
+\r
+Management servers with enterprise policies for account management provide the ability to change or reset passwords for accounts. Some organizations rotate credentials periodically to limit the risk of stolen credentials.\r
+\r
+## Considerations\r
+\r
+- When responding to an incident, severity of compromise should be considered to determine what credentials to what accounts should be regenerated\r
 - If proactively rotating credentials periodically, several factors should be considered to determine the frequency. Also introduces some risk including promoting the creation of weak passwords and poor storage practices for employees and presents challenges in proper tracking.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-EvictionGuidanceforNetworksAffectedbytheSolarWindsandActiveDirectory/M365Compromise-CISA>,
         :Reference-PasswordandKeyRotation-SSH .
@@ -8696,7 +8696,7 @@ Management servers with enterprise policies for account management provide the a
     rdfs:subClassOf :Image-to-ImageTranslationGAN ;
     :d3fend-id "D3A-CYC" ;
     :definition "The Cycle Generative Adversarial Network (CycleGAN) is an approach to training a deep convolutional neural network for image-to-image translation tasks by mapping between input and output images using unpaired dataset." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Esri. (n.d.). How CycleGAN Works. [Link](https://developers.arcgis.com/python/guide/how-cyclegan-works/)""" .
 
 :D3FENDCatalogThing a owl:Class ;
@@ -8760,15 +8760,15 @@ Esri. (n.d.). How CycleGAN Works. [Link](https://developers.arcgis.com/python/gu
             owl:someValuesFrom :DatabaseQuery ] ;
     :d3fend-id "D3-DQSA" ;
     :definition "Analyzing database queries to detect [SQL Injection](https://capec.mitre.org/data/definitions/66.html)." ;
-    :kb-article """## How it works
-
-Some implementations use software hooks to intercept function calls related to database query operations. Other implementations might intercept or collect network traffic. The database query string is then extracted and analyzed with various methods, for example:
-* Detecting specific administrative SQL commands
-* Anomalous sequences of commands when compared to a statistical baseline.
-* Anomalous commands for a given user role.
-
-## Considerations
-
+    :kb-article """## How it works\r
+\r
+Some implementations use software hooks to intercept function calls related to database query operations. Other implementations might intercept or collect network traffic. The database query string is then extracted and analyzed with various methods, for example:\r
+* Detecting specific administrative SQL commands\r
+* Anomalous sequences of commands when compared to a statistical baseline.\r
+* Anomalous commands for a given user role.\r
+\r
+## Considerations\r
+\r
 Some capabilities sanitize queries before permitting them to be transmitted to the database. This incurs risks such altering data in an undesired way or breaking application functionality.""" ;
     :kb-reference :Reference-SystemAndMethodForInternetSecurity_CylanceInc .
 
@@ -8841,10 +8841,10 @@ Some capabilities sanitize queries before permitting them to be transmitted to t
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-DAT" ;
     :definition "Datalog is a declarative logic programming language that is a syntactically a subset of Prolog." ;
-    :kb-article """## How it works
-Datalog generally uses a bottom-up rather than top-down evaluation model. This difference yields significantly different behavior and properties from Prolog. It is often used as a query language for deductive databases. Datalog has been applied to problems in data integration, networking, program analysis, and more.
-
-## References
+    :kb-article """## How it works\r
+Datalog generally uses a bottom-up rather than top-down evaluation model. This difference yields significantly different behavior and properties from Prolog. It is often used as a query language for deductive databases. Datalog has been applied to problems in data integration, networking, program analysis, and more.\r
+\r
+## References\r
 1. Datalog. (2023, April 20). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Datalog)""" .
 
 :DBSCAN a owl:Class,
@@ -8853,7 +8853,7 @@ Datalog generally uses a bottom-up rather than top-down evaluation model. This d
     rdfs:subClassOf :Density-basedClustering ;
     :d3fend-id "D3A-DBS" ;
     :definition "A density-based clustering algorithm that works on the assumption that clusters are dense regions in space separated by regions of lower density." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Analytics Vidhya. (2020, September 15). How DBSCAN Clustering Works: A Comprehensive Guide with Implementations in Python. [Link](https://www.analyticsvidhya.com/blog/2020/09/how-dbscan-clustering-works/#:~:text=DBSCAN%20is%20a%20density%2Dbased,points%20into%20a%20single%20cluster.)""" ;
     :todo "Do we need HBDSCAN and OPTICS as well in density based clustering ?" .
 
@@ -8864,14 +8864,14 @@ Analytics Vidhya. (2020, September 15). How DBSCAN Clustering Works: A Comprehen
     rdfs:subClassOf :ApplicationHardening ;
     :d3fend-id "D3-DCE" ;
     :definition "Removing unreachable or \"dead code\" from compiled source code." ;
-    :kb-article """## How it works
-
-Dead code is code that is considered unreachable by normal program execution. Dead code can be created by adding code under a condition that never evaluates to true. Dead code should be removed since this type of code can produce unexpected results, if accidentally or maliciously forced to execute.
-
-Dead code identification is typically performed by algorithms that implement program flows analysis looking for unreachable code. The dead code is eliminated by instructing compilers to remove the code through compiler flags, i.e., '-fdce' is used for Dead Code Elimination.
-
-## Considerations
-
+    :kb-article """## How it works\r
+\r
+Dead code is code that is considered unreachable by normal program execution. Dead code can be created by adding code under a condition that never evaluates to true. Dead code should be removed since this type of code can produce unexpected results, if accidentally or maliciously forced to execute.\r
+\r
+Dead code identification is typically performed by algorithms that implement program flows analysis looking for unreachable code. The dead code is eliminated by instructing compilers to remove the code through compiler flags, i.e., '-fdce' is used for Dead Code Elimination.\r
+\r
+## Considerations\r
+\r
 Code can also be deemed unreachable for certain run-time conditions. Different deployed systems and environments may contain some code that is unreachable for the given environment. This technique does not consider run-time conditions for unreachable code.""" ;
     :kb-reference :Reference-DeadCodeElimination .
 
@@ -8890,35 +8890,35 @@ Code can also be deemed unreachable for certain run-time conditions. Different d
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-DT" ;
     :definition "Decision tree learning is a supervised learning approach used in statistics, data mining, and machine learning. In this formalism, a classification or regression decision tree is used as a predictive model to draw conclusions about a set of observations." ;
-    :kb-article """## How it works
-A decision tree starts with a root node, which does not have any incoming branches. The outgoing branches from the root node then feed into the internal nodes, also known as decision nodes. Based on the available features, both node types conduct evaluations to form homogenous subsets, which are denoted by leaf nodes, or terminal nodes. The leaf nodes represent all the possible outcomes within the dataset.
-
-## Considerations
-
-While the basic underlying model is that of a decision tree, the decision tree node criteria, and the method for identifying splits varies significantly depending on the learning algorithm selected (e.g., CART, ID3, C4.5, C5.0, CHAID, MARS.)  Extensions like linear and logistic trees can add additional expressiveness as well.
-
-### Verification Approach
-- Use software libraries and tools built for ML where possible, so that the underlying code is verified by prior use.
-- Use standard ML measures for both verification (developmental test) and operational test stages (e.g., accuracy, precision, recall, F1, ROC, confusion matrices.)
-- Assay your data to determine if a decision tree learning method will be effective, and if additional steps or supplemental ML techniques should be incorporated into the solution:
-  - Missing values,
-  - Noise and/or error rates in input data for each feature, or
-  - Decision trees are ideal when decision boundaries can be found that lie along axes of features.
-  - Target class balance; decision tree learning algorithms are especially sensitive to unbalanced target classes.
-- Decision tree learning overfitting may require tuning algorithm hyperparameters such as tree depth, max features used, max leaf nodes, etc.
-- Pruning may result in a more robust model in real-word applications.
-
-### Validation Approach
-- Use operationally relevant data across the range of application's operating environment.
-  - Use a variety of data sets reflecting different operating and environment conditions.
-  - Apply cross-fold validation to see sensitivity to data variation and avoid overfitting operational models.
-- Use SMEs to investigate model errors for problem domain areas or conditions for which the model may underperform and suggest refinements.
-- Incorporate some kind of continuous validation to address concept drift and the need to retrain the model and/or check data quality.
-
-## References
-1. Decision tree learning. (2023, May 30). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Decision_tree_learning)
-2. Decision Trees. (n.d.). In _scikit-learn User Guide 1.2.2_. [Link](https://scikit-learn.org/stable/modules/tree.html)
-3. Concept drift. (2023, April 17). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Concept_drift)
+    :kb-article """## How it works\r
+A decision tree starts with a root node, which does not have any incoming branches. The outgoing branches from the root node then feed into the internal nodes, also known as decision nodes. Based on the available features, both node types conduct evaluations to form homogenous subsets, which are denoted by leaf nodes, or terminal nodes. The leaf nodes represent all the possible outcomes within the dataset.\r
+\r
+## Considerations\r
+\r
+While the basic underlying model is that of a decision tree, the decision tree node criteria, and the method for identifying splits varies significantly depending on the learning algorithm selected (e.g., CART, ID3, C4.5, C5.0, CHAID, MARS.)  Extensions like linear and logistic trees can add additional expressiveness as well.\r
+\r
+### Verification Approach\r
+- Use software libraries and tools built for ML where possible, so that the underlying code is verified by prior use.\r
+- Use standard ML measures for both verification (developmental test) and operational test stages (e.g., accuracy, precision, recall, F1, ROC, confusion matrices.)\r
+- Assay your data to determine if a decision tree learning method will be effective, and if additional steps or supplemental ML techniques should be incorporated into the solution:\r
+  - Missing values,\r
+  - Noise and/or error rates in input data for each feature, or\r
+  - Decision trees are ideal when decision boundaries can be found that lie along axes of features.\r
+  - Target class balance; decision tree learning algorithms are especially sensitive to unbalanced target classes.\r
+- Decision tree learning overfitting may require tuning algorithm hyperparameters such as tree depth, max features used, max leaf nodes, etc.\r
+- Pruning may result in a more robust model in real-word applications.\r
+\r
+### Validation Approach\r
+- Use operationally relevant data across the range of application's operating environment.\r
+  - Use a variety of data sets reflecting different operating and environment conditions.\r
+  - Apply cross-fold validation to see sensitivity to data variation and avoid overfitting operational models.\r
+- Use SMEs to investigate model errors for problem domain areas or conditions for which the model may underperform and suggest refinements.\r
+- Incorporate some kind of continuous validation to address concept drift and the need to retrain the model and/or check data quality.\r
+\r
+## References\r
+1. Decision tree learning. (2023, May 30). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Decision_tree_learning)\r
+2. Decision Trees. (n.d.). In _scikit-learn User Guide 1.2.2_. [Link](https://scikit-learn.org/stable/modules/tree.html)\r
+3. Concept drift. (2023, April 17). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Concept_drift)\r
 4. 8 Concept Drift Detection Methods. (n.d.). In _Aporia Learning Center_. [Link](https://www.aporia.com/learn/data-drift/concept-drift-detection-methods/)""" .
 
 :DecisionTreeRegression a owl:Class,
@@ -8927,7 +8927,7 @@ While the basic underlying model is that of a decision tree, the decision tree n
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-DTR" ;
     :definition "Decision Trees Regression is asupervised learning method with the goal  to create a model that predicts the value of a target variable by learning simple decision rules inferred from the data features" ;
-    :kb-article """## References
+    :kb-article """## References\r
 scikit-learn. (n.d.). Decision Trees. [Link](https://scikit-learn.org/stable/modules/tree.html#tree)""" .
 
 :DecoyArtifact a owl:Class ;
@@ -8959,8 +8959,8 @@ scikit-learn. (n.d.). Decision Trees. [Link](https://scikit-learn.org/stable/mod
     :d3fend-id "D3-DE" ;
     :definition "A Decoy Environment comprises hosts and networks for the purposes of deceiving an attacker." ;
     :enables :Deceive ;
-    :kb-article """## Technique Overview
-
+    :kb-article """## Technique Overview\r
+\r
 Systems in a decoy environment are typically configured so that some detectable means of communication does not have any legitimate business purpose.  Any communication via these means should be logged and analyzed to find potential indicators of compromise for a possible past or future attack against other systems.""" ;
     :synonym "Honeypot" .
 
@@ -8974,14 +8974,14 @@ Systems in a decoy environment are typically configured so that some detectable 
             owl:someValuesFrom :File ] ;
     :d3fend-id "D3-DF" ;
     :definition "A file created for the purposes of deceiving an adversary." ;
-    :kb-article """## How it works
-The decoy file is made available as a local or network resource. Accesses to the file may be monitored. The files may be configurations, documents, executables, or other file types.
-
-
-## Considerations
-Properties of the file such as cryptographic checksums, file creation date, file modified date, file size, file owner etc may be modified to improve the credibility of the file.
-
-## Example
+    :kb-article """## How it works\r
+The decoy file is made available as a local or network resource. Accesses to the file may be monitored. The files may be configurations, documents, executables, or other file types.\r
+\r
+\r
+## Considerations\r
+Properties of the file such as cryptographic checksums, file creation date, file modified date, file size, file owner etc may be modified to improve the credibility of the file.\r
+\r
+## Example\r
 * A CSV file with decoy user credentials is placed on a system. The system or network is then monitored to detect any accesses to the decoy files.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-SupplyChainCyber-deception_Cymmetria,Inc.>,
         :Reference-OpenSourceIntelligenceDeceptions_IllusiveNetworksLtd,
@@ -8998,19 +8998,19 @@ Properties of the file such as cryptographic checksums, file creation date, file
             owl:someValuesFrom :NetworkResource ] ;
     :d3fend-id "D3-DNR" ;
     :definition "Deploying a network resource for the purposes of deceiving an adversary." ;
-    :kb-article """## How it works
-Decoy network resources are deployed to web application servers, network file shares, or other network based sharing services.
-
-A "honeypot" may serve a variety of decoy network resources.
-
-## Considerations
-
-* Developing a deployment and placement strategy for the decoy network resource.
-* Personnel responsible for creation of decoy networks should consider the potential for resource exhaustion through denial of service attacks.
-
-## Examples
-* Honeypots are typically used to mimic a known system with fake vulnerabilities. This may attract attackers to the honeypot.
-* Decoy accounts are also used to scan for attempted logins. The decoy accounts can provide security analysts with the attacker's potential intents and strategies.
+    :kb-article """## How it works\r
+Decoy network resources are deployed to web application servers, network file shares, or other network based sharing services.\r
+\r
+A "honeypot" may serve a variety of decoy network resources.\r
+\r
+## Considerations\r
+\r
+* Developing a deployment and placement strategy for the decoy network resource.\r
+* Personnel responsible for creation of decoy networks should consider the potential for resource exhaustion through denial of service attacks.\r
+\r
+## Examples\r
+* Honeypots are typically used to mimic a known system with fake vulnerabilities. This may attract attackers to the honeypot.\r
+* Decoy accounts are also used to scan for attempted logins. The decoy accounts can provide security analysts with the attacker's potential intents and strategies.\r
 * Tarpits are used to monitor unallocated IP space for unauthorized network activity.""" ;
     :kb-reference :Reference-AutomaticallyGeneratingNetworkResourceGroupsAndAssigningCustomizedDecoyPoliciesThereto_IllusiveNetworksLtd,
         :Reference-Deception-BasedResponsesToSecurityAttacks_CrowdstrikeInc,
@@ -9028,7 +9028,7 @@ A "honeypot" may serve a variety of decoy network resources.
     :d3fend-id "D3-DO" ;
     :definition "A Decoy Object is created and deployed for the purposes of deceiving attackers." ;
     :enables :Deceive ;
-    :kb-article """## Technique Overview
+    :kb-article """## Technique Overview\r
 Decoy objects are typically configured with detectable means of communication but do not have any legitimate business purpose. Any communication via or to these objects should be logged and analyzed to find potential indicators of compromise for a possible past or future attack against other systems.""" ;
     :synonym "Lure" .
 
@@ -9042,11 +9042,11 @@ Decoy objects are typically configured with detectable means of communication bu
             owl:someValuesFrom :User ] ;
     :d3fend-id "D3-DP" ;
     :definition "Establishing a fake online identity to misdirect, deceive, and or interact with adversaries." ;
-    :kb-article """## How it works
-A false online identity is created for the purposes of interacting with adversaries in a direct or indirect manner. This includes the associated email addresses, social media accounts, and other online communication profiles.
-
-## Considerations
-* Include phone numbers and online social profiles as well as automatically or manually responding to contact made to the persona to improve realism.
+    :kb-article """## How it works\r
+A false online identity is created for the purposes of interacting with adversaries in a direct or indirect manner. This includes the associated email addresses, social media accounts, and other online communication profiles.\r
+\r
+## Considerations\r
+* Include phone numbers and online social profiles as well as automatically or manually responding to contact made to the persona to improve realism.\r
 * Continuous updating and managing the decoy personas and online activity streams to ensure personas do not become stale and outdated.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-DecoyAndDeceptiveDataObjectTechnology_Cymmetria,Inc.>,
         :Reference-DecoyPersonasForSafeguardingOnlineIdentityUsingDeception_ .
@@ -9058,12 +9058,12 @@ A false online identity is created for the purposes of interacting with adversar
     rdfs:subClassOf :DecoyObject ;
     :d3fend-id "D3-DPR" ;
     :definition "Issuing publicly released media to deceive adversaries." ;
-    :kb-article """## How it works
-Publicly released media includes press release, videos, or other marketing collateral. The media may include URLs, points of contact, or other identifiers to entice interaction from adversaries.
-
-## Considerations
-* Information used in decoy public released media must contain enough realism to deceive and provide interaction from adversaries.
-* Continuous development, creation, and distribution of media and identifiers are needed to ensure adversary interaction continues over time.
+    :kb-article """## How it works\r
+Publicly released media includes press release, videos, or other marketing collateral. The media may include URLs, points of contact, or other identifiers to entice interaction from adversaries.\r
+\r
+## Considerations\r
+* Information used in decoy public released media must contain enough realism to deceive and provide interaction from adversaries.\r
+* Continuous development, creation, and distribution of media and identifiers are needed to ensure adversary interaction continues over time.\r
 * Decoy public releases could be placed on platforms with different degrees of ownership, including entirely enterprise-owned infrastructure, IaaS, and SaaS (including social applications). Platforms that are not entirely enterprise-owned may be more likely to gather information""" ;
     :kb-reference :Reference-MockAttackCybersecurityTrainingSystemAndMethods_WOMBATSECURITYTECHNOLOGIESInc .
 
@@ -9077,12 +9077,12 @@ Publicly released media includes press release, videos, or other marketing colla
             owl:someValuesFrom :AccessToken ] ;
     :d3fend-id "D3-DST" ;
     :definition "An authentication token created for the purposes of deceiving an adversary." ;
-    :kb-article """## How it works
-Usage of decoy session tokens may be monitored to track attacker behavior or otherwise control the beliefs of the attacker.
-
-## Considerations
-* Interaction and activity with the decoy session token must be constantly monitored and analyzed to detect unauthorized activity.
-* Session tokens are typically short-lived and therefore the decoy must be continuously updated to provide the appearance of it being used in the production environment.
+    :kb-article """## How it works\r
+Usage of decoy session tokens may be monitored to track attacker behavior or otherwise control the beliefs of the attacker.\r
+\r
+## Considerations\r
+* Interaction and activity with the decoy session token must be constantly monitored and analyzed to detect unauthorized activity.\r
+* Session tokens are typically short-lived and therefore the decoy must be continuously updated to provide the appearance of it being used in the production environment.\r
 * Automated tools can assist with maintenance and updates by automatically adjusting the decoy session token and environment to mimic the production environment.""" ;
     :kb-reference :Reference-DecoyAndDeceptiveDataObjectTechnology_CymmetriaInc .
 
@@ -9096,15 +9096,15 @@ Usage of decoy session tokens may be monitored to track attacker behavior or oth
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-DUC" ;
     :definition "A Credential created for the purpose of deceiving an adversary." ;
-    :kb-article """## How it works
-A detection analytic is developed to determine when a user uses decoy credentials. Subsequent actions by that user may be monitored or controlled by the defender.
-
-A credential may be:
- * Domain username and password
- * Local system username and password
-
-## Considerations
-* Decoy credentials should be integrated with a larger decoy environment to ensure that when decoy credentials are compromised, the credentials are used to interact with a decoy asset that is being monitored.
+    :kb-article """## How it works\r
+A detection analytic is developed to determine when a user uses decoy credentials. Subsequent actions by that user may be monitored or controlled by the defender.\r
+\r
+A credential may be:\r
+ * Domain username and password\r
+ * Local system username and password\r
+\r
+## Considerations\r
+* Decoy credentials should be integrated with a larger decoy environment to ensure that when decoy credentials are compromised, the credentials are used to interact with a decoy asset that is being monitored.\r
 * Continuous maintenance and updates are needed to ensure the legitimacy of the larger decoy environment and specifically the assets that utilize the decoy credentials.""" ;
     :kb-reference :Reference-DecoyAndDeceptiveDataObjectTechnology_CymmetriaInc,
         :Reference-DecoyNetwork-BasedServiceForDeceivingAttackers-AmazonTechnologies,
@@ -9116,7 +9116,7 @@ A credential may be:
     rdfs:subClassOf :ImageSynthesisGAN ;
     :d3fend-id "D3A-DCG" ;
     :definition "Deep Convolutional GAN (DCGAN) uses convolutional and convolutional-transpose layers in the generator and discriminator, respectively." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Analytics Vidhya. (2021). Deep Convolutional Generative Adversarial Network (DCGAN) for Beginners. [Link](https://www.analyticsvidhya.com/blog/2021/07/deep-convolutional-generative-adversarial-network-dcgan-for-beginners/)""" ;
     :synonym "DCGAN" .
 
@@ -9126,7 +9126,7 @@ Analytics Vidhya. (2021). Deep Convolutional Generative Adversarial Network (DCG
     rdfs:subClassOf :ArtificialNeuralNetClassification ;
     :d3fend-id "D3A-DNNC" ;
     :definition "A deep neural network (DNN) is an artificial neural network (ANN) with multiple layers between the input and output layers. There are different types of neural networks but they always consist of the same components: neurons, synapses, weights, biases, and functions. These components as a whole function similarly to a human brain, and can be trained like any other ML algorithm" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Deep learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Deep_learning).""" .
 
 :DeepQ-learning a owl:Class,
@@ -9135,7 +9135,7 @@ Deep learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Deep_learning).""
     rdfs:subClassOf :Q-Learning ;
     :d3fend-id "D3A-DQL" ;
     :definition "Uses a deep convolutional neural network, with layers of tiled convolutional filters to mimic the effects of receptive fields." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Q-learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Q-learning#Deep_Q-learning).""" .
 
 :DefaultUserAccount a owl:Class ;
@@ -9257,7 +9257,7 @@ Q-learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Q-learning#Deep_Q-l
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-DBC" ;
     :definition "Density-based clustering connects areas of high example density into clusters. This allows for arbitrary-shaped distributions as long as dense areas can be connected." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Google Developers. (n.d.). Clustering algorithms. [Link](https://developers.google.com/machine-learning/clustering/clustering-algorithms)""" .
 
 :Density-weightedMethod a owl:Class,
@@ -9266,7 +9266,7 @@ Google Developers. (n.d.). Clustering algorithms. [Link](https://developers.goog
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-DWM" ;
     :definition "An Actvie Learning technique that uses a density estimate meta-parameter to avoid sampling sparsely populated regions of the feature space and can be based parametrically or from a parameter free model." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :DeonticLogic a owl:Class,
@@ -9275,7 +9275,7 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-DL" ;
     :definition "Deontic logic addresses the modality of obligations and norms; i.e., the modality of morality." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Deontic logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Deontic_logic)""" .
 
 :Dependency a owl:Class ;
@@ -9297,12 +9297,12 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-DL" ;
     :definition "A description logic (DL) is a form of logic usually more expressive than propositional logic but less expressive than first-order logic." ;
-    :kb-article """## How it works
-The core reasoning problems for description logics (DLs) are (usually) decidable, and efficient decision procedures have been designed and implemented for these problems. There are general, spatial, temporal, spatiotemporal, and fuzzy description logics, and each description logic features a different balance between expressive power and reasoning complexity by supporting different sets of mathematical constructors.
-
-DLs are used in artificial intelligence to describe and reason about the relevant concepts of an application domain (known as terminological knowledge). It is of particular importance in providing a logical formalism for ontologies and the Semantic Web: the Web Ontology Language (OWL) and its profiles are based on DLs.
-
-## References
+    :kb-article """## How it works\r
+The core reasoning problems for description logics (DLs) are (usually) decidable, and efficient decision procedures have been designed and implemented for these problems. There are general, spatial, temporal, spatiotemporal, and fuzzy description logics, and each description logic features a different balance between expressive power and reasoning complexity by supporting different sets of mathematical constructors.\r
+\r
+DLs are used in artificial intelligence to describe and reason about the relevant concepts of an application domain (known as terminological knowledge). It is of particular importance in providing a logical formalism for ontologies and the Semantic Web: the Web Ontology Language (OWL) and its profiles are based on DLs.\r
+\r
+## References\r
 1. Description logic. (2023, April 16). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Description_logic)""" .
 
 :DescriptiveStatistics a owl:Class,
@@ -9311,7 +9311,7 @@ DLs are used in artificial intelligence to describe and reason about the relevan
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-DS" ;
     :definition "Descriptive statistics provide simple summaries about the sample and about the observations that have been made." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/Descriptive_statistics)""" .
 
 :DeserializationFunction a owl:Class ;
@@ -9401,7 +9401,7 @@ Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-DR" ;
     :definition "Dimensionality reduction is a key technique within unsupervised learning. It compresses the data by finding a smaller, different set of variables that capture what matters most in the original features, while minimizing the loss of information." ;
-    :kb-article """## References
+    :kb-article """## References\r
 O'Reilly Media. (n.d.). Chapter 7. Machine Learning and Security: Protecting Systems with Data and Algorithms. [Link](https://www.oreilly.com/library/view/machine-learning-and/9781492073048/ch07.html)""" .
 
 :Directory a owl:Class ;
@@ -9439,7 +9439,7 @@ O'Reilly Media. (n.d.). Chapter 7. Machine Learning and Security: Protecting Sys
     rdfs:subClassOf :MultivariateAnalysis ;
     :d3fend-id "D3A-DA" ;
     :definition "Discriminant analysis attempts to establish whether a set of variables can be used to distinguish between two or more groups of cases." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki/Multivariate_statistics)""" .
 
 :DiskEncryption a owl:Class,
@@ -9486,7 +9486,7 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-DBC" ;
     :definition "Distribution-based clustering creates and groups data points based on their likely hood of belonging to the same probability distribution (Gaussian, Binomial, etc.) in the data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 AnalytixLabs. (n.d.). Types of Clustering Algorithms. [Link](https://www.analytixlabs.co.in/blog/types-of-clustering-algorithms/#:~:text=Distribution-Based)""" .
 
 :DistributionProperties a owl:Class,
@@ -9495,7 +9495,7 @@ AnalytixLabs. (n.d.). Types of Clustering Algorithms. [Link](https://www.analyti
     rdfs:subClassOf :DescriptiveStatistics ;
     :d3fend-id "D3A-DP" ;
     :definition "The properties derived from a probability distribution." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wiki/Probability_distribution)""" ;
     :todo "Might be lots more to add in this tree" .
 
@@ -9505,7 +9505,7 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
     rdfs:subClassOf :ANN-basedClustering ;
     :d3fend-id "D3A-DBC" ;
     :definition "DNNs serve for clustering as mappings to better representations. The features of these representations can be drawn from different layers of the network or even from several layers." ;
-    :kb-article """## References
+    :kb-article """## References\r
 OpenReview. (n.d.). Unsupervised Clustering using Pseudo Ensemble Models. [Link](https://openreview.net/pdf?id=B1eT9VMgOX)""" .
 
 :DNSAllowlisting a :NetworkIsolation,
@@ -9531,22 +9531,22 @@ OpenReview. (n.d.). Unsupervised Clustering using Pseudo Ensemble Models. [Link]
             owl:someValuesFrom :DNSNetworkTraffic ] ;
     :d3fend-id "D3-DNSDL" ;
     :definition "Blocking DNS Network Traffic based on criteria such as IP address, domain name, or DNS query type." ;
-    :kb-article """## How it works
-Rules are implemented that filter DNS queries using criteria such as:
-- Client subnet
-- Type of network protocol used in query
-- Fully qualified domain name (FQDN) of record in the query
-- DNS Server IP address that received the DNS request
-- Type of DNS record being queried
-- Time of day the query is received
-- Size of the response
-
-For example, a DNS policy can be created for blocking DNS queries for FQDNs that have been identified as unauthorized.
-
-## Considerations
-- Implementation considerations for DNS filtering policies to avoid over-blocking or under-blocking domains.
-- Continuous maintenance of unauthorized domain lists is needed to keep up to date with possible site content changes.
-- File sharing or content delivery networks may require other filtering techniques that are more fine-grained (URL blocking).
+    :kb-article """## How it works\r
+Rules are implemented that filter DNS queries using criteria such as:\r
+- Client subnet\r
+- Type of network protocol used in query\r
+- Fully qualified domain name (FQDN) of record in the query\r
+- DNS Server IP address that received the DNS request\r
+- Type of DNS record being queried\r
+- Time of day the query is received\r
+- Size of the response\r
+\r
+For example, a DNS policy can be created for blocking DNS queries for FQDNs that have been identified as unauthorized.\r
+\r
+## Considerations\r
+- Implementation considerations for DNS filtering policies to avoid over-blocking or under-blocking domains.\r
+- Continuous maintenance of unauthorized domain lists is needed to keep up to date with possible site content changes.\r
+- File sharing or content delivery networks may require other filtering techniques that are more fine-grained (URL blocking).\r
 - Access to malicious websites or other network resources directly by IP instead of by DNS record, or after alteration of local DNS hosts file, may not result in DNS network traffic.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "DNS Blacklisting" .
@@ -9576,8 +9576,8 @@ For example, a DNS policy can be created for blocking DNS queries for FQDNs that
     rdfs:label "DNS Server" ;
     rdfs:subClassOf :Server ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Name_server> ;
-    :definition """A Domain Name System (DNS) name server is a kind of name server.  Domain names are one of the two principal namespaces of the Internet. The most important function of DNS servers is the translation (resolution) of human-memorable domain names and hostnames into the corresponding numeric Internet Protocol (IP) addresses, the second principal name space of the Internet which is used to identify and locate computer systems and resources on the Internet. (en).
-
+    :definition """A Domain Name System (DNS) name server is a kind of name server.  Domain names are one of the two principal namespaces of the Internet. The most important function of DNS servers is the translation (resolution) of human-memorable domain names and hostnames into the corresponding numeric Internet Protocol (IP) addresses, the second principal name space of the Internet which is used to identify and locate computer systems and resources on the Internet. (en).\r
+\r
 More generally, a name server is a computer application that implements a network service for providing responses to queries against a directory service. It translates an often humanly meaningful, text-based identifier to a system-internal, often numeric identification or addressing component. This service is performed by the server in response to a service protocol request.""" .
 
 :DNSTrafficAnalysis a :NetworkTrafficAnalysis,
@@ -9593,18 +9593,18 @@ More generally, a name server is a computer application that implements a networ
             owl:someValuesFrom :DNSLookup ] ;
     :d3fend-id "D3-DNSTA" ;
     :definition "Analysis of domain name metadata, including name and DNS records, to determine whether the domain is likely to resolve to an undesirable host." ;
-    :kb-article """## How it works
-This technique can be accomplished in a number of ways.
-
-* One example analytic determines whether or not a domain name was generated with an algorithm. Domain generation algorithms (DGAs) are sometimes used to create a domain name automatically  that will resolve to C2 infrastructure, without directly coding the domains in question into the malicious code.
-* Another method analyzes information about domains that have been visited, including whether a domain name is longer than a common length,  if a dynamic DNS domain was visited, if a fast-flux domain was visited, and if a recently created domain was visited. These factors are used to develop a score and if that score is over a certain threshold, an alert is generated.
-* Collected malware samples can be executed in a virtual environment to identify network domains that are connected to during execution. The network domains are then generated into signatures to identity bad domains for other hosts.
-
-This technique does not check for content hosted at the domain.
-
-## Considerations
-
-* DNS produces a large amount of traffic which can be resource-intensive to analyze in real time.
+    :kb-article """## How it works\r
+This technique can be accomplished in a number of ways.\r
+\r
+* One example analytic determines whether or not a domain name was generated with an algorithm. Domain generation algorithms (DGAs) are sometimes used to create a domain name automatically  that will resolve to C2 infrastructure, without directly coding the domains in question into the malicious code.\r
+* Another method analyzes information about domains that have been visited, including whether a domain name is longer than a common length,  if a dynamic DNS domain was visited, if a fast-flux domain was visited, and if a recently created domain was visited. These factors are used to develop a score and if that score is over a certain threshold, an alert is generated.\r
+* Collected malware samples can be executed in a virtual environment to identify network domains that are connected to during execution. The network domains are then generated into signatures to identity bad domains for other hosts.\r
+\r
+This technique does not check for content hosted at the domain.\r
+\r
+## Considerations\r
+\r
+* DNS produces a large amount of traffic which can be resource-intensive to analyze in real time.\r
 * If a server is compromised, for example, as part of a watering hole attack, but the DNS information pointing to that server is not altered, this technique would not catch such an incident.""" ;
     :kb-reference :Reference-DomainAgeRegistrationAlert_IncRapid7IncRAPID7Inc,
         :Reference-HeuristicBotnetDetection_PaloAltoNetworksInc,
@@ -9702,22 +9702,22 @@ This technique does not check for content hosted at the domain.
             owl:someValuesFrom :HardwareDriver ] ;
     :d3fend-id "D3-DLIC" ;
     :definition "Ensuring the integrity of drivers loaded during initialization of the operating system." ;
-    :kb-article """## How it works
-This technique can be accomplished in a number of ways:
-
-* A kernel level security agent installed on a host machine ensures that the driver associated with the agent is first in the initialization order. A dependent DLL associated with the driver is configured to be processed before other dependent DLLs and executes a number of operations to ensure the driver associated with the security agent is initialized first.
-
-* Kernel components can be signed by a certificate obtained by a third party to verify the source of the component and whether it has been modified. When signed, the component will include a signature block implemented as a hash value of the component header and can also include a certificate chain. The signature and certificate data are typically added before the kernel component is distributed to the public.
-
-
-## Considerations
-
-* The private keys to sign certificates as reputable companies have been stolen in the past -- in cases such as where certificates from Adobe, Realtek, and JMicron have been used to sign malicious executables. (Source: https://resources.infosecinstitute.com/cybercrime-exploits-digital-certificates/#gref)
-
-* Trusted Root Certificate Authorities have been compromised, yielding the ability to use the compromised keys to generate certificates with an arbitrary company name.
-
-* It may not be difficult for an attacker to start an organization which can obtain a signed certificate.
-
+    :kb-article """## How it works\r
+This technique can be accomplished in a number of ways:\r
+\r
+* A kernel level security agent installed on a host machine ensures that the driver associated with the agent is first in the initialization order. A dependent DLL associated with the driver is configured to be processed before other dependent DLLs and executes a number of operations to ensure the driver associated with the security agent is initialized first.\r
+\r
+* Kernel components can be signed by a certificate obtained by a third party to verify the source of the component and whether it has been modified. When signed, the component will include a signature block implemented as a hash value of the component header and can also include a certificate chain. The signature and certificate data are typically added before the kernel component is distributed to the public.\r
+\r
+\r
+## Considerations\r
+\r
+* The private keys to sign certificates as reputable companies have been stolen in the past -- in cases such as where certificates from Adobe, Realtek, and JMicron have been used to sign malicious executables. (Source: https://resources.infosecinstitute.com/cybercrime-exploits-digital-certificates/#gref)\r
+\r
+* Trusted Root Certificate Authorities have been compromised, yielding the ability to use the compromised keys to generate certificates with an arbitrary company name.\r
+\r
+* It may not be difficult for an attacker to start an organization which can obtain a signed certificate.\r
+\r
 * A root certificate authority (CA) whose certificate is trusted in the verification logic could generate incorrect certificates, if they are lax or have ulterior motives.""" ;
     :kb-reference :Reference-IntegrityAssuranceThroughEarlyLoadingInTheBootPhase_CrowdstrikeInc,
         :Reference-ProtectedComputingEnvironment_MicrosoftTechnologyLicensingLLC .
@@ -9728,7 +9728,7 @@ This technique can be accomplished in a number of ways:
     rdfs:subClassOf :Model-basedReinforcementLearning ;
     :d3fend-id "D3A-DQ" ;
     :definition "A Dyna-Q agent combines acting, learning, and planning." ;
-    :kb-article """## References
+    :kb-article """## References\r
 CompNeuro Neuromatch Academy Tutorials. [Link](https://compneuro.neuromatch.io/tutorials/W3D4_ReinforcementLearning/student/W3D4_Tutorial4.html)""" .
 
 :DynamicAnalysis a :FileAnalysis,
@@ -9744,16 +9744,16 @@ CompNeuro Neuromatch Academy Tutorials. [Link](https://compneuro.neuromatch.io/t
             owl:someValuesFrom :ExecutableFile ] ;
     :d3fend-id "D3-DA" ;
     :definition "Executing or opening a file in a synthetic \"sandbox\" environment to determine if the file is a malicious program or if the file exploits another program such as a document reader." ;
-    :kb-article """## How it works
-Analyzing the interaction of a piece of code with a system while the code is being executed in a controlled environment such as a sandbox, virtual machine, or simulator. This exposes the natural behavior of the piece of code without requiring the code to be disassembled.
-
-## Considerations
- * Malware often detects a fake environment, then changes its behavior accordingly. For example, it could detect that the system clock is being sped up in an effort to get it to execute commands that it would normally only execute at a later time, or that the hardware manufacturer of the machine is a virtualization provider.
- * Malware can attempt to determine if it is being debugged, and change its behavior accordingly.
- * For maximum fidelity, the simulated and real environments should be as similar as possible because the malware could perform differently in different environments.
- * Sometimes the malware behavior is triggered only under certain conditions (on a specific system date, after a certain time, or after it is sent a specific command) and can't be detected through a short execution in a virtual environment.
-
-## Implementations
+    :kb-article """## How it works\r
+Analyzing the interaction of a piece of code with a system while the code is being executed in a controlled environment such as a sandbox, virtual machine, or simulator. This exposes the natural behavior of the piece of code without requiring the code to be disassembled.\r
+\r
+## Considerations\r
+ * Malware often detects a fake environment, then changes its behavior accordingly. For example, it could detect that the system clock is being sped up in an effort to get it to execute commands that it would normally only execute at a later time, or that the hardware manufacturer of the machine is a virtualization provider.\r
+ * Malware can attempt to determine if it is being debugged, and change its behavior accordingly.\r
+ * For maximum fidelity, the simulated and real environments should be as similar as possible because the malware could perform differently in different environments.\r
+ * Sometimes the malware behavior is triggered only under certain conditions (on a specific system date, after a certain time, or after it is sent a specific command) and can't be detected through a short execution in a virtual environment.\r
+\r
+## Implementations\r
 * [Cuckoo Sandbox](https://cuckoosandbox.org)""" ;
     :kb-reference :Reference-MalwareAnalysisSystem_PaloAltoNetworksInc,
         :Reference-UseOfAnApplicationControllerToMonitorAndControlSoftwareFileAndApplicationEnvironments_SophosLtd ;
@@ -9799,13 +9799,13 @@ Analyzing the interaction of a piece of code with a system while the code is bei
             owl:someValuesFrom :Email ] ;
     :d3fend-id "D3-EF" ;
     :definition "Filtering incoming email traffic based on specific criteria." ;
-    :kb-article """## How it works
-
-Mail filters can be implemented to scan inbound email messages at the initial SMTP connection stage to detect and reject email containing spam and malware.
-
-This technique is distinct from d3f:EmailDeletion because it prevents an email from reaching an user's inbox. This technique can also be used for outbound email traffic.
-
-## Considerations
+    :kb-article """## How it works\r
+\r
+Mail filters can be implemented to scan inbound email messages at the initial SMTP connection stage to detect and reject email containing spam and malware.\r
+\r
+This technique is distinct from d3f:EmailDeletion because it prevents an email from reaching an user's inbox. This technique can also be used for outbound email traffic.\r
+\r
+## Considerations\r
 * The effectiveness of mail filters depend on the completeness of the filter policies""" ;
     :kb-reference :Reference-SystemAndMethodForProvidingAnonymousRemailingAndFilteringOfElectronicMail_Nokia .
 
@@ -9822,16 +9822,16 @@ This technique is distinct from d3f:EmailDeletion because it prevents an email f
             owl:someValuesFrom :MailServer ] ;
     :d3fend-id "D3-ER" ;
     :definition "The email removal technique deletes email files from system storage." ;
-    :kb-article """## How it works
-
-Email removal is a technique that can be used to prevent a user from executing malware or responding to phishing attempts. Security software or users themselves may detect malicious or suspicious email in a local or remote mail folder email and then employ this technique.
-
-## Considerations
-
-For email that needs to be removed, an infosec organization may choose to take additional follow-up actions (such as blocking the sources or notifying providers), rather than only relying on email deletion.
-
-For the case where users detect likely suspicious email files, the organization should consider implementing a means for reporting these emails to their infosec organization.
-
+    :kb-article """## How it works\r
+\r
+Email removal is a technique that can be used to prevent a user from executing malware or responding to phishing attempts. Security software or users themselves may detect malicious or suspicious email in a local or remote mail folder email and then employ this technique.\r
+\r
+## Considerations\r
+\r
+For email that needs to be removed, an infosec organization may choose to take additional follow-up actions (such as blocking the sources or notifying providers), rather than only relying on email deletion.\r
+\r
+For the case where users detect likely suspicious email files, the organization should consider implementing a means for reporting these emails to their infosec organization.\r
+\r
 Email files may propagate through many storage systems across the an organization's systems over time, so early detection and blocking helps avoid residual, latent stores of malicous email content in the enterprise.""" ;
     :kb-reference :Reference-SystemAndMethodForScanningRemoteServicesToLocateStoredObjectsWithMalware ;
     :synonym "Email Deletion" .
@@ -9905,13 +9905,13 @@ Email files may propagate through many storage systems across the an organizatio
             owl:someValuesFrom :NetworkNode ] ;
     :d3fend-id "D3-EHB" ;
     :definition "Monitoring the security status of an endpoint by sending periodic messages with health status, where absence of a response may indicate that the endpoint has been compromised." ;
-    :kb-article """## How it works
-Endpoints are configured to periodically generate and transmit a secure heartbeat that is delivered on a configured schedule and provides endpoint status information. Status information can include software details (version, configuration, etc), endpoint identification (MAC, IP address, machine ID) or other hardware/software configuration information. Interruption of the heartbeat can signal that the endpoint has been compromised.
-
-## Considerations
-* Security of heartbeat messages to ensure message integrity
-* Disappearance of the heartbeat could simply mean that the endpoint is powered off or intentionally disconnected from the network. Therefore other criteria may need to be used to accurately detect endpoint compromise.
-* Attacker presence on the machine may leave the heartbeat intact.
+    :kb-article """## How it works\r
+Endpoints are configured to periodically generate and transmit a secure heartbeat that is delivered on a configured schedule and provides endpoint status information. Status information can include software details (version, configuration, etc), endpoint identification (MAC, IP address, machine ID) or other hardware/software configuration information. Interruption of the heartbeat can signal that the endpoint has been compromised.\r
+\r
+## Considerations\r
+* Security of heartbeat messages to ensure message integrity\r
+* Disappearance of the heartbeat could simply mean that the endpoint is powered off or intentionally disconnected from the network. Therefore other criteria may need to be used to accurately detect endpoint compromise.\r
+* Attacker presence on the machine may leave the heartbeat intact.\r
 * An attacker may determine the format of the heartbeat and continue to send it even after the machine is compromised.""" ;
     :kb-reference :Reference-IntrusionDetectionUsingAHeartbeat_SophosLtd ;
     :synonym "Endpoint Health Telemetry" .
@@ -9928,7 +9928,7 @@ Endpoints are configured to periodically generate and transmit a secure heartbea
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-EL" ;
     :definition "In statistics and machine learning, ensemble methods use multiple learning algorithms to obtain better predictive performance than could be obtained from any of the constituent learning algorithms alone" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :EpistemicLogic a owl:Class,
@@ -9937,7 +9937,7 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-EL" ;
     :definition "Epistemic logic addresses modalities of knowledge; i.e., the certainty of sentences." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Epistemic logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Epistemic_logic)""" ;
     :synonym "Epistemic Modal Logic" .
 
@@ -9947,16 +9947,16 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :LogicalRules ;
     :d3fend-id "D3A-EM" ;
     :definition "Equivalence matching is matching two values, which may be bound to variables, to see if they are equivalent." ;
-    :kb-article """## How it works
-Equality is a relationship between two quantities or, more generally two mathematical expressions, asserting that the quantities have the same value, or that the expressions represent the same mathematical object.
-
-Programming languages can have multiple senses of equality that may include, but are not limited to:
-
-- Identity: The objects are identical; often indicated by having values indicating the same logical address.
-- Equality: The values of the expessions and properties are equivalent when evaluated; they do not need to have the same logical address.
-
-## References
-1. Equality (mathematics). (2023, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Equality_(mathematics)]
+    :kb-article """## How it works\r
+Equality is a relationship between two quantities or, more generally two mathematical expressions, asserting that the quantities have the same value, or that the expressions represent the same mathematical object.\r
+\r
+Programming languages can have multiple senses of equality that may include, but are not limited to:\r
+\r
+- Identity: The objects are identical; often indicated by having values indicating the same logical address.\r
+- Equality: The values of the expessions and properties are equivalent when evaluated; they do not need to have the same logical address.\r
+\r
+## References\r
+1. Equality (mathematics). (2023, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Equality_(mathematics)]\r
 2. Types of Equality. (2007, March 2). In _WikiWikiWeb_. [Link](https://wiki.c2.com/?TypesOfEquality)""" .
 
 :Estimation a owl:Class,
@@ -9965,7 +9965,7 @@ Programming languages can have multiple senses of equality that may include, but
     rdfs:subClassOf :InferentialStatistics ;
     :d3fend-id "D3A-EST" ;
     :definition "Estimation represents ways or a process of learning and determining the population parameter based on the model fitted to the data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Link](https://online.stat.psu.edu/stat504/lesson/statistical-inference-and-estimation)""" ;
     :todo "Seems like there should be more than just interval and pont estimation in here." .
 
@@ -10003,7 +10003,7 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
         :NumericPatternMatching ;
     :d3fend-id "D3A-EM" ;
     :definition "Exact matching for numeric types is just the simple test for mathematical equivalence of the values being matched." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Equality (mathematics). (2023, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Equality_(mathematics)]""" ;
     :synonym "Numeric Equivalence Matching" .
 
@@ -10023,29 +10023,29 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
             owl:someValuesFrom :Pointer ] ;
     :d3fend-id "D3-EHPV" ;
     :definition "Validates that a referenced exception handler pointer is a valid exception handler." ;
-    :kb-article """## How It Works
-When a process encounters an exception, it calls an exception handler to deal with the exception.  The method by which this exception handler is determined varies by the operating system.  The exception handler is called, even if it is the default exception handler to terminate the program and display a message that the program stopped working.  In the case that no valid exception handler is found, the program would fail to proceed as normal and could be programmed to terminate.
-
-In Windows, the address of the exception registration record is stored at the very start of the the Thread Information Block; the GS register points to this structure.
-
-The exception registration record contains two pointers: a pointer to the next exception registration record should this handler fail to handle the exception, and a pointer to the handler.
-
-A buffer overflow can overwrite the saved return pointer with an invalid location to execute memory; this often triggers the exception handler chain, which could also be corrupted by the buffer overflow.  Although Process Exception Handler Validation does not make sure that the exception handler pointer or the code at the exception handler was unaltered, or that the exception handler code is secure, this technique does ensure that the pointer is at least an exception handler that could be called by the program.
-
-With Process Exception Handler Validation, before the handler is called, it checks the exception handler against a source of valid exception handlers.  If the requested handler is not in this list, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.
-
-### Runtime valid exception handler source generation
-The source of valid exception handlers could be generated at runtime, with the risk of the information that is used to determine the validity of exception handlers being compromised.
-
-### Compile-time
-The source of valid exception handlers could also be generated at compile time or as a binary patch.  Given the source code, it would be rather straightforward to find the exceptions, as they are pointed in the catch statement of a try-catch clause and the compiler must already generate the code to call exceptions from this.
-
-## Considerations
-If the program file can be altered by the attacker, then the security could be bypassed by replacing it with any desired program, without even bypassing SEH.
-
-If the attacker was already able to overwrite the code for a valid exception handler via other functionality in the program, this defense would not prevent arbitrary code execution.
-If an exception handler recognized as valid is vulnerable, it would be executed anyway.
-
+    :kb-article """## How It Works\r
+When a process encounters an exception, it calls an exception handler to deal with the exception.  The method by which this exception handler is determined varies by the operating system.  The exception handler is called, even if it is the default exception handler to terminate the program and display a message that the program stopped working.  In the case that no valid exception handler is found, the program would fail to proceed as normal and could be programmed to terminate.\r
+\r
+In Windows, the address of the exception registration record is stored at the very start of the the Thread Information Block; the GS register points to this structure.\r
+\r
+The exception registration record contains two pointers: a pointer to the next exception registration record should this handler fail to handle the exception, and a pointer to the handler.\r
+\r
+A buffer overflow can overwrite the saved return pointer with an invalid location to execute memory; this often triggers the exception handler chain, which could also be corrupted by the buffer overflow.  Although Process Exception Handler Validation does not make sure that the exception handler pointer or the code at the exception handler was unaltered, or that the exception handler code is secure, this technique does ensure that the pointer is at least an exception handler that could be called by the program.\r
+\r
+With Process Exception Handler Validation, before the handler is called, it checks the exception handler against a source of valid exception handlers.  If the requested handler is not in this list, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.\r
+\r
+### Runtime valid exception handler source generation\r
+The source of valid exception handlers could be generated at runtime, with the risk of the information that is used to determine the validity of exception handlers being compromised.\r
+\r
+### Compile-time\r
+The source of valid exception handlers could also be generated at compile time or as a binary patch.  Given the source code, it would be rather straightforward to find the exceptions, as they are pointed in the catch statement of a try-catch clause and the compiler must already generate the code to call exceptions from this.\r
+\r
+## Considerations\r
+If the program file can be altered by the attacker, then the security could be bypassed by replacing it with any desired program, without even bypassing SEH.\r
+\r
+If the attacker was already able to overwrite the code for a valid exception handler via other functionality in the program, this defense would not prevent arbitrary code execution.\r
+If an exception handler recognized as valid is vulnerable, it would be executed anyway.\r
+\r
 SafeSEH might be applied only to some executable files or modules, allowing an attacker to call any piece of code as an exception handler in the unprotected modules.""" ;
     :kb-reference :Reference-SAFESEH_ImageHasSafeExceptionHandlers_MicrosoftDocs ;
     :synonym "Exception Handler Validation" .
@@ -10063,15 +10063,15 @@ SafeSEH might be applied only to some executable files or modules, allowing an a
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-EAL" ;
     :definition "Using a digital signature to authenticate a file before opening." ;
-    :kb-article """## How it works
-
-This technique is generic and there are numerous ways to compute and authenticate digital signatures.
-A digital certificate is generated from a private/public key pair issued by a certificate authority (CA). A hash of the file is encrypted using the private key. When the file is downloaded by another user, the user's system uses the public key to decrypt the hash and a new hash is created of the downloaded file. The hash decrypted by the public key is compared to the new hash and if there is a mismatch, further techniques, such as file deletion, file quarantine, or **Executable Blacklisting** may be invoked.
-
-This technique may be invoked when deciding whether to execute a file.
-
-## Considerations
-
+    :kb-article """## How it works\r
+\r
+This technique is generic and there are numerous ways to compute and authenticate digital signatures.\r
+A digital certificate is generated from a private/public key pair issued by a certificate authority (CA). A hash of the file is encrypted using the private key. When the file is downloaded by another user, the user's system uses the public key to decrypt the hash and a new hash is created of the downloaded file. The hash decrypted by the public key is compared to the new hash and if there is a mismatch, further techniques, such as file deletion, file quarantine, or **Executable Blacklisting** may be invoked.\r
+\r
+This technique may be invoked when deciding whether to execute a file.\r
+\r
+## Considerations\r
+\r
 Organizations which download or create high volumes of software make management complex, in particular engineering or scientific organizations.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ComputingApparatusWithAutomaticIntegrityReferenceGenerationAndMaintenance_Tripwire,Inc.>,
         :Reference-EnhancingNetworkSecurityByPreventingUser-InitiatedMalwareExecution_ ;
@@ -10105,45 +10105,45 @@ Organizations which download or create high volumes of software make management 
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-EDL" ;
     :definition "Blocking the execution of files on a host in accordance with defined application policy rules." ;
-    :kb-article """## How it works
-
-#### Criteria
-
-A policy-enforcing application can register an application for denylisting based on conditions including the following:
-
-* File attributes
-    * file name
-    * file path
-    * file hash
-    * file publisher, as obtained from the digital signature
-    * permissions of the file
-* File malware scan (eg. Windows SmartScreen)
-* User-File combination
-
-This may be done to prevent execution of applications which are:
-
-* an old version with known vulnerabilities
-* without a valid license, which could cause legal issues
-* in a directory that is accessible to low-privileged users, that could be accessed by a malware dropper
-* known trojan horse programs
-* too open in their permissions, possibly set to run as a user other than the originator or allowing execution when they should not be
-* a match to the hash of other known malware
-* are detected as undesirable based on a file scan runtime behavior
-
-System administrators will customize the rules for the given environment.
-
-#### Backend
-
-The policy-enforcing program may work by running in kernel mode, and [intercepting] [system calls which execute a process].
-
-## Considerations
-
-* If denylisting is done by filename, filepath, or hash, these mechanisms may be a worthy first line of defense and detection, but could still be evaded by an attacker.
-* Continuous management is needed to keep the denylist up to date, whether it is based on hash, publisher, behavior, or any other digital artifact.
-* Although denylists based on attributes such as file path and virus scan could defend against some threats which they have not been explicitly coded to block, denylists may not provide protection from new, unknown, or zero day attacks.
-
-
-## Examples
+    :kb-article """## How it works\r
+\r
+#### Criteria\r
+\r
+A policy-enforcing application can register an application for denylisting based on conditions including the following:\r
+\r
+* File attributes\r
+    * file name\r
+    * file path\r
+    * file hash\r
+    * file publisher, as obtained from the digital signature\r
+    * permissions of the file\r
+* File malware scan (eg. Windows SmartScreen)\r
+* User-File combination\r
+\r
+This may be done to prevent execution of applications which are:\r
+\r
+* an old version with known vulnerabilities\r
+* without a valid license, which could cause legal issues\r
+* in a directory that is accessible to low-privileged users, that could be accessed by a malware dropper\r
+* known trojan horse programs\r
+* too open in their permissions, possibly set to run as a user other than the originator or allowing execution when they should not be\r
+* a match to the hash of other known malware\r
+* are detected as undesirable based on a file scan runtime behavior\r
+\r
+System administrators will customize the rules for the given environment.\r
+\r
+#### Backend\r
+\r
+The policy-enforcing program may work by running in kernel mode, and [intercepting] [system calls which execute a process].\r
+\r
+## Considerations\r
+\r
+* If denylisting is done by filename, filepath, or hash, these mechanisms may be a worthy first line of defense and detection, but could still be evaded by an attacker.\r
+* Continuous management is needed to keep the denylist up to date, whether it is based on hash, publisher, behavior, or any other digital artifact.\r
+* Although denylists based on attributes such as file path and virus scan could defend against some threats which they have not been explicitly coded to block, denylists may not provide protection from new, unknown, or zero day attacks.\r
+\r
+\r
+## Examples\r
 On a Windows machine the Windows Defender Application Control (WDAC) policy enforcement is run in the kernel and allows for restricting applications.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ContentExtractorAndAnalysisSystem_Bit9Inc,CarbonBlackInc>,
         :Reference-MethodAndApparatusForIncreasingTheSpeedAtWhichComputerVirusesAreDetected_McAfeeLLC ;
@@ -10222,7 +10222,7 @@ On a Windows machine the Windows Defender Application Control (WDAC) policy enfo
     rdfs:subClassOf :Distribution-basedClustering ;
     :d3fend-id "D3A-EMC" ;
     :definition "An unsupervised clustering algorithm and extends to NLP applications like Latent Dirichlet Allocation, the Baum-Welch algorithm for Hidden Markov Models, and medical imaging." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Towards Data Science. (n.d.). Expectation Maximization Explained. [Link](https://towardsdatascience.com/expectation-maximization-explained-c82f5ed438e5#:~:text=Expectation%20Maximization%20(EM)%20is%20a,Markov%20Models%2C%20and%20medical%20imaging.)""" .
 
 :ExpectedErrorReduction a owl:Class,
@@ -10231,7 +10231,7 @@ Towards Data Science. (n.d.). Expectation Maximization Explained. [Link](https:/
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-EER" ;
     :definition "Expected Error Reduction (EER) follows similar ideas as EMC, but again looks at the model output instead of the model itself and also takes the other data into account. In particular, a sample x is considered useful, if we can expect that knowing the label will reduce the future error on unseen samples" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :ExpectedModelChange a owl:Class,
@@ -10240,9 +10240,9 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-EMC" ;
     :definition "Supervised learning establishes a relationship between the known input and output variables to conduct a predictive analysis." ;
-    :kb-article """nal Consiterations
-
-## References
+    :kb-article """nal Consiterations\r
+\r
+## References\r
 Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :ExternalContentInclusionFunction a owl:Class ;
@@ -10306,10 +10306,10 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
             owl:someValuesFrom :LocalResourceAccess ] ;
     :d3fend-id "D3-FAPA" ;
     :definition "Analyzing the files accessed by a process to identify unauthorized activity." ;
-    :kb-article """## How it works
-File modifying malware such as wipers and ransomware are detected by identifying file access patterns that are associated with a malicious process. Examples of file access patterns include accessing a large number of files, accessing multiple file types, files being accessed located in multiple locations in a directory, and copying a file and encrypting the contents of that file into a copy.
-
-## Considerations
+    :kb-article """## How it works\r
+File modifying malware such as wipers and ransomware are detected by identifying file access patterns that are associated with a malicious process. Examples of file access patterns include accessing a large number of files, accessing multiple file types, files being accessed located in multiple locations in a directory, and copying a file and encrypting the contents of that file into a copy.\r
+\r
+## Considerations\r
 Certain file access actions may not be statistically different from authorized activity.""" ;
     :kb-reference :Reference-File-modifyingMalwareDetection_CrowdstrikeInc .
 
@@ -10327,7 +10327,7 @@ Certain file access actions may not be statistically different from authorized a
     :d3fend-id "D3-FA" ;
     :definition "File Analysis is an analytic process to determine a file's status. For example: virus, trojan, benign, malicious, trusted, unauthorized, sensitive, etc." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview
+    :kb-article """## Technique Overview\r
 Some techniques use file signatures or file metadata to compare against historical collections of malware. Files may also be compared against a source of ground truth such as cryptographic signatures. Examining files for potential malware using pattern matching against file contents/file behavior. Binary code may be dissembled and analyzed for predictive malware behavior, such as API call signatures. Analysis might occur within a protected environment such as a sandbox or live system.""" .
 
 :FileCarving a :NetworkTrafficAnalysis,
@@ -10340,11 +10340,11 @@ Some techniques use file signatures or file metadata to compare against historic
             owl:someValuesFrom :FileTransferNetworkTraffic ] ;
     :d3fend-id "D3-FC" ;
     :definition "Identifying and extracting files from network application protocols through the use of network stream reassembly software." ;
-    :kb-article """## How it works
-Protocol stream reassembly software recreates a directional byte stream by analyzing captured network packets. Once the stream is reassembled pattern matching is applied to determine if it contains a file of interest. Files of interest range from executable, archive, or document file formats. Once the file is captured, it is then processed with standard File Analysis Techniques. Example network protocols include HTTP, SMTP, FTP, HTTP/2, and TLS/HTTP/Dropbox.
-
-## Considerations
-- This is an error prone process due to the intricacies of network protocols and network packet capture.  For example reassembly may be done in real-time or streaming fashion, or packets may be written to disk, then bulk processed.  The packets may arrive out of order, with fragmentation, duplicates, or re-transmissions.  The reassembly software must compensate for the imperfect packet stream in order to recreate the well formed file which was transmitted.
+    :kb-article """## How it works\r
+Protocol stream reassembly software recreates a directional byte stream by analyzing captured network packets. Once the stream is reassembled pattern matching is applied to determine if it contains a file of interest. Files of interest range from executable, archive, or document file formats. Once the file is captured, it is then processed with standard File Analysis Techniques. Example network protocols include HTTP, SMTP, FTP, HTTP/2, and TLS/HTTP/Dropbox.\r
+\r
+## Considerations\r
+- This is an error prone process due to the intricacies of network protocols and network packet capture.  For example reassembly may be done in real-time or streaming fashion, or packets may be written to disk, then bulk processed.  The packets may arrive out of order, with fragmentation, duplicates, or re-transmissions.  The reassembly software must compensate for the imperfect packet stream in order to recreate the well formed file which was transmitted.\r
 - File type identification can be a difficult process which can be exploited by adversaries.""" ;
     :kb-reference :Reference-ComputerWormDefenseSystemAndMethod_FireEyeInc .
 
@@ -10355,20 +10355,20 @@ Protocol stream reassembly software recreates a directional byte stream by analy
     rdfs:subClassOf :FileAnalysis ;
     :d3fend-id "D3-FCR" ;
     :definition "Employing a pattern matching rule language to analyze files." ;
-    :kb-article """## How it works
-Rules, often called signatures, are used for both generic and targeted malware detection. The rules are usually expressed in a domain specific language (DSL), then deployed to software that scans files for matches. The rules are developed and broadly distributed by commercial vendors, or they are developed and deployed by enterprise security teams to address highly targeted or custom malware. Conceptually, there are public and private rule sets. Both leverage the same technology, but they are intended to detect different types of cyber adversaries.
-
-## Considerations
-* Patterns expressed in the DSLs range in their complexity. Some scanning engines support file parsing and normalization for high fidelity matching, others support only simple regular expression matching against raw file data. Engineers must make a trade-off in terms of:
-     * The fidelity of the matching capabilities in order to balance high recall with avoiding false positives,
-     * The computational load for scanning, and
-     * The resilience of the engine to deal with adversarial content presented in different forms-- content which in some cases is designed to exploit or defeat the scanning engines.
- * Signature libraries can become large over time and impact scanning performance.
- * Some vendors who sell signatures have to delete old signatures over time.
- * Simple signatures against raw content cannot match against encoded, encrypted, or sufficiently obfuscated content.
-
-## Implementations
- * YARA
+    :kb-article """## How it works\r
+Rules, often called signatures, are used for both generic and targeted malware detection. The rules are usually expressed in a domain specific language (DSL), then deployed to software that scans files for matches. The rules are developed and broadly distributed by commercial vendors, or they are developed and deployed by enterprise security teams to address highly targeted or custom malware. Conceptually, there are public and private rule sets. Both leverage the same technology, but they are intended to detect different types of cyber adversaries.\r
+\r
+## Considerations\r
+* Patterns expressed in the DSLs range in their complexity. Some scanning engines support file parsing and normalization for high fidelity matching, others support only simple regular expression matching against raw file data. Engineers must make a trade-off in terms of:\r
+     * The fidelity of the matching capabilities in order to balance high recall with avoiding false positives,\r
+     * The computational load for scanning, and\r
+     * The resilience of the engine to deal with adversarial content presented in different forms-- content which in some cases is designed to exploit or defeat the scanning engines.\r
+ * Signature libraries can become large over time and impact scanning performance.\r
+ * Some vendors who sell signatures have to delete old signatures over time.\r
+ * Simple signatures against raw content cannot match against encoded, encrypted, or sufficiently obfuscated content.\r
+\r
+## Implementations\r
+ * YARA\r
  * ClamAV""" ;
     :kb-reference :Reference-ComputationalModelingAndClassificationOfDataStreams_CrowdstrikeInc,
         :Reference-DetectingScript-basedMalware_CrowdstrikeInc,
@@ -10400,17 +10400,17 @@ Rules, often called signatures, are used for both generic and targeted malware d
             owl:someValuesFrom :File ] ;
     :d3fend-id "D3-FE" ;
     :definition "Encrypting a file using a cryptographic key." ;
-    :kb-article """## How it Works
-Files are encrypted using either a single key for both encryption and decryption or separate keys. Single key encryption is symmetric encryption and using two key distinct keys is asymmetric encryption.
-
-### Symmetric Cryptography
-Symmetric encryption uses the same cryptographic key for both the encryption and decryption a file. Managing keys at scale sometimes uses asymmetric key exchange protocols such as Diffie-Hellman can be used to share the symmetric cryptographic key with the others.
-
-### Asymmetric Cryptography
-Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. Files are encrypted using the public key and decrypted using their private key. Asymmetric encryption is typically slower than symmetric encryption and not widely used for large file encryption, but is popular for key wrapping, key exchanges, and digital signatures.
-
-## Considerations
-- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
+    :kb-article """## How it Works\r
+Files are encrypted using either a single key for both encryption and decryption or separate keys. Single key encryption is symmetric encryption and using two key distinct keys is asymmetric encryption.\r
+\r
+### Symmetric Cryptography\r
+Symmetric encryption uses the same cryptographic key for both the encryption and decryption a file. Managing keys at scale sometimes uses asymmetric key exchange protocols such as Diffie-Hellman can be used to share the symmetric cryptographic key with the others.\r
+\r
+### Asymmetric Cryptography\r
+Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. Files are encrypted using the public key and decrypted using their private key. Asymmetric encryption is typically slower than symmetric encryption and not widely used for large file encryption, but is popular for key wrapping, key exchanges, and digital signatures.\r
+\r
+## Considerations\r
+- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.\r
 - Secure transfer of private keys between multiple devices.""" ;
     :kb-reference :Reference-MethodForFileEncryption .
 
@@ -10439,10 +10439,10 @@ Asymmetric encryption is typically accomplished using public and private key cer
     rdfs:subClassOf :FileAnalysis ;
     :d3fend-id "D3-FH" ;
     :definition "Employing file hash comparisons to detect known malware." ;
-    :kb-article """## How it works
-This technique requires a list of hashes to compare a file against.
-
-## Considerations
+    :kb-article """## How it works\r
+This technique requires a list of hashes to compare a file against.\r
+\r
+## Considerations\r
 Performance on large files or very large numbers of files.""" ;
     :kb-reference :Reference-Munin .
 
@@ -10468,14 +10468,14 @@ Performance on large files or very large numbers of files.""" ;
             owl:someValuesFrom :File ] ;
     :d3fend-id "D3-FIM" ;
     :definition "Detecting any suspicious changes to files in a computer system." ;
-    :kb-article """## How it Works
-There are a number of tools in Windows and Unix that can monitor specific files in a system and generate alerts if any artifacts have been created, modified, or removed. They accomplish this by comparing the current artifacts to a previous snapshot.
-
-Unix - Unix systems have a file integrity checker tool called tripwire. Tripwire first initializes a database that serves as a basis for comparison and can then scan the system to compare the state of the current file system against the initial baseline database. Additionally, users can define policies that specify potential violations.
-
-Windows - In Microsoft Azure, file integrity monitoring can be enabled which can track file and registry key creation, removals, and modifications of specific files.
-
-## Considerations
+    :kb-article """## How it Works\r
+There are a number of tools in Windows and Unix that can monitor specific files in a system and generate alerts if any artifacts have been created, modified, or removed. They accomplish this by comparing the current artifacts to a previous snapshot.\r
+\r
+Unix - Unix systems have a file integrity checker tool called tripwire. Tripwire first initializes a database that serves as a basis for comparison and can then scan the system to compare the state of the current file system against the initial baseline database. Additionally, users can define policies that specify potential violations.\r
+\r
+Windows - In Microsoft Azure, file integrity monitoring can be enabled which can track file and registry key creation, removals, and modifications of specific files.\r
+\r
+## Considerations\r
 Files can change constantly due to the non-static nature of a computer system. File Integrity Monitoring works best when pointed at a narrow scope of critical files to limit the number of unneccessary files that may be modified over the course of normal use. The accuracy and precision of defined policies also affect the efficacy of this technique.""" ;
     :kb-reference :Reference-FileIntegrityMonitoringinMicrosoftDefenderforCloud-Microsoft,
         :Reference-Tripwire .
@@ -10504,16 +10504,16 @@ Files can change constantly due to the non-static nature of a computer system. F
             owl:someValuesFrom :FileServer ] ;
     :d3fend-id "D3-FR" ;
     :definition "The file removal technique deletes malicious artifacts or programs from a computer system." ;
-    :kb-article """## How it works
-
-Adversaries may place files or programs into a computer's file system to perform malicious actions. As part of the eviction process, these files and programs should be removed to prevent further compromise or reinfection. Examples of malicious types of files are malware which is directly harmful and content files with the intent to deceive users (e.g., phishing.)
-
-On Windows systems, antivirus (AV) software should be used to safely and permanently remove malicious files. AV software may first quarantine a suspected malicious file, which is the process of moving a file from its original location to a new location and makes changes so that it cannot be executed. Users can then verify that the file is not benign and then permanently delete it.
-
-## Considerations
-
-When it is determined that a file should be removed for security purposes, the organization--or systems implementing an organization's policies--may determine that the file should not simply be deleted from the enterprise's mission systems, but be quarantined to a secure system by an approved mechanism, so as to allow follow-up investigation by security staff.
-
+    :kb-article """## How it works\r
+\r
+Adversaries may place files or programs into a computer's file system to perform malicious actions. As part of the eviction process, these files and programs should be removed to prevent further compromise or reinfection. Examples of malicious types of files are malware which is directly harmful and content files with the intent to deceive users (e.g., phishing.)\r
+\r
+On Windows systems, antivirus (AV) software should be used to safely and permanently remove malicious files. AV software may first quarantine a suspected malicious file, which is the process of moving a file from its original location to a new location and makes changes so that it cannot be executed. Users can then verify that the file is not benign and then permanently delete it.\r
+\r
+## Considerations\r
+\r
+When it is determined that a file should be removed for security purposes, the organization--or systems implementing an organization's policies--may determine that the file should not simply be deleted from the enterprise's mission systems, but be quarantined to a secure system by an approved mechanism, so as to allow follow-up investigation by security staff.\r
+\r
 On Windows systems, deleting a file in File Explorer does not permanently delete a file - it sends it to the Recycle Bin instead. The Recycle Bin must be emptied, or alternative steps must be performed to remove files completely. Even then, in some cases the data may persist in disk, so data shredder tools may be needed to completely wipe a file. Thus, AV tools are recommended.""" ;
     :kb-reference :Reference-HowDoesAntivirusQuarantineWork-SafetyDetectives ;
     :synonym "File Deletion" .
@@ -10610,20 +10610,20 @@ On Windows systems, deleting a file in File Explorer does not permanently delete
             owl:someValuesFrom :Firmware ] ;
     :d3fend-id "D3-FBA" ;
     :definition "Analyzing the behavior of embedded code in firmware and looking for anomalous behavior and suspicious activity." ;
-    :kb-article """## How it works
-Firmware behavior analysis provides protections by ensuring that installed firmware has not been tampered with or modified. Firmware analysis applies to mutable firmware and immutable read-only memory (ROMs).
-
-Firmware in deployed network devices is typically not analyzed and monitored for vulnerabilities and thus is subject to potential attacks. This technique makes use of known and measured behavioral attributes, including timing attributes, of analyzed firmware on deployed devices.
-
-A behavioral method that employs known timing measurements may use the timing results from a challenge and response protocol to detect the presence of malware in embedded firmware. Firmware device timing measurements are made, specific to the installed device, and are used in the verifying function.
-
-The original firmware image is modified by injecting a monitoring software component into the embedded firmware code. The injected software components will allow for a software root of trust, the challenge and response protocol, to be implement in the firmware.
-
-A challenge-response is issued and includes a nonce so that replays are not allowed. The firmware will calculate a checksum over all of memory, including the nonce, and return the result. The verification system will compare the computed checksum and the time it took for the computation of the checksum to determine if the firmware has been modified.
-
-## Considerations
-* The firmware code will need to be modified to include the behavioral monitoring functionality.
-* This technique is sensitive to the device the embedded firmware is hosted on and it is expected that the devices and firmware will need to be profiled and analyzed to determine timing estimation.
+    :kb-article """## How it works\r
+Firmware behavior analysis provides protections by ensuring that installed firmware has not been tampered with or modified. Firmware analysis applies to mutable firmware and immutable read-only memory (ROMs).\r
+\r
+Firmware in deployed network devices is typically not analyzed and monitored for vulnerabilities and thus is subject to potential attacks. This technique makes use of known and measured behavioral attributes, including timing attributes, of analyzed firmware on deployed devices.\r
+\r
+A behavioral method that employs known timing measurements may use the timing results from a challenge and response protocol to detect the presence of malware in embedded firmware. Firmware device timing measurements are made, specific to the installed device, and are used in the verifying function.\r
+\r
+The original firmware image is modified by injecting a monitoring software component into the embedded firmware code. The injected software components will allow for a software root of trust, the challenge and response protocol, to be implement in the firmware.\r
+\r
+A challenge-response is issued and includes a nonce so that replays are not allowed. The firmware will calculate a checksum over all of memory, including the nonce, and return the result. The verification system will compare the computed checksum and the time it took for the computation of the checksum to determine if the firmware has been modified.\r
+\r
+## Considerations\r
+* The firmware code will need to be modified to include the behavioral monitoring functionality.\r
+* This technique is sensitive to the device the embedded firmware is hosted on and it is expected that the devices and firmware will need to be profiled and analyzed to determine timing estimation.\r
 * This technique is not expected to be one hundred percent correct as you would expect in a hardware root of trust solution and may require some tuning.""" ;
     :kb-reference :Reference-FirmwareBehaviorAnalysisConFirm,
         :Reference-FirmwareBehaviorAnalysisVIPER ;
@@ -10639,17 +10639,17 @@ A challenge-response is issued and includes a nonce so that replays are not allo
             owl:someValuesFrom :Firmware ] ;
     :d3fend-id "D3-FEMC" ;
     :definition "Monitoring code is injected into firmware for integrity monitoring of firmware and firmware data." ;
-    :kb-article """## How it works
-Firmware in deployed network devices is typically not monitored for malicious changes. This technique provides a method to embed a software security component into the deployed firmware which provides a near real-time monitoring hook. The exception handling code, in the firmware, is typically used to expose any detected vulnerabilities.
-
-The injected software components provide a feature similar to intrusion detection systems for the firmware by detecting unauthorized modifications of the embedded firmware. The integrity of static code and firmware data are monitored continuously in the hosted devices. Comparisons are made to monitored elements like firmware memory addresses and data segments. Memory pages are scanned and if a modification is detected the software component may lock the page. This will protect subsequent attempted modifications to the firmware. The software component may utilize the exception handling code and thus be able to disclose the exact address of the modified memory.
-
-The injected software components are inserted during the firmware imaging process. The injected software is assumed to have knowledge of both the embedded code and the current execution state of the host program. The injected software will monitor and alert, in near real-time, on potential suspicious activity. The injected code is run alongside of the embedded code in the host. The injected software operates as an independent entity and is not dependent on the host software.
-
-Finally, this technique may implement other countermeasure techniques as part of their analytical processes. These should be identified by referencing other countermeasure techniques directly as necessary.
-
-## Considerations
-* The firmware code will need to be modified and re-hosted on the device.
+    :kb-article """## How it works\r
+Firmware in deployed network devices is typically not monitored for malicious changes. This technique provides a method to embed a software security component into the deployed firmware which provides a near real-time monitoring hook. The exception handling code, in the firmware, is typically used to expose any detected vulnerabilities.\r
+\r
+The injected software components provide a feature similar to intrusion detection systems for the firmware by detecting unauthorized modifications of the embedded firmware. The integrity of static code and firmware data are monitored continuously in the hosted devices. Comparisons are made to monitored elements like firmware memory addresses and data segments. Memory pages are scanned and if a modification is detected the software component may lock the page. This will protect subsequent attempted modifications to the firmware. The software component may utilize the exception handling code and thus be able to disclose the exact address of the modified memory.\r
+\r
+The injected software components are inserted during the firmware imaging process. The injected software is assumed to have knowledge of both the embedded code and the current execution state of the host program. The injected software will monitor and alert, in near real-time, on potential suspicious activity. The injected code is run alongside of the embedded code in the host. The injected software operates as an independent entity and is not dependent on the host software.\r
+\r
+Finally, this technique may implement other countermeasure techniques as part of their analytical processes. These should be identified by referencing other countermeasure techniques directly as necessary.\r
+\r
+## Considerations\r
+* The firmware code will need to be modified and re-hosted on the device.\r
 * Exposing monitoring hooks to the injected code may introduce additional risk.""" ;
     :kb-reference :Reference-FirmwareEmbeddedMonitoringCodeRedBalloon,
         :Reference-FirmwareEmbeddedMonitoringCodeSymbiotes .
@@ -10672,11 +10672,11 @@ Finally, this technique may implement other countermeasure techniques as part of
             owl:someValuesFrom :Firmware ] ;
     :d3fend-id "D3-FV" ;
     :definition "Cryptographically verifying firmware integrity." ;
-    :kb-article """## How it works
-Cryptographic hash values are computed for system and peripheral firmware. The hash values are compared against precomputed hash values for the identified firmware. A hash value mismatch may indicate that the firmware may have been tampered with or updated with a non-current release indicating a misconfiguration for the system.
-
-## Considerations
-* Requires cryptographically computed hash values of firmware
+    :kb-article """## How it works\r
+Cryptographic hash values are computed for system and peripheral firmware. The hash values are compared against precomputed hash values for the identified firmware. A hash value mismatch may indicate that the firmware may have been tampered with or updated with a non-current release indicating a misconfiguration for the system.\r
+\r
+## Considerations\r
+* Requires cryptographically computed hash values of firmware\r
 * Requires storage of precomputed firmware hash values""" ;
     :kb-reference :Reference-FirmwareVerificationEclypsium,
         :Reference-FirmwareVerificationTrapezoid,
@@ -10688,45 +10688,45 @@ Cryptographic hash values are computed for system and peripheral firmware. The h
     rdfs:subClassOf :PredicateLogic ;
     :d3fend-id "D3A-FOL" ;
     :definition "First-order logic is a collection of formal systems used in mathematics, philosophy, linguistics, and computer science. First-order logic uses quantified variables over non-logical objects, and allows the use of sentences that contain variables." ;
-    :kb-article """## How it works
-
-For propositions such as "Socrates is a man", one can have expressions in the form "there exists x such that x is Socrates and x is a man", where "there exists" is a quantifier, while x is a variable. This distinguishes it from propositional logic, which does not use quantifiers or relations.
-
-The term "first-order" distinguishes first-order logic from higher-order logic, in which there are predicates having predicates or functions as arguments, or in which quantification over predicates, functions, or both, are permitted.
-
-## Considerations
-
-- Advantages:
--- First-order logic is more expressive than propositional logic; one can talk about objects and their properties, relations between objects.
--- First-order logic is able to make use of variables and quantifiers (e.g., "for all" and "exists".)
--- First-order logic supports power forms of reasoning, such as inferring the properties of an unknown object from the properties of known objects.
-
-- Disadvantages:
--- First-order logic is more difficult to learn and use than propositional logic, due to its greater complexity.
--- First-order logic is also less tractable than propositional logic in many cases; reasoning about quantifiers and variables adds complexity.
--- First-order logic can be difficult to apply in practice, due to the need to find appropriate axioms and rules for each application.
-
-### Verification Approach
-
-- Automated theorem provers can assist in formal verification, performing automated reasoning over system modeled in first-order logic and explore a complete space of system behaviors
-- First-order logic may be more expressive than necessary for many types of problems and may be more difficult to verify by SMEs.
-- Theorem provers based in FOL are capable of use in software verification tasks, but an SMT solver such as Z3 might be more appropriate.
-- Defining a set of competency questions (i.e., query use cases for a first-order logic ontology) can help scope the logic required for a complete solution.
-
-### Validation Approach
-
-- Domain SMEs should be identified to review the analytics results and compare them to expected results for a given input.
-- Where possible, an outside team of SMEs should inspect the formal logic specification of a system against its stated requirements and suitability to address its domain problem sets.
-- Defining a set of competency questions and the expected results provides one means of validation.
-
-## References
-
-1.  First-order logic. (2023, May 26). In _Wikipedia_.  [Link](https://en.wikipedia.org/wiki/First-order_logic)
-2. Shapiro, S. and Kissel, T. Classical Logic. (2022). Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-classical/)
-3. A.I. For Anyone. First-order Logic (n.d.). [Link](https://www.aiforanyone.org/glossary/first-order-logic)
-4. Smith, P. An Introduction to Formal Logic. (2020). [Link](https://doi.org/10.1017/9781108328999)
-5. Gruninger, M. and Fox, M. (1995). Methodology for the Design and Evaluation of Ontologies. [Link](https://www.researchgate.net/publication/2288533_Methodology_for_the_Design_and_Evaluation_of_Ontologies)
-6. Keet, C., Suarez-Figurosa, M., and Poveda-Villalon, M. (2014). Pitfalls in Ontologies and TIPS to Prevent Them. [Link](https://dl.acm.org/doi/10.4018/ijswis.2014040102)
+    :kb-article """## How it works\r
+\r
+For propositions such as "Socrates is a man", one can have expressions in the form "there exists x such that x is Socrates and x is a man", where "there exists" is a quantifier, while x is a variable. This distinguishes it from propositional logic, which does not use quantifiers or relations.\r
+\r
+The term "first-order" distinguishes first-order logic from higher-order logic, in which there are predicates having predicates or functions as arguments, or in which quantification over predicates, functions, or both, are permitted.\r
+\r
+## Considerations\r
+\r
+- Advantages:\r
+-- First-order logic is more expressive than propositional logic; one can talk about objects and their properties, relations between objects.\r
+-- First-order logic is able to make use of variables and quantifiers (e.g., "for all" and "exists".)\r
+-- First-order logic supports power forms of reasoning, such as inferring the properties of an unknown object from the properties of known objects.\r
+\r
+- Disadvantages:\r
+-- First-order logic is more difficult to learn and use than propositional logic, due to its greater complexity.\r
+-- First-order logic is also less tractable than propositional logic in many cases; reasoning about quantifiers and variables adds complexity.\r
+-- First-order logic can be difficult to apply in practice, due to the need to find appropriate axioms and rules for each application.\r
+\r
+### Verification Approach\r
+\r
+- Automated theorem provers can assist in formal verification, performing automated reasoning over system modeled in first-order logic and explore a complete space of system behaviors\r
+- First-order logic may be more expressive than necessary for many types of problems and may be more difficult to verify by SMEs.\r
+- Theorem provers based in FOL are capable of use in software verification tasks, but an SMT solver such as Z3 might be more appropriate.\r
+- Defining a set of competency questions (i.e., query use cases for a first-order logic ontology) can help scope the logic required for a complete solution.\r
+\r
+### Validation Approach\r
+\r
+- Domain SMEs should be identified to review the analytics results and compare them to expected results for a given input.\r
+- Where possible, an outside team of SMEs should inspect the formal logic specification of a system against its stated requirements and suitability to address its domain problem sets.\r
+- Defining a set of competency questions and the expected results provides one means of validation.\r
+\r
+## References\r
+\r
+1.  First-order logic. (2023, May 26). In _Wikipedia_.  [Link](https://en.wikipedia.org/wiki/First-order_logic)\r
+2. Shapiro, S. and Kissel, T. Classical Logic. (2022). Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-classical/)\r
+3. A.I. For Anyone. First-order Logic (n.d.). [Link](https://www.aiforanyone.org/glossary/first-order-logic)\r
+4. Smith, P. An Introduction to Formal Logic. (2020). [Link](https://doi.org/10.1017/9781108328999)\r
+5. Gruninger, M. and Fox, M. (1995). Methodology for the Design and Evaluation of Ontologies. [Link](https://www.researchgate.net/publication/2288533_Methodology_for_the_Design_and_Evaluation_of_Ontologies)\r
+6. Keet, C., Suarez-Figurosa, M., and Poveda-Villalon, M. (2014). Pitfalls in Ontologies and TIPS to Prevent Them. [Link](https://dl.acm.org/doi/10.4018/ijswis.2014040102)\r
 7. Bjorner, N. et al. The inner magic behind the Z3 theorem prover. (2019) [Link](https://www.microsoft.com/en-us/research/blog/the-inner-magic-behind-the-z3-theorem-prover/)""" ;
     :synonym "First-order Predicate Calculus",
         "FOL",
@@ -10763,12 +10763,12 @@ The term "first-order" distinguishes first-order logic from higher-order logic, 
             owl:someValuesFrom :OutboundInternetDNSLookupTraffic ] ;
     :d3fend-id "D3-FRDDL" ;
     :definition "Blocking a lookup based on the query's domain name value." ;
-    :kb-article """## How it works
-
-Policies are created that filter DNS queries using fully qualified domain name (FQDN) of record in the query. A DNS policy can be created for blocking DNS queries from FQDNs that have been identified as unauthorized.
-
-## Considerations
-
+    :kb-article """## How it works\r
+\r
+Policies are created that filter DNS queries using fully qualified domain name (FQDN) of record in the query. A DNS policy can be created for blocking DNS queries from FQDNs that have been identified as unauthorized.\r
+\r
+## Considerations\r
+\r
 Continuous maintenance of unauthorized domain lists is needed to keep up to date as updates occur.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Forward Resolution Domain Blacklisting" .
@@ -10783,22 +10783,22 @@ Continuous maintenance of unauthorized domain lists is needed to keep up to date
             owl:someValuesFrom :InboundInternetDNSResponseTraffic ] ;
     :d3fend-id "D3-FRIDL" ;
     :definition "Blocking a DNS lookup's answer's IP address value." ;
-    :kb-article """## How it works
-
-This technique prevents a client from learning IP addresses deemed to be potentially malicious, which would have been delivered via forward resolution responses.
-
-Responses to forward resolution requests (that is, requests where a domain is sent and IP(s) are returned) are collected, and the IP address(es) included as a response are examined. If the IP address(es) are in a range included in the blacklist, then the response is dropped and not forwarded to the client.
-
-The DNS lookup can be blocked by either dropping the network traffic with an inline device, or modifying the value of the response sent by the DNS server. To transparently prevent client applications from hanging on a request, it is common practice to replace malicious values with addresses in the range 127.0.0.0/8 or the address of a honeypot maintained by the network administrators.
-
-## Considerations
-
-* This technique does not prevent the client from contacting the blacklisted IP, only from learning about this IP address via a nameserver lookup request.
-* DNS Response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer IP address value(s).
-  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.
-  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.
-* This technique must be implemented logically between the application that receives the response and the server which sent the response.
-  * DNS responses sent in an encrypted manner, such as those using DoH or DoT, will require interception of the TLS connections in order to determine the IP address(es) in the response.
+    :kb-article """## How it works\r
+\r
+This technique prevents a client from learning IP addresses deemed to be potentially malicious, which would have been delivered via forward resolution responses.\r
+\r
+Responses to forward resolution requests (that is, requests where a domain is sent and IP(s) are returned) are collected, and the IP address(es) included as a response are examined. If the IP address(es) are in a range included in the blacklist, then the response is dropped and not forwarded to the client.\r
+\r
+The DNS lookup can be blocked by either dropping the network traffic with an inline device, or modifying the value of the response sent by the DNS server. To transparently prevent client applications from hanging on a request, it is common practice to replace malicious values with addresses in the range 127.0.0.0/8 or the address of a honeypot maintained by the network administrators.\r
+\r
+## Considerations\r
+\r
+* This technique does not prevent the client from contacting the blacklisted IP, only from learning about this IP address via a nameserver lookup request.\r
+* DNS Response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer IP address value(s).\r
+  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.\r
+  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.\r
+* This technique must be implemented logically between the application that receives the response and the server which sent the response.\r
+  * DNS responses sent in an encrypted manner, such as those using DoH or DoT, will require interception of the TLS connections in order to determine the IP address(es) in the response.\r
 * Replacing the response is not effective in the case that the nameserver uses a technique to provide integrity of its responses, such as DNSSEC for DNS responses.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Forward Resolution IP Blacklisting" .
@@ -10816,10 +10816,10 @@ The DNS lookup can be blocked by either dropping the network traffic with an inl
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-FL" ;
     :definition "Fuzzy logic is a form of many-valued logic in which the truth value of variables may be any real number between 0 and 1." ;
-    :kb-article """## How it works
-It is employed to handle the concept of partial truth, where the truth value may range between completely true and completely false.[1] By contrast, in Boolean logic, the truth values of variables may only be the integer values 0 or 1.
-
-## References
+    :kb-article """## How it works\r
+It is employed to handle the concept of partial truth, where the truth value may range between completely true and completely false.[1] By contrast, in Boolean logic, the truth values of variables may only be the integer values 0 or 1.\r
+\r
+## References\r
 1. Fuzzy logic. (2023, May 28). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Fuzzy_logic)""" .
 
 :GatedRecurrentUnit a owl:Class,
@@ -10828,7 +10828,7 @@ It is employed to handle the concept of partial truth, where the truth value may
     rdfs:subClassOf :RecurrentNeuralNetwork ;
     :d3fend-id "D3A-GRU" ;
     :definition "The GRU is like a long short-term memory (LSTM) with a forget gate, but has fewer parameters than LSTM, as it lacks an output gate. GRU's performance on certain tasks of polyphonic music modeling, speech signal modeling and natural language processing was found to be similar to that of LSTM" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (2021, September 20). Gated Recurrent Unit. [Link](https://en.wikipedia.org/wiki/Gated_recurrent_unit)""" .
 
 :Generation a owl:Class ;
@@ -10841,7 +10841,7 @@ Wikipedia. (2021, September 20). Gated Recurrent Unit. [Link](https://en.wikiped
     rdfs:subClassOf :UnsupervisedLearning ;
     :d3fend-id "D3A-GAN" ;
     :definition "Generative Adversarial Networks (GAN) are an approach to generative modeling using deep learning methods, such as convolutional neural networks." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Brownlee, J. (2019). What Are Generative Adversarial Networks (GANs)? Machine Learning Mastery. [Link](https://machinelearningmastery.com/what-are-generative-adversarial-networks-gans/)""" ;
     :synonym "GAN" .
 
@@ -10851,7 +10851,7 @@ Brownlee, J. (2019). What Are Generative Adversarial Networks (GANs)? Machine Le
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-GM" ;
     :definition "The nth root of the product of the data values, where there are n of these. This measure is valid only for data that are measured absolutely on a strictly positive scale." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :GetOpenSockets a owl:Class ;
@@ -10904,8 +10904,8 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:isDefinedBy "https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html" ;
     :d3fend-id "D3A-GAKG" ;
     :definition "Goodman-Kruskal $\\\\gamma$ is a measure of rank correlation between x and y and is given by $(n_c -n_d) / (n_c + n_d)$, where $n_c$ is the number of concordant pairs of the observations and $n_d$ is the number of discordant pairs." ;
-    :kb-article """## References
-1. Wolfram Research. (2012). GoodmanKruskalGamma. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html)
+    :kb-article """## References\r
+1. Wolfram Research. (2012). GoodmanKruskalGamma. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html)\r
 1. Goodman and Kruskal's gamma. (2022, Nov 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Goodman_and_Kruskal%27s_gamma]""" .
 
 :GPT a owl:Class,
@@ -10914,7 +10914,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :Transformer-basedLearning ;
     :d3fend-id "D3A-GPT" ;
     :definition "Generative pre-trained transformers (GPT) are a type of large language model (LLM) and a prominent framework for generative artificial intelligence." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Generative pre-trained transformer. (n.d.). In Wikipedia. [Link](https://en.wikipedia.org/wiki/Generative_pre-trained_transformer)""" ;
     :synonym "Generative Pre-trained Transformer" .
 
@@ -10924,7 +10924,7 @@ Generative pre-trained transformer. (n.d.). In Wikipedia. [Link](https://en.wiki
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-GBC" ;
     :definition "Graph-based Clustering is a form of clustering where data is represented with graphs to identify clusters ." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Density-Based and Graph-Based Clustering. [Link](https://towardsdatascience.com/density-based-and-graph-based-clustering-a1f0d45ff5fb)""" .
 
 :Graph-basedSemi-supervisedLearning a owl:Class,
@@ -10933,7 +10933,7 @@ Density-Based and Graph-Based Clustering. [Link](https://towardsdatascience.com/
     rdfs:subClassOf :Semi-supervisedTransductiveLearning ;
     :d3fend-id "D3A-GBSSL" ;
     :definition "Graph-based Semi-Supervised Learning (GSSL) methods aim to classify unlabeled data by learning the graph structure and labeled data jointly." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Yang, S., Pan, L., & Cheng, J. (2021). Graph-based Semi-Supervised Learning Methods for Imbalanced Data Classification. [Link](https://www.sciencedirect.com/science/article/pii/S0031320321002132?viewFullText=true).""" .
 
 :GraphicalUserInterface a owl:Class ;
@@ -10961,7 +10961,7 @@ Yang, S., Pan, L., & Cheng, J. (2021). Graph-based Semi-Supervised Learning Meth
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-GBC" ;
     :definition "Divides the entire data space into a finite number of cells reducing the complexity of the data and focuses on the cells rather than the data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 TechVidvan. (n.d.). Clustering in Machine Learning Tutorial. [Link](https://techvidvan.com/tutorials/clustering-in-machine-learning/)""" .
 
 :Grid-CNN a owl:Class,
@@ -10970,7 +10970,7 @@ TechVidvan. (n.d.). Clustering in Machine Learning Tutorial. [Link](https://tech
     rdfs:subClassOf :ConvolutionalNeuralNetwork ;
     :d3fend-id "D3A-GC" ;
     :definition "A class of neural networks that specializes in processing data that has a grid-like topology, such as an image." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Talukdar, P. (2020, June 10). Convolutional Neural Networks Explained. Towards Data Science. [Link](https://towardsdatascience.com/convolutional-neural-networks-explained-9cc5188c4939)""" .
 
 :Grouping a owl:Class ;
@@ -11026,22 +11026,22 @@ Talukdar, P. (2020, June 10). Convolutional Neural Networks Explained. Towards D
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-HBPI" ;
     :definition "Preventing one process from writing to the memory space of another process through hardware based address manager implementations." ;
-    :kb-article """## How it works
-Process isolation, in this context, is address space separation controlled by a security function that limits the communication between processes so that one process cannot directly modify the executing code of another process. For example with virtual address space:
-
-* Process A address space is different from process B address space, which prevents process A from writing to process B
-
-Hardware process isolation is commonly implemented through Direct Memory Access (DMA) which collaborates with a Memory Management Unit (MMU), or Input-Output Memory Management Unit (IOMMU). These hardware controls are deployed directly on processors to aid hosts or enclaves in process isolation.
-
-* DMA - Direct memory access allows memory access to occur independently of the program currently run by the microprocessor. DMA allows for I/O devices to directly read from and write to memory, or it can be used to efficiently copy blocks of memory. During DMA transfers, the microprocessor can execute an unrelated program.
-* MMU - A memory management unit acts as an access control and is responsible for performing the translation of virtual memory addresses to physical memory addresses. The MMU allocates each process its own virtual memory space.
-* IOMMU - An input-output memory management unit is used to allocate each I/O device its own virtual address space to the underlying physical addresses. IOMMU allows devices that do not support long memory addresses to address the entire memory space.
-
-## Considerations
-* Private hosts may be vulnerable to DMA attack if they have a PCI or PCI Express port that connects attached devices directly to physical address space.
-
-## Implementations:
- * Intel Virtualization Technology for Directed I/O (Intel VT-d)
+    :kb-article """## How it works\r
+Process isolation, in this context, is address space separation controlled by a security function that limits the communication between processes so that one process cannot directly modify the executing code of another process. For example with virtual address space:\r
+\r
+* Process A address space is different from process B address space, which prevents process A from writing to process B\r
+\r
+Hardware process isolation is commonly implemented through Direct Memory Access (DMA) which collaborates with a Memory Management Unit (MMU), or Input-Output Memory Management Unit (IOMMU). These hardware controls are deployed directly on processors to aid hosts or enclaves in process isolation.\r
+\r
+* DMA - Direct memory access allows memory access to occur independently of the program currently run by the microprocessor. DMA allows for I/O devices to directly read from and write to memory, or it can be used to efficiently copy blocks of memory. During DMA transfers, the microprocessor can execute an unrelated program.\r
+* MMU - A memory management unit acts as an access control and is responsible for performing the translation of virtual memory addresses to physical memory addresses. The MMU allocates each process its own virtual memory space.\r
+* IOMMU - An input-output memory management unit is used to allocate each I/O device its own virtual address space to the underlying physical addresses. IOMMU allows devices that do not support long memory addresses to address the entire memory space.\r
+\r
+## Considerations\r
+* Private hosts may be vulnerable to DMA attack if they have a PCI or PCI Express port that connects attached devices directly to physical address space.\r
+\r
+## Implementations:\r
+ * Intel Virtualization Technology for Directed I/O (Intel VT-d)\r
  * Firecracker""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ApproachesForSecuringAnInternetEndpointUsingFine-grainedOperatingSystemVirtualization_Bromium,Inc.>,
         <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-IsolationOfApplicationsWithinAVirtualMachine_Bromium,Inc.>,
@@ -11058,20 +11058,20 @@ Hardware process isolation is commonly implemented through Direct Memory Access 
             owl:someValuesFrom :HardwareDevice ] ;
     :d3fend-id "D3-HCI" ;
     :definition "Hardware component inventorying identifies and records the hardware items in the organization's architecture." ;
-    :kb-article """## How it works
-Administrators collect information on hardware devices such as peripherals, NICs, processors, and memory devices that are components of the computers in their architecture using a variety of administrative and management tools that query for this information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through remote adminstration tools and system commands, either manually or using scripts.
-
-## Considerations
-* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.
-* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools
-
-## Examples
-* Bus discovery
-   * Admin-scripted PCI Bus inventory using ssh and pciutils
-* Application-layer discovery
-   * Simple Network Management Protocol (SNMP) collects MIB information
-   * Web-based Enterprise Management (WBEM) collects CIM information
-      * Windows Management Instrumentation (WMI)
+    :kb-article """## How it works\r
+Administrators collect information on hardware devices such as peripherals, NICs, processors, and memory devices that are components of the computers in their architecture using a variety of administrative and management tools that query for this information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through remote adminstration tools and system commands, either manually or using scripts.\r
+\r
+## Considerations\r
+* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.\r
+* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools\r
+\r
+## Examples\r
+* Bus discovery\r
+   * Admin-scripted PCI Bus inventory using ssh and pciutils\r
+* Application-layer discovery\r
+   * Simple Network Management Protocol (SNMP) collects MIB information\r
+   * Web-based Enterprise Management (WBEM) collects CIM information\r
+      * Windows Management Instrumentation (WMI)\r
       * Windows Management Infrastructure (MI)""" ;
     :kb-reference :Reference-AdvancedDeviceMatchingSystem ;
     :synonym "Hardware Component Discovery",
@@ -11101,7 +11101,7 @@ Administrators collect information on hardware devices such as peripherals, NICs
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-HM" ;
     :definition "The reciprocal of the arithmetic mean of the reciprocals of the data values. This measure too is valid only for data that are measured absolutely on a strictly positive scale." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :HeapSegment a owl:Class ;
@@ -11116,7 +11116,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :HeterogeneousTransferLearning ;
     :d3fend-id "D3A-HAFBTL" ;
     :definition "Asymmetric transformation mapping  transforms the source feature space to align with that of the target or the target to that of the source. This, in effect, bridges the feature space gap and reduces the problem into a homogeneous transfer problem when further distribution differences need to be corrected." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid optimization algorithm. Journal of Big Data, 4(1), 25. [Link](https://journalofbigdata.springeropen.com/articles/10.1186/s40537-017-0089-0).""" .
 
 :HeterogeneousFeature-basedTransferLearning a owl:Class,
@@ -11125,7 +11125,7 @@ Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid
     rdfs:subClassOf :HeterogeneousTransferLearning ;
     :d3fend-id "D3A-HFBTL" ;
     :definition "Symmetric transformation  takes both the source feature space Xs and target feature space Xt and learns feature transformations as to project each onto a common subspace Xc for adaptation purposes. This derived subspace becomes a domain-invariant feature subspace to associate cross-domain data, and in effect, reduces marginal distribution differences." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid optimization algorithm. Journal of Big Data, 4(1), 25. [Link](https://journalofbigdata.springeropen.com/articles/10.1186/s40537-017-0089-0).""" .
 
 :HeterogeneousTransferLearning a owl:Class,
@@ -11134,7 +11134,7 @@ Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid
     rdfs:subClassOf :TransferLearning ;
     :d3fend-id "D3A-HTL" ;
     :definition "Heterogeneous transfer learning is characterized by the source and target domains having differing feature spaces, but may also be combined with other issues such as differing data distributions and label spaces." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid optimization algorithm. Journal of Big Data, 4(1), 25. [Link](https://journalofbigdata.springeropen.com/articles/10.1186/s40537-017-0089-0).""" .
 
 :HierarchicalClustering a owl:Class,
@@ -11143,8 +11143,8 @@ Wang, Q., Mao, K. Z., Wang, B., & Guan, J. (2017). Big data clustering by hybrid
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-HC" ;
     :definition "Hierarchical clustering (also called hierarchical cluster analysis or HCA) is a method of cluster analysis that seeks to build a hierarchy of clusters." ;
-    :kb-article """## References
-Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)
+    :kb-article """## References\r
+Wikipedia. (2021, August 10). Hierarchical clustering. [Link](https://en.wikipedia.org/wiki/Hierarchical_clustering)\r
 html)""" ;
     :todo "Consider Divisive clustering as per the wiki" .
 
@@ -11155,14 +11155,14 @@ html)""" ;
     rdfs:subClassOf :ForwardResolutionDomainDenylisting ;
     :d3fend-id "D3-HDDL" ;
     :definition "Blocking the resolution of any subdomain of a specified domain name." ;
-    :kb-article """## How it works
-This technique is used to block DNS queries from related domains and subdomains that are unauthorized.
-
-Hierarchical domain blacklisting considers the blacklisting of second level domains and additional sub-domains and specific hosts for a given query value. A denylist is maintained that contains DNS names and corresponding subdomains, including wildcards, that should be blocked for a given lookup.
-
-## Considerations
-* The denylist of domain names will have to be maintained and will need to be kept up to date
-* Other domains that resolve to the domain of interest for blocking (CNAME, etc).
+    :kb-article """## How it works\r
+This technique is used to block DNS queries from related domains and subdomains that are unauthorized.\r
+\r
+Hierarchical domain blacklisting considers the blacklisting of second level domains and additional sub-domains and specific hosts for a given query value. A denylist is maintained that contains DNS names and corresponding subdomains, including wildcards, that should be blocked for a given lookup.\r
+\r
+## Considerations\r
+* The denylist of domain names will have to be maintained and will need to be kept up to date\r
+* Other domains that resolve to the domain of interest for blocking (CNAME, etc).\r
 * Denylists should have identified maintenance cycles to ensure lists are not stale.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Hierarchical Domain Blacklisting" .
@@ -11173,7 +11173,7 @@ Hierarchical domain blacklisting considers the blacklisting of second level doma
     rdfs:subClassOf :ClusterAnalysis ;
     :d3fend-id "D3A-HDC" ;
     :definition "The cluster analysis of data with anywhere from a few dozen to many thousands of dimensions." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Clustering high-dimensional data. [Link](https://en.wikipedia.org/wiki/Clustering_high-dimensional_data)""" .
 
 :Higher-orderLogic a owl:Class,
@@ -11182,7 +11182,7 @@ Wikipedia. (n.d.). Clustering high-dimensional data. [Link](https://en.wikipedia
     rdfs:subClassOf :PredicateLogic ;
     :d3fend-id "D3A-HOL" ;
     :definition "Higher-order logic is a form of predicate logic that is distinguished from first-order logic by additional quantifiers and, sometimes, stronger semantics. Higher-order logics with their standard semantics are more expressive, but their model-theoretic properties are less well-behaved than those of first-order logic." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Higher-order logic. (2023, May 13). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Higher-order_logic)""" ;
     :synonym "HOL" .
 
@@ -11196,7 +11196,7 @@ Wikipedia. (n.d.). Clustering high-dimensional data. [Link](https://en.wikipedia
     rdfs:subClassOf :TransferLearning ;
     :d3fend-id "D3A-HTL" ;
     :definition "In homogeneous transfer learning, the feature spaces of the source and target domains is of the same dimension (Ds = Dt) while the data of both domains is represented by the same attributes (Xs = Xt) and labels (Ys = Yt). Thus, homogeneous transfer learning aims to bridge the gap in the data distributions experienced during cross-domain transfer." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Khalil, K., Asgher, U., & Ayaz, Y. (2022). Novel fNIRS study on homogeneous symmetric feature-based transfer learning for brain-computer interface. Scientific Reports, 12, 3198. [Link](https://www.nature.com/articles/s41598-022-06805-4).""" .
 
 :HomoglyphDenylisting a :ForwardResolutionDomainDenylisting,
@@ -11206,14 +11206,14 @@ Khalil, K., Asgher, U., & Ayaz, Y. (2022). Novel fNIRS study on homogeneous symm
     rdfs:subClassOf :ForwardResolutionDomainDenylisting ;
     :d3fend-id "D3-HDL" ;
     :definition "Blocking DNS queries that are deceptively similar to legitimate domain names." ;
-    :kb-article """## How it works
-
-Homoglyph domain blacklisting considers the domain and subdomain structure of a lookup and compares the named components to blacklisted named components. The blacklisted named components are typically crafted modifications of known good domains, e.g., gooogle.com versus google.com. The blacklisted domains typically resemble trusted domains, but have been altered slightly to deceive users.
-
-The blacklisted named components also include consideration for fonts or Unicode characters that can make certain characters appear very similar (zero vs capital O and the letter l vs the number one). The blacklisted domains under certain fonts will appear to be a trusted domain.
-
-## Considerations
-* Maintaining the currency of the list can be a challenge especially with newly registered domain entries.
+    :kb-article """## How it works\r
+\r
+Homoglyph domain blacklisting considers the domain and subdomain structure of a lookup and compares the named components to blacklisted named components. The blacklisted named components are typically crafted modifications of known good domains, e.g., gooogle.com versus google.com. The blacklisted domains typically resemble trusted domains, but have been altered slightly to deceive users.\r
+\r
+The blacklisted named components also include consideration for fonts or Unicode characters that can make certain characters appear very similar (zero vs capital O and the letter l vs the number one). The blacklisted domains under certain fonts will appear to be a trusted domain.\r
+\r
+## Considerations\r
+* Maintaining the currency of the list can be a challenge especially with newly registered domain entries.\r
 * Blacklists should have identified maintenance cycles to ensure lists are not stale.""" ;
     :kb-reference :Reference-DetectionOfMaliciousIDNHomoglyphDomains ;
     :synonym "Homoglyph Blacklisting" .
@@ -11231,11 +11231,11 @@ The blacklisted named components also include consideration for fonts or Unicode
             owl:someValuesFrom :URL ] ;
     :d3fend-id "D3-HD" ;
     :definition "Comparing strings using a variety of techniques to determine if a deceptive or malicious string is being presented to a user." ;
-    :kb-article """## How it works
-A homoglyph, in this context, is a deceptive string or word which looks like a trusted word, but is composed of different characters, for example: goooogle.com versus google.com. This is commonly found in phishing and typo squatting attacks where a human exploiting through a social engineering campaign.
-
-## Considerations
-* In very large environments processing DNS queries can be computationally expensive due to the amount of traffic that is generated
+    :kb-article """## How it works\r
+A homoglyph, in this context, is a deceptive string or word which looks like a trusted word, but is composed of different characters, for example: goooogle.com versus google.com. This is commonly found in phishing and typo squatting attacks where a human exploiting through a social engineering campaign.\r
+\r
+## Considerations\r
+* In very large environments processing DNS queries can be computationally expensive due to the amount of traffic that is generated\r
 * Legitimate companies and products use non-dictionary words in their names that could result in many false positives""" ;
     :kb-reference :Reference-Computer-implementedMethodsAndSystemsForIdentifyingVisuallySimilarTextCharacterStrings_GreathornInc,
         :Reference-SystemAndMethodForDetectingHomoglyphAttacksWithASiameseConvolutionalNeuralNetwork_EndgameInc .
@@ -11313,7 +11313,7 @@ A homoglyph, in this context, is a deceptive string or word which looks like a t
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-HBTL" ;
     :definition "This method creates an asymmetric mapping from the target to the source and takes into account bias issues of cross-domain correspondences." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learning. Journal of Big Data, 4(1), 29. [Link](https://doi.org/10.1186/s40537-017-0089-0).""" .
 
 :HypothesisTesting a owl:Class,
@@ -11322,7 +11322,7 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
     rdfs:subClassOf :InferentialStatistics ;
     :d3fend-id "D3A-HT" ;
     :definition "A statistical hypothesis test is a method of statistical inference used to decide whether the data at hand sufficiently support a particular hypothesis. Hypothesis testing allows us to make probabilistic statements about population parameters." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Statistical hypothesis testing. [Link](https://en.wikipedia.org/wiki/Statistical_hypothesis_testing)""" .
 
 :ID3 a owl:Class,
@@ -11331,10 +11331,10 @@ Wikipedia. (n.d.). Statistical hypothesis testing. [Link](https://en.wikipedia.o
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-ID3" ;
     :definition "ID3 stands for Iterative Dichotomiser 3 and is named such because the algorithm iteratively (repeatedly) dichotomizes(divides) features into two or more groups at each step." ;
-    :kb-article """## Addtional Consiterations
-ID3 is the basis of C4.5, and is best used in natural language processing.
-
-## References
+    :kb-article """## Addtional Consiterations\r
+ID3 is the basis of C4.5, and is best used in natural language processing.\r
+\r
+## References\r
 Decision Trees for Classification: ID3 Algorithm Explained. Towards Data Science. [Link](https://towardsdatascience.com/decision-trees-for-classification-id3-algorithm-explained-89df76e72df1).""" .
 
 :Identifier a owl:Class ;
@@ -11351,21 +11351,21 @@ Decision Trees for Classification: ID3 Algorithm Explained. Towards Data Science
     rdfs:subClassOf :IdentifierAnalysis ;
     :d3fend-id "D3-IAA" ;
     :definition "Taking known malicious identifiers and determining if they are present in a system." ;
-    :kb-article """## How it works
-
-Identifier activity analysis is the process of taking identifiers--typically known malicious identifiers--and determining the artifacts that have interacted with those identifiers.
-
-There are many open and closed source repositories of identifiers that represent indicators of compromise. For example, VirusTotal contains hash signatures of malware and IP Addresses used by threat actors. Defenders can search for these indicators of compromise their own systems to gain context on activity around an identifier.
-
-## Considerations
-
-Indicator activity analysis is a good way to gain high precision analysis, but adversaries can modify their own signatures such as hashes quickly to evade detection. This is related to David Bianco’s Pyramid of Pain - Indicators on the lower level (hash values, IP addresses domain names) are easy for adversaries to change.
-
-Identifier activity data of interest for analysis with the identifier might include, but is not limited to:
-
-* network traffic activity where the identifier was used to identify communicating entities or referred to in the communication
-* process activity referencing the identifier, especially for resource access
-* file activity referencing the identifier
+    :kb-article """## How it works\r
+\r
+Identifier activity analysis is the process of taking identifiers--typically known malicious identifiers--and determining the artifacts that have interacted with those identifiers.\r
+\r
+There are many open and closed source repositories of identifiers that represent indicators of compromise. For example, VirusTotal contains hash signatures of malware and IP Addresses used by threat actors. Defenders can search for these indicators of compromise their own systems to gain context on activity around an identifier.\r
+\r
+## Considerations\r
+\r
+Indicator activity analysis is a good way to gain high precision analysis, but adversaries can modify their own signatures such as hashes quickly to evade detection. This is related to David Bianco’s Pyramid of Pain - Indicators on the lower level (hash values, IP addresses domain names) are easy for adversaries to change.\r
+\r
+Identifier activity data of interest for analysis with the identifier might include, but is not limited to:\r
+\r
+* network traffic activity where the identifier was used to identify communicating entities or referred to in the communication\r
+* process activity referencing the identifier, especially for resource access\r
+* file activity referencing the identifier\r
 * registry settings referencing the identifier""" ;
     :kb-reference :Reference-ThePyramidOfPain-DavidBianco .
 
@@ -11399,7 +11399,7 @@ Identifier activity data of interest for analysis with the identifier might incl
     rdfs:subClassOf :GenerativeAdversarialNetwork ;
     :d3fend-id "D3A-ITITG" ;
     :definition "Image-to-image translation is the task of transferring styles and characteristics from one image domain to another." ;
-    :kb-article """## References
+    :kb-article """## References\r
 MathWorks. (n.d.). Get Started with GANs for Image-to-Image Translation. [Link](https://www.mathworks.com/help/images/get-started-with-gans-for-image-to-image-translation.html)""" .
 
 :ImageCodeSegment a owl:Class ;
@@ -11440,8 +11440,8 @@ MathWorks. (n.d.). Get Started with GANs for Image-to-Image Translation. [Link](
     rdfs:subClassOf :GenerativeAdversarialNetwork ;
     :d3fend-id "D3A-ISG" ;
     :definition "Image synthesis thorugh the application of Generative Adversarial Networks." ;
-    :kb-article """## References
-
+    :kb-article """## References\r
+\r
 Zhang, Q., Wang, H., Lu, H., Won, D., & Yoon, S. W. (2018). Medical Image Synthesis with Generative Adversarial Networks for Tissue Recognition. 2018 IEEE International Conference on Healthcare Informatics (ICHI), 199-207. doi: 10.1109/ICHI.2018.00030. [Link](https://ieeexplore.ieee.org/document/8419363)""" .
 
 :Impact a :OffensiveTactic,
@@ -11518,10 +11518,10 @@ Zhang, Q., Wang, H., Lu, H., Won, D., & Yoon, S. W. (2018). Medical Image Synthe
             owl:someValuesFrom :InboundInternetNetworkTraffic ] ;
     :d3fend-id "D3-ISVA" ;
     :definition "Analyzing inbound network session or connection attempt volume." ;
-    :kb-article """## How it works
-Network appliances are configured to alert on certain packets that typically are involved in DoS attacks. Typical packets include ICMP packets and SYN requests that are commonly used to flood networks. A sampling period is used to define a time window in which collected counts of the identified packets can be measured. If the collected number of packets exceeds a predefined limit then an alert is generated.
-
-## Considerations
+    :kb-article """## How it works\r
+Network appliances are configured to alert on certain packets that typically are involved in DoS attacks. Typical packets include ICMP packets and SYN requests that are commonly used to flood networks. A sampling period is used to define a time window in which collected counts of the identified packets can be measured. If the collected number of packets exceeds a predefined limit then an alert is generated.\r
+\r
+## Considerations\r
 Scalability as volume of attacks increase; single servers may not have the memory and storage resources to handle high volumes of network traffic.""" ;
     :kb-reference :Reference-DetectingDDoSAttackUsingSnort,
         <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-IdentifyingADenial-of-serviceAttackInACloud-basedProxyService-CloudfareInc.>,
@@ -11539,28 +11539,28 @@ Scalability as volume of attacks increase; single servers may not have the memor
             owl:someValuesFrom :InboundNetworkTraffic ] ;
     :d3fend-id "D3-ITF" ;
     :definition "Restricting network traffic originating from untrusted networks destined towards a private host or enclave." ;
-    :kb-article """## How it works
-Inbound Traffic, in this context, is network traffic originating from an untrusted network towards a private host or enclave.
-For example:
-
-* An untrusted network host connecting to a internal commercial portal, shopping.example.com
-* An external mail server connecting to an internal mail server, mail.example.com
-
-Filtering policies are developed by administrators to meet business requirements and limit connectivity. These policies are implemented on edge devices such as firewalls, routers, and intrusion prevention systems. Examples of filters:
-
-* Blocking incoming traffic from spoofed internally facing IP addresses
-* Blocking specific ports and services from establishing connections
-* Limiting specific IP ranges from connecting to the network
-* Dynamic inbound filtering (Hole punching, STUN, NAT-T)
-
-## Considerations
-* Business requirements typically drive the development of filtering rulesets
-* Protocols using non-standard ports may circumvent filtering technology, which does not detect application protocol based on traffic content
-
-## Implementations
-* OpenWRT (Embedded)
-* Netfilter (Linux)
-* Windows Firewall
+    :kb-article """## How it works\r
+Inbound Traffic, in this context, is network traffic originating from an untrusted network towards a private host or enclave.\r
+For example:\r
+\r
+* An untrusted network host connecting to a internal commercial portal, shopping.example.com\r
+* An external mail server connecting to an internal mail server, mail.example.com\r
+\r
+Filtering policies are developed by administrators to meet business requirements and limit connectivity. These policies are implemented on edge devices such as firewalls, routers, and intrusion prevention systems. Examples of filters:\r
+\r
+* Blocking incoming traffic from spoofed internally facing IP addresses\r
+* Blocking specific ports and services from establishing connections\r
+* Limiting specific IP ranges from connecting to the network\r
+* Dynamic inbound filtering (Hole punching, STUN, NAT-T)\r
+\r
+## Considerations\r
+* Business requirements typically drive the development of filtering rulesets\r
+* Protocols using non-standard ports may circumvent filtering technology, which does not detect application protocol based on traffic content\r
+\r
+## Implementations\r
+* OpenWRT (Embedded)\r
+* Netfilter (Linux)\r
+* Windows Firewall\r
 * pf(BSD)""" ;
     :kb-reference :Reference-ActiveFirewallSystemAndMethodology_McAfeeLLC,
         :Reference-AutomaticallyGeneratingRulesForConnectionSecurity_Microsoft,
@@ -11579,34 +11579,34 @@ Filtering policies are developed by administrators to meet business requirements
     rdfs:subClassOf :ProcessAnalysis ;
     :d3fend-id "D3-IBCA" ;
     :definition "Analyzing vendor specific branch call recording in order to detect ROP style attacks." ;
-    :kb-article """## How it works
-
-This technique is used to detect an attacker attempting to exploit and execute code on a target system's call stack using return-oriented programming (ROP). Modern processors that have the ability to maintain a list of the branching calls, e.g., Intel's Last Branch Recording (LBR), can be used to track and analyze indirect branching calls that are indicative of malicious activity.
-
-In order to reduce the number of indirect branch calls to analyze to a manageable set it is assumed that malicious ROP activity will involve the use of system calls.  The technique observes indirect branch calls that are part of paths that lead to system calls, all others are ignored. Branching calls chained together is often referred to as gadgets and gadgets are often used in ROP attacks. Indirect branch calls that involve a transfer from user-space to kernel-space are of interest for this technique.
-
-Identification of potential ROP exploit execution includes:
-
-- Inspecting the LBR when a system function call is made
-
-  - The LBR is configured to return only instruction of interest (ret, indirect jmp, indirect calls)
-
-
-- Behavior is analyzed for
-  - Ret instructions that appear to target areas not preceded by the call sites
-  - Sequences of small code fragments that appear to be chained through the indirect branching calls (gadgets)
-
-
-- Of interest are returns that appear to not render control back after calls
-  - Typical ret-call are paired
-  - gadgets will appear to have ret followed by instruction of next instruction of the following gadget
-
-
-## Considerations
-
-* May be operating system dependent since specific system calls are used to scope branching behavoir
-* Processors need to support access to a Last Branch Recording list feature
-* The size of the LBR stack can limit the expected size of the analyzed execution stack
+    :kb-article """## How it works\r
+\r
+This technique is used to detect an attacker attempting to exploit and execute code on a target system's call stack using return-oriented programming (ROP). Modern processors that have the ability to maintain a list of the branching calls, e.g., Intel's Last Branch Recording (LBR), can be used to track and analyze indirect branching calls that are indicative of malicious activity.\r
+\r
+In order to reduce the number of indirect branch calls to analyze to a manageable set it is assumed that malicious ROP activity will involve the use of system calls.  The technique observes indirect branch calls that are part of paths that lead to system calls, all others are ignored. Branching calls chained together is often referred to as gadgets and gadgets are often used in ROP attacks. Indirect branch calls that involve a transfer from user-space to kernel-space are of interest for this technique.\r
+\r
+Identification of potential ROP exploit execution includes:\r
+\r
+- Inspecting the LBR when a system function call is made\r
+\r
+  - The LBR is configured to return only instruction of interest (ret, indirect jmp, indirect calls)\r
+\r
+\r
+- Behavior is analyzed for\r
+  - Ret instructions that appear to target areas not preceded by the call sites\r
+  - Sequences of small code fragments that appear to be chained through the indirect branching calls (gadgets)\r
+\r
+\r
+- Of interest are returns that appear to not render control back after calls\r
+  - Typical ret-call are paired\r
+  - gadgets will appear to have ret followed by instruction of next instruction of the following gadget\r
+\r
+\r
+## Considerations\r
+\r
+* May be operating system dependent since specific system calls are used to scope branching behavoir\r
+* Processors need to support access to a Last Branch Recording list feature\r
+* The size of the LBR stack can limit the expected size of the analyzed execution stack\r
 * If processor does not support LBR then overhead costs for the analysis can be significant""" ;
     :kb-reference :Reference-IndirectBranchingCalls .
 
@@ -11616,7 +11616,7 @@ Identification of potential ROP exploit execution includes:
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-IS" ;
     :definition "Statistical inference is the process of using data analysis to infer properties of an underlying distribution of probability." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Statistical inference. [Link](https://en.wikipedia.org/wiki/Statistical_inference)""" .
 
 :InformationContentEntity a owl:Class ;
@@ -11666,53 +11666,53 @@ Wikipedia. (n.d.). Statistical inference. [Link](https://en.wikipedia.org/wiki/S
             owl:someValuesFrom :InputDevice ] ;
     :d3fend-id "D3-IDA" ;
     :definition "Operating system level mechanisms to prevent abusive input device exploitation." ;
-    :kb-article """## How it works
-
-Input Device Hardening techniques filter certain commands, or disable related operating system functionality.
-
-### Analytics
-
-All of these values can be analyzed and compared to a baseline:
-
-* Amount of input
-* Duration of a single input
-* Durations between inputs
-* Value of input
-
-Context can also include:
-
-* User which is logged in, to include attributes such as physical location of the user
-* Date and time
-* System which is processing the input
-* Source device of input, to include its properties (eg. manufacturer), configuration (eg. keyboard layout) and behavioral attributes of this device (eg. first use)
-* Source system of input (local or remote system)
-* Other hardware devices attached to the system
-
-
-### Actions
-
-Actions can include:
-
-* Disabling the source device
-* Sending an alert
-* Locking the current session (eg. system screen lock, or returning to an authentication screen in a web app) and requiring one or more methods of authentication to continue
-* Administratively disabling credentials for the account or the entire account -- the technique *Account Locking*
-
-
-### Examples
-A malicious input device sends many keystrokes with approximately the same delay between each.  This does not match the normal cadence of input, and the device is disabled.
-
-Input to type the session user's name takes abnormally longer for each keystroke.  The system is locked to the password prompt screen.
-
-A system receives key press events from two different devices -- one device sends keystrokes after the other has been idle for a long time.
-
-A system receives physical input in a user session, while that user has sent input from a device located out of the country in the past hour.
-
-Network traffic is suddenly routed through a new external device, and nearly the same volume of network traffic is subsequently sent out the previously existing interface.  The new external device is disabled, and an alert is raised to investigate the network configuration for a potential compromise.
-
-
-## Considerations
-
+    :kb-article """## How it works\r
+\r
+Input Device Hardening techniques filter certain commands, or disable related operating system functionality.\r
+\r
+### Analytics\r
+\r
+All of these values can be analyzed and compared to a baseline:\r
+\r
+* Amount of input\r
+* Duration of a single input\r
+* Durations between inputs\r
+* Value of input\r
+\r
+Context can also include:\r
+\r
+* User which is logged in, to include attributes such as physical location of the user\r
+* Date and time\r
+* System which is processing the input\r
+* Source device of input, to include its properties (eg. manufacturer), configuration (eg. keyboard layout) and behavioral attributes of this device (eg. first use)\r
+* Source system of input (local or remote system)\r
+* Other hardware devices attached to the system\r
+\r
+\r
+### Actions\r
+\r
+Actions can include:\r
+\r
+* Disabling the source device\r
+* Sending an alert\r
+* Locking the current session (eg. system screen lock, or returning to an authentication screen in a web app) and requiring one or more methods of authentication to continue\r
+* Administratively disabling credentials for the account or the entire account -- the technique *Account Locking*\r
+\r
+\r
+### Examples\r
+A malicious input device sends many keystrokes with approximately the same delay between each.  This does not match the normal cadence of input, and the device is disabled.\r
+\r
+Input to type the session user's name takes abnormally longer for each keystroke.  The system is locked to the password prompt screen.\r
+\r
+A system receives key press events from two different devices -- one device sends keystrokes after the other has been idle for a long time.\r
+\r
+A system receives physical input in a user session, while that user has sent input from a device located out of the country in the past hour.\r
+\r
+Network traffic is suddenly routed through a new external device, and nearly the same volume of network traffic is subsequently sent out the previously existing interface.  The new external device is disabled, and an alert is raised to investigate the network configuration for a potential compromise.\r
+\r
+\r
+## Considerations\r
+\r
 Given some example of legitimate behavioral input patterns, attackers could mimic those input patterns, a technique which has been used in popular culture in the creation of Deepfake videos and [This Person Does Not Exist](https://thispersondoesnotexist.com).""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ContinuousAuthenticationByAnalysisOfKeyboardTypingCharacteristics_BradfordUniv.,UK>,
         :Reference-www.biometric-solutions.com_keystroke-dynamics .
@@ -11728,7 +11728,7 @@ Given some example of legitimate behavioral input patterns, attackers could mimi
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-IBTL" ;
     :definition "Instance-based transfer learning methods try to reweight the samples in the source domain in an attempt to correct for marginal distribution differences. These reweighted instances are then directly used in the target domain for training." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.com/georgian-impact-blog/transfer-learning-part-1-ed0c174ad6e7#:~:text=Homogeneous%20Transfer%20Learning-,1.,the%20target%20domain%20for%20training).""" .
 
 :InstantMessagingClient a owl:Class ;
@@ -11747,15 +11747,15 @@ Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.co
             owl:someValuesFrom :IntranetNetwork ] ;
     :d3fend-id "D3-IHN" ;
     :definition "The practice of setting decoys in a production environment to entice interaction from attackers." ;
-    :kb-article """## How it works
-Integrated honeynets use full production environments connected to the enterprise network, that utilize computing resources or software that attract attackers, and allow full interaction and access that provides a complete view of an attack.
-
-## Considerations
-An attacker with control of a system on an Integrated Honeynet could:
-* try to attack other connected hosts on the network, its IP range of internal hosts not properly configured to react to connections from machines on the integrated honeynet, or position behind the firewall.
-* exploit its position by eavesdropping on network traffic
-If an attacker manages to stop the processes used to log an attack without setting off any alarms. [1]
-
+    :kb-article """## How it works\r
+Integrated honeynets use full production environments connected to the enterprise network, that utilize computing resources or software that attract attackers, and allow full interaction and access that provides a complete view of an attack.\r
+\r
+## Considerations\r
+An attacker with control of a system on an Integrated Honeynet could:\r
+* try to attack other connected hosts on the network, its IP range of internal hosts not properly configured to react to connections from machines on the integrated honeynet, or position behind the firewall.\r
+* exploit its position by eavesdropping on network traffic\r
+If an attacker manages to stop the processes used to log an attack without setting off any alarms. [1]\r
+\r
 1. Honeypots for Windows, Roger Grimes, 2005""" ;
     :kb-reference :Reference-SynchronizingAHoneyNetworkConfigurationToReflectATargetNetworkEnvironment_PaloAltoNetworksInc .
 
@@ -11816,7 +11816,7 @@ If an attacker manages to stop the processes used to log an attack without setti
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-IR" ;
     :definition "The interquartile range (IQR) is a measure of statistical dispersion, which is the spread of the data and is defined as the difference between the 75th and 25th percentiles of the data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Interquartile range. [Link](https://en.wikipedia.org/wiki/Interquartile_range)""" ;
     :synonym "IQR" .
 
@@ -11826,7 +11826,7 @@ Wikipedia. (n.d.). Interquartile range. [Link](https://en.wikipedia.org/wiki/Int
     rdfs:subClassOf :Estimation ;
     :d3fend-id "D3A-IE" ;
     :definition "Interval estimation is the use of sample data to estimate an interval of possible values of a parameter of interest." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Interval estimation. [Link](https://en.wikipedia.org/wiki/Interval_estimation)""" .
 
 :IntranetAdministrativeNetworkTraffic a owl:Class ;
@@ -11904,7 +11904,7 @@ Wikipedia. (n.d.). Interval estimation. [Link](https://en.wikipedia.org/wiki/Int
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-ISSL" ;
     :definition "These methods directly optimize an objective function with components for labeled and unlabeled samples and do not rely on any intermediate steps or supervised base learners. Basically, these methods are extension of existing supervised methods to include the effect of unlabeled data samples in the objective function." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Beginner's Guide to Semi-Supervised Learning. Jashish Blog.  [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/).""" .
 
 :IntrusionDetectionSystem a owl:Class ;
@@ -11921,8 +11921,8 @@ Beginner's Guide to Semi-Supervised Learning. Jashish Blog.  [Link](http://jashi
         "IPS" ;
     rdfs:subClassOf :IntrusionDetectionSystem ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Intrusion_detection_system#Intrusion_prevention> ;
-    :definition """Intrusion prevention systems (IPS), also known as intrusion detection and prevention systems (IDPS), are network security appliances that monitor network or system activities for malicious activity. The main functions of intrusion prevention systems are to identify malicious activity, log information about this activity, report it and attempt to block or stop it.
-
+    :definition """Intrusion prevention systems (IPS), also known as intrusion detection and prevention systems (IDPS), are network security appliances that monitor network or system activities for malicious activity. The main functions of intrusion prevention systems are to identify malicious activity, log information about this activity, report it and attempt to block or stop it.\r
+\r
 Intrusion prevention systems are considered extensions of intrusion detection systems because they both monitor network traffic and/or system activities for malicious activity. The main differences are, unlike intrusion detection systems, intrusion prevention systems are placed in-line and are able to actively prevent or block intrusions that are detected. IPS can take such actions as sending an alarm, dropping detected malicious packets, resetting a connection or blocking traffic from the offending IP address. An IPS also can correct cyclic redundancy check (CRC) errors, defragment packet streams, mitigate TCP sequencing issues, and clean up unwanted transport and network layer options.""" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Intrusion_detection_system> .
 
@@ -11939,21 +11939,21 @@ Intrusion prevention systems are considered extensions of intrusion detection sy
             owl:someValuesFrom :RemovableMediaDevice ] ;
     :d3fend-id "D3-IOPR" ;
     :definition "Limiting access to computer input/output (IO) ports to restrict unauthorized devices." ;
-    :kb-article """## How It works
-
-Software-based restriction uses agent software installed on a computer system. The agent software monitors all IO port system traffic. The agent software is configurable to limit the use of certain devices connected to IO ports. The restriction software can also be configured to limit the access to files and applications on external storage devices connected to IO ports.
-
-Hardware-based restriction can also be employed to limit access to IO ports. For example, a hardware USB filter device that is placed between the host system and the external devices can filter IO port connections based on configurable rules. When new devices are connected to the USB filter the type of device is determined. Using an allow list a connection determination is made for the device.
-
-Some implementations detect when a device is connected in order to authorize the connection against a list of approved devices, in some cases by device type. For example, if the device is determined to be a storage device, then the contained files and executables are examined to more accurately identify the device type.
-
-Types of restrictions that may be applied:
-- Device connection
-- Device command filtering
-- Device file system read or write restrictions
-
-## Considerations
- * Agent software will need to be installed on host systems
+    :kb-article """## How It works\r
+\r
+Software-based restriction uses agent software installed on a computer system. The agent software monitors all IO port system traffic. The agent software is configurable to limit the use of certain devices connected to IO ports. The restriction software can also be configured to limit the access to files and applications on external storage devices connected to IO ports.\r
+\r
+Hardware-based restriction can also be employed to limit access to IO ports. For example, a hardware USB filter device that is placed between the host system and the external devices can filter IO port connections based on configurable rules. When new devices are connected to the USB filter the type of device is determined. Using an allow list a connection determination is made for the device.\r
+\r
+Some implementations detect when a device is connected in order to authorize the connection against a list of approved devices, in some cases by device type. For example, if the device is determined to be a storage device, then the contained files and executables are examined to more accurately identify the device type.\r
+\r
+Types of restrictions that may be applied:\r
+- Device connection\r
+- Device command filtering\r
+- Device file system read or write restrictions\r
+\r
+## Considerations\r
+ * Agent software will need to be installed on host systems\r
  * Configurations for allow/deny for devices and files will need to be maintained""" ;
     :kb-reference :Reference-ComputerMotherboardHavingPeripheralSecurityFunctions,
         :Reference-MethodAndSystemForControllingCommunicationPorts,
@@ -11983,17 +11983,17 @@ Types of restrictions that may be applied:
             owl:someValuesFrom :IntranetIPCNetworkTraffic ] ;
     :d3fend-id "D3-IPCTA" ;
     :definition "Analyzing standard inter process communication (IPC) protocols to detect deviations from normal protocol activity." ;
-    :kb-article """## How it works
-Inter process communication enables applications or threads to share data. This can involve one or more computers. Monitoring IPC in your environment can reveal abnormal or malicious activity.
-IPC can occur within a single computer or between multiple computers remotely through network protocols. Thus there are multiple ways to collect and monitor these exchanges between processes. A network protocol analyzer may monitor and parse SMB network traffic to record system activity. A host based monitoring agent may monitor IPC activity contained within a single host to look for deviations from standard usages.
-
-### Examples
- * SMB
- * Zeromq
- * Java RMI API
-
-## Considerations
-* IPC can generate substantial amounts of data, and it may not be feasible to collect all of it.
+    :kb-article """## How it works\r
+Inter process communication enables applications or threads to share data. This can involve one or more computers. Monitoring IPC in your environment can reveal abnormal or malicious activity.\r
+IPC can occur within a single computer or between multiple computers remotely through network protocols. Thus there are multiple ways to collect and monitor these exchanges between processes. A network protocol analyzer may monitor and parse SMB network traffic to record system activity. A host based monitoring agent may monitor IPC activity contained within a single host to look for deviations from standard usages.\r
+\r
+### Examples\r
+ * SMB\r
+ * Zeromq\r
+ * Java RMI API\r
+\r
+## Considerations\r
+* IPC can generate substantial amounts of data, and it may not be feasible to collect all of it.\r
 * IPC may occur over loopback interfaces or direct memory access granted by the operating system.""" ;
     :kb-reference :Reference-CAR-2015-04-001%3ARemotelyScheduledTasksViaAT_MITRE,
         :Reference-SecuritySystemWithMethodologyForInterprocessCommunicationControl_CheckPointSoftwareTechInc,
@@ -12057,10 +12057,10 @@ IPC can occur within a single computer or between multiple computers remotely th
             owl:someValuesFrom :Authorization ] ;
     :d3fend-id "D3-JFAPA" ;
     :definition "Detecting anomalies in user access patterns by comparing user access activity to behavioral profiles that categorize users by role such as job title, function, department." ;
-    :kb-article """## How it works
-Peer group analysis identifies functionally similar groups of actors (users or resources) based on categorizations such as job title, organizational hierarchy, or other attribute that indicates similarity of job function. Current user access activity is then compared to the appropriate peer group behavior profile to identify anomalies.
-
-## Considerations
+    :kb-article """## How it works\r
+Peer group analysis identifies functionally similar groups of actors (users or resources) based on categorizations such as job title, organizational hierarchy, or other attribute that indicates similarity of job function. Current user access activity is then compared to the appropriate peer group behavior profile to identify anomalies.\r
+\r
+## Considerations\r
 Potential for false positives from anomalies that are not associated with malicious activity.""" ;
     :kb-reference :Reference-AnomalyDetectionUsingAdaptiveBehavioralProfiles_SecuronixInc .
 
@@ -12106,7 +12106,7 @@ Potential for false positives from anomalies that are not associated with malici
     rdfs:subClassOf :ResamplingEnsemble ;
     :d3fend-id "D3A-KFCV" ;
     :definition "Cross-validation is a resampling procedure used to evaluate machine learning models on a limited data sample. The procedure has a single parameter called k that refers to the number of groups that a given data sample is to be split into. As such, the procedure is often called k-fold cross-validation. When a specific value for k is chosen, it may be used in place of k in the reference to the model, such as k=10 becoming 10-fold cross-validation" ;
-    :kb-article """## References
+    :kb-article """## References\r
 K-Fold Cross-Validation. Machine Learning Mastery.  [Link](https://machinelearningmastery.com/k-fold-cross-validation/#:~:text=Cross%2Dvalidation%20is%20a%20resampling,k%2Dfold%20cross%2Dvalidation).""" .
 
 :K-meansClustering a owl:Class,
@@ -12115,7 +12115,7 @@ K-Fold Cross-Validation. Machine Learning Mastery.  [Link](https://machinelearni
     rdfs:subClassOf :Centroid-basedClustering ;
     :d3fend-id "D3A-KMC" ;
     :definition "K-means algorithm identifies k number of centroids, and then allocates every data point to the nearest cluster, while keeping the centroids as small as possible." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Towards Data Science. (n.d.). Understanding K-means Clustering in Machine Learning. [Link](https://towardsdatascience.com/understanding-k-means-clustering-in-machine-learning-6a6e67336aa1)""" .
 
 :K-NearestNeighbors a owl:Class,
@@ -12124,11 +12124,11 @@ Towards Data Science. (n.d.). Understanding K-means Clustering in Machine Learni
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-KNN" ;
     :definition "The k-nearest neighbors algorithm, also known as KNN or k-NN, is a non-parametric, supervised learning classifier, which uses proximity to make classifications or predictions about the grouping of an individual data point." ;
-    :kb-article """## How it works
-For classification problems, a class label is assigned on the basis of a majority vote-i.e. the label that is most frequently represented around a given data point is used. While this is technically considered “plurality voting”, the term, “majority vote” is more commonly used in literature. The distinction between these terminologies is that “majority voting” technically requires a majority of greater than 50%, which primarily works when there are only two categories. When you have multiple classes-e.g. four categories, you don’t necessarily need 50% of the vote to make a conclusion about a class; you could assign a class label with a vote of greater than 25%.
-
-
-## References
+    :kb-article """## How it works\r
+For classification problems, a class label is assigned on the basis of a majority vote-i.e. the label that is most frequently represented around a given data point is used. While this is technically considered “plurality voting”, the term, “majority vote” is more commonly used in literature. The distinction between these terminologies is that “majority voting” technically requires a majority of greater than 50%, which primarily works when there are only two categories. When you have multiple classes-e.g. four categories, you don’t necessarily need 50% of the vote to make a conclusion about a class; you could assign a class label with a vote of greater than 25%.\r
+\r
+\r
+## References\r
 K-Nearest Neighbors (k-NN). IBM. [Link](https://www.ibm.com/topics/knn?mhsrc=ibmsearch_a&mhq=k-nearest%20neighbors%20).""" .
 
 :KendallsRankCorrelationCoefficient a owl:Class,
@@ -12138,8 +12138,8 @@ K-Nearest Neighbors (k-NN). IBM. [Link](https://www.ibm.com/topics/knn?mhsrc=ibm
     rdfs:isDefinedBy "https://reference.wolfram.com/language/ref/KendallTau.html" ;
     :d3fend-id "D3A-KRCC" ;
     :definition "Kendall's $\\\\tau$ between and is given by $(n_c - n_d) / \\\\sqrt((n_c+n_d+n_x)(n_c+n_d+n_y)$, where is the number of concordant pairs of observations, is the number of discordant pairs, is the number of ties involving only the variable, and is the number of ties involving only the variable.\" ;" ;
-    :kb-article """## References
-1. Wolfram Research. (2012). KendallTau. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/KendallTau.html)
+    :kb-article """## References\r
+1. Wolfram Research. (2012). KendallTau. Wolfram Language function.  [Link](https://reference.wolfram.com/language/ref/KendallTau.html)\r
 1. Kendall's Tau. (2023, May 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Kendall_rank_correlation_coefficient]\"\"\",""" ;
     :synonym "Kendall's Tau Coefficient" .
 
@@ -12209,8 +12209,8 @@ K-Nearest Neighbors (k-NN). IBM. [Link](https://www.ibm.com/topics/knn?mhsrc=ibm
         "Loadable Kernel Module" ;
     rdfs:subClassOf :ObjectFile ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Loadable_kernel_module> ;
-    :definition """A loadable kernel module (LKM) is an object file that contains code to extend the running kernel, or so-called base kernel, of an operating system. LKMs are typically used to add support for new hardware (as device drivers) and/or filesystems, or for adding system calls. When the functionality provided by a LKM is no longer required, it can be unloaded in order to free memory and other resources.
-
+    :definition """A loadable kernel module (LKM) is an object file that contains code to extend the running kernel, or so-called base kernel, of an operating system. LKMs are typically used to add support for new hardware (as device drivers) and/or filesystems, or for adding system calls. When the functionality provided by a LKM is no longer required, it can be unloaded in order to free memory and other resources.\r
+\r
 Most current Unix-like systems and Microsoft Windows support loadable kernel modules, although they might use a different name for them, such as kernel loadable module (kld) in FreeBSD, kernel extension (kext) in macOS,[1] kernel extension module in AIX, kernel-mode driver in Windows NT[2] and downloadable kernel module (DKM) in VxWorks. They are also known as kernel loadable modules (or KLM), and simply as kernel modules (KMOD).""" ;
     rdfs:seeAlso "https://schema.ocsf.io/objects/kernel_driver" .
 
@@ -12243,7 +12243,7 @@ Most current Unix-like systems and Microsoft Windows support loadable kernel mod
     rdfs:subClassOf :DistributionProperties ;
     :d3fend-id "D3A-KUR" ;
     :definition "The measure of the \"fatness\" of the tails of a pmf or pdf. The fourth standardized moment of the distribution." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wiki/Probability_distribution)""" .
 
 :LaptopComputer a owl:Class ;
@@ -12286,7 +12286,7 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
     rdfs:subClassOf :ApproximateStringMatching ;
     :d3fend-id "D3A-LM" ;
     :definition "The Levenshtein distance (LD) is a metric for measuring the differences between two sequences - or strings. Informally, the LD is the number of individual edits one would have to make to turn one sequence into another." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Navarro, G. (2001). A guided tour to approximate string matching. _ACM Computing Surveys_, 33(1), 31-88. [Link](https://doi.org/10.1145/375360.375365)""" ;
     :synonym "Edit Distance" .
 
@@ -12301,7 +12301,7 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-LC" ;
     :definition "A linear classifier is a model that makes a decision to categories a set of data points to a discrete class based on a linear combination of its explanatory variables" ;
-    :kb-article """## References
+    :kb-article """## References\r
 A Look at the Maths Behind Linear Classification. Towards Data Science. [Link](https://towardsdatascience.com/a-look-at-the-maths-behind-linear-classification-166e99a9e5fb).""" .
 
 :LinearLogicProgramming a owl:Class,
@@ -12310,8 +12310,8 @@ A Look at the Maths Behind Linear Classification. Towards Data Science. [Link](h
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-LLP" ;
     :definition "Linear logic programming is a form of logic programming that uses linear logic, that is, it emphasizes the use of formulas as resources." ;
-    :kb-article """## References
-1. Cosmo, R. and Miller D. (2019, May 24). _Linear logic_. Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-linear/#LinLogComSci)
+    :kb-article """## References\r
+1. Cosmo, R. and Miller D. (2019, May 24). _Linear logic_. Stanford Encyclopedia of Philosophy. [Link](https://plato.stanford.edu/entries/logic-linear/#LinLogComSci)\r
 2. Linear logic programming. (2023, May 16). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Logic_programming#Linear_logic_programming)""" .
 
 :LinearRegression a owl:Class,
@@ -12320,34 +12320,34 @@ A Look at the Maths Behind Linear Classification. Towards Data Science. [Link](h
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-LR" ;
     :definition "Statistical regression method used for predictive analysis by modeling the linear relationship between independent and dependent variables." ;
-    :kb-article """## How it works
-Takes independent variables (i.e. covariate, features, predictors, input variables) and dependent variables (i.e. response, output, “thing to be estimated”) and produces the coefficient(s) and intercept for a linear equation (e.g. (β1, β0) for y = β1x + β0) which predicts the relationship between the independent and independent variables by minimizing a cost function, Mean Squared Error, either directly in the case of univariate linear regression or by gradient descent* in the case of multivariate linear regression.
-
-## Considerations
- - There are four principal assumptions required for good results using linear regression (the first letters of the four principal assumptions form the "LINE" mnemonic):
-   - Linearity and Additivity
-   - Independent Residuals
-   - Normal Residual Distributions
-   - Equal Variances (i.e. homoscedasticity)
- - Linear regression is a low variance/high bias model.
- - Optimizers like Adam, Batch, and Mini-Batch and others are available for certain applications and data sets.
-- A large learning ratio or training coefficient may lead to divergent behavior of the model and too small of values may lead to long run times and inefficiency.
-
-
-## Verification Approach
- - Models are often evaluated by examining one or more of the metrics of R2, Root Mean Squared Error (RMSE), Mean Absolute Error (MAE), and Mean Absolute Percentage Error (MAPE).
- - While there is no generally accepted single best performance metric as a criterion, users of linear regression should consider the suitability of one or more of these metrics for assessing the performance of their model.
- - Use well known data sets to verify model execution.
-
-## Validation Approach
- - Violating the principal assumptions of linear regression results in poor or misleading results.
- - Ensure data is truly representative and if there are any known biases.
-
-
-## References
-1. Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.
-1. Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.
-1. Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.
+    :kb-article """## How it works\r
+Takes independent variables (i.e. covariate, features, predictors, input variables) and dependent variables (i.e. response, output, “thing to be estimated”) and produces the coefficient(s) and intercept for a linear equation (e.g. (β1, β0) for y = β1x + β0) which predicts the relationship between the independent and independent variables by minimizing a cost function, Mean Squared Error, either directly in the case of univariate linear regression or by gradient descent* in the case of multivariate linear regression.\r
+\r
+## Considerations\r
+ - There are four principal assumptions required for good results using linear regression (the first letters of the four principal assumptions form the "LINE" mnemonic):\r
+   - Linearity and Additivity\r
+   - Independent Residuals\r
+   - Normal Residual Distributions\r
+   - Equal Variances (i.e. homoscedasticity)\r
+ - Linear regression is a low variance/high bias model.\r
+ - Optimizers like Adam, Batch, and Mini-Batch and others are available for certain applications and data sets.\r
+- A large learning ratio or training coefficient may lead to divergent behavior of the model and too small of values may lead to long run times and inefficiency.\r
+\r
+\r
+## Verification Approach\r
+ - Models are often evaluated by examining one or more of the metrics of R2, Root Mean Squared Error (RMSE), Mean Absolute Error (MAE), and Mean Absolute Percentage Error (MAPE).\r
+ - While there is no generally accepted single best performance metric as a criterion, users of linear regression should consider the suitability of one or more of these metrics for assessing the performance of their model.\r
+ - Use well known data sets to verify model execution.\r
+\r
+## Validation Approach\r
+ - Violating the principal assumptions of linear regression results in poor or misleading results.\r
+ - Ensure data is truly representative and if there are any known biases.\r
+\r
+\r
+## References\r
+1. Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.\r
+1. Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.\r
+1. Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.\r
 1. Bochkarev, Alexei. "A New Typology Design of Performance Metrics to Measure Errors in Machine Learning Regression Algorithms", 2019, https://www.researchgate.net/publication/330661543_A_New_Typology_Design_of_Performance_Metrics_to_Measure_Errors_in_Machine_Learning_Regression_Algorithms.""" .
 
 :LinearRegressionLearning a owl:Class,
@@ -12356,10 +12356,10 @@ Takes independent variables (i.e. covariate, features, predictors, input variabl
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-LRL" ;
     :definition "A supervised learning method that builds a linear regression model using training data." ;
-    :kb-article """## References
-- Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.
-- Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.
-- Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.
+    :kb-article """## References\r
+- Gawali, Suvarna. “Linear Regression Algorithm to Make Predictions Easily.” Analytics Vidhya, 22 July 2022, https://www.analyticsvidhya.com/blog/2021/06/linear-regression-in-machine-learning/.\r
+- Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.\r
+- Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.\r
 - Bochkarev, Alexei. "A New Typology Design of Performance Metrics to Measure Errors in Machine Learning Regression Algorithms", 2019, https://www.researchgate.net/publication/330661543_A_New_Typology_Design_of_Performance_Metrics_to_Measure_Errors_in_Machine_Learning_Regression_Algorithms.""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#LinearRegression" .
 
@@ -12384,8 +12384,8 @@ Takes independent variables (i.e. covariate, features, predictors, input variabl
     rdfs:label "Linux Clone3" ;
     rdfs:subClassOf :CreateProcess ;
     rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/clone3.2.html" ;
-    :definition """Creates a child process and provides more precise control over the data shared between the parent and child processes.
-
+    :definition """Creates a child process and provides more precise control over the data shared between the parent and child processes.\r
+\r
 Newer system call.""" .
 
 :LinuxClone3ArgumentCLONE_THREAD a owl:Class ;
@@ -12689,10 +12689,10 @@ Newer system call.""" .
             owl:onProperty :contains ;
             owl:someValuesFrom :Log ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Log_file> ;
-    :definition """A log file is a file that records either events that occur in an operating system or other software runs, or messages between different users of a communication software. Logging is the act of keeping a log. In the simplest case, messages are written to a single log file.
-
-A transaction log is a file (i.e., log) of the communications between a system and the users of that system, or a data collection method that automatically captures the type, content, or time of transactions made by a person from a terminal with that system. For Web searching, a transaction log is an electronic record of interactions that have occurred during a searching episode between a Web search engine and users searching for information on that Web search engine.
-
+    :definition """A log file is a file that records either events that occur in an operating system or other software runs, or messages between different users of a communication software. Logging is the act of keeping a log. In the simplest case, messages are written to a single log file.\r
+\r
+A transaction log is a file (i.e., log) of the communications between a system and the users of that system, or a data collection method that automatically captures the type, content, or time of transactions made by a person from a terminal with that system. For Web searching, a transaction log is an electronic record of interactions that have occurred during a searching episode between a Web search engine and users searching for information on that Web search engine.\r
+\r
 Many operating systems, software frameworks and programs include a logging system. A widely used logging standard is syslog, defined in Internet Engineering Task Force (IETF) RFC 5424). The syslog standard enables a dedicated, standardized subsystem to generate, filter, record, and analyze log messages. This relieves software developers of having to design and code their own ad hoc logging systems.""" ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/06515875-n> .
 
@@ -12724,9 +12724,9 @@ Many operating systems, software frameworks and programs include a logging syste
     rdfs:subClassOf :SymbolicLogic ;
     :d3fend-id "D3A-LR" ;
     :definition "A logical rule matches event data or set of values to a conditional expression and results in the determination of a truth value, which may be used to determine the next action or step to take." ;
-    :kb-article """## References
-1. Event condition action. (2019, Nov 21). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Event_condition_action)
-2. Business rule. (2023, April 10). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Business_rule)
+    :kb-article """## References\r
+1. Event condition action. (2019, Nov 21). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Event_condition_action)\r
+2. Business rule. (2023, April 10). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Business_rule)\r
 3. YARA. (2023, June 5). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/YARA)""" .
 
 :LogicProgramming a owl:Class,
@@ -12735,12 +12735,12 @@ Many operating systems, software frameworks and programs include a logging syste
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-LP" ;
     :definition "Logic programming is a programming paradigm which is largely based on formal logic." ;
-    :kb-article """## How it works
-Any program written in a logic programming language is a set of sentences in logical form, expressing facts and rules about some problem domain. Major logic programming language families include Prolog, answer set programming (ASP) and Datalog. In all of these languages, rules are written in the form of clauses:
-
-H :- B_1, ..., B_n.
-
-## References
+    :kb-article """## How it works\r
+Any program written in a logic programming language is a set of sentences in logical form, expressing facts and rules about some problem domain. Major logic programming language families include Prolog, answer set programming (ASP) and Datalog. In all of these languages, rules are written in the form of clauses:\r
+\r
+H :- B_1, ..., B_n.\r
+\r
+## References\r
 1. Logic programming. (2023, May 29). In _Wikipedia_. [Link]( https://en.wikipedia.org/wiki/Logic_programming)""" .
 
 :LoginSession a owl:Class ;
@@ -12755,7 +12755,7 @@ H :- B_1, ..., B_n.
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-LR" ;
     :definition "Logistic regression is estimating the parameters of a logistic model." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Logistic_regression)""" .
 
 :LogististicRegressionLearning a owl:Class,
@@ -12764,7 +12764,7 @@ Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Log
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-LRL" ;
     :definition "A supervised learning method that builds a logistic regression model using training data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Logistic_regression)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#LogisticRegression" .
 
@@ -12786,7 +12786,7 @@ Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Log
     rdfs:subClassOf :RecurrentNeuralNetwork ;
     :d3fend-id "D3A-LSTM" ;
     :definition "Unlike standard feedforward neural networks, LSTM has feedback connections. Such a recurrent neural network (RNN) can process not only single data points (such as images), but also entire sequences of data (such as speech or video). This characteristic makes LSTM networks ideal for processing and predicting data" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (2021, September 29). Long short-term memory. [Link](https://en.wikipedia.org/wiki/Long_short-term_memory)""" .
 
 :MachineLearning a owl:Class,
@@ -12795,7 +12795,7 @@ Wikipedia. (2021, September 29). Long short-term memory. [Link](https://en.wikip
     rdfs:subClassOf :AnalyticTechnique ;
     :d3fend-id "D3A-ML" ;
     :definition "Machine learning techniques are computational methods that combine statistics, probability, and optimization to make accurate predictions and/or improve performance." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Machine learning." Wikipedia. [Link](https://en.wikipedia.org/wiki/Machine_learning).""" .
 
 :MacOSKeychain a owl:Class ;
@@ -12849,41 +12849,41 @@ Machine learning." Wikipedia. [Link](https://en.wikipedia.org/wiki/Machine_learn
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-MAC" ;
     :definition "Controlling access to local computer system resources with kernel-level capabilities." ;
-    :kb-article """## How it works
-Mandatory access control is a non-discretionary access control system because the rules and polices that determine access is determined by a security control authority and not distributed to local users. Access determinations are based on designed access control polices and are not based on local resource owner determinations.
-
-Access is typically granted by defining sets of subjects and sets of objects. Subjects are the entities requesting access and objects are the resources that subjects are trying to access. Rules and policies are defined that associate subjects and object permissions and access controls.
-
-### Common MAC implementations
-#### Security label access control
-A fine-grained form of mandatory access control is to apply security labels to individual resources, including processes, and the access control decisions are against a particular resource and a given user attempting to gain access. This type of MAC requires that the file system has built-in support for security labels.
-
-Access controls are typically implemented through the use of label identifiers for every file system object. Identifier labels are applied to resources and users are assigned a similar access identifier. Users attempting to access a resource will result in the operating system performing an access control check. The access control check will compare the assigned user's credentials to that of the resource or object they are attempting to access.
-
-A security context is associated with resources and is used to determine assess. Typical basic access control elements include users, roles and types and together they form a security context which is the basis for the security labels.
-
-This type of access control is what is employed in SELinux [2]. This form of MAC is considered the most flexible implementation, but it also is the most complex to deploy across the enterprise. Where multiple virtual machines (VM) are run together this type of access control is typically employed to ensure true isolation of processes and VMs.
-
-#### File path level controls
-A less fine-grained form of mandatory access control is to apply security labels that allow for access control at the file path level.  Access control is filesystem agnostic and no relabeling of resources is required. Pathname access control usually seems more natural for implementation and corresponding access audits.
-
-This type of MAC is what is employed in AppArmor [3]. AppArmor was developed to provide a simpler alternative MAC method with much less management overhead. A simple access policy is maintained that defines path resource access rules. Access control attributes are typically associated with programs instead of users.
-
-
-## Considerations
-Some implementations of security label mandatory access control contain complex rules set that are hard to verify and complex to maintain over time.
-
-Initial planning of access model and continuous monitoring of the available users, resources and object is necessary.
-
-## Implementations
-
- * Linux C-Groups, and policy engines like SELinux and AppArmor
- * Windows Mandatory Integrity Control introduced in Windows Vista
-
-
-### Citations
-1. [Implementation of Mandatory Access Control in Distributed Systems](https://link.springer.com/article/10.3103/S0146411618080357)
-2. [SELinux](https://selinuxproject.org/)
+    :kb-article """## How it works\r
+Mandatory access control is a non-discretionary access control system because the rules and polices that determine access is determined by a security control authority and not distributed to local users. Access determinations are based on designed access control polices and are not based on local resource owner determinations.\r
+\r
+Access is typically granted by defining sets of subjects and sets of objects. Subjects are the entities requesting access and objects are the resources that subjects are trying to access. Rules and policies are defined that associate subjects and object permissions and access controls.\r
+\r
+### Common MAC implementations\r
+#### Security label access control\r
+A fine-grained form of mandatory access control is to apply security labels to individual resources, including processes, and the access control decisions are against a particular resource and a given user attempting to gain access. This type of MAC requires that the file system has built-in support for security labels.\r
+\r
+Access controls are typically implemented through the use of label identifiers for every file system object. Identifier labels are applied to resources and users are assigned a similar access identifier. Users attempting to access a resource will result in the operating system performing an access control check. The access control check will compare the assigned user's credentials to that of the resource or object they are attempting to access.\r
+\r
+A security context is associated with resources and is used to determine assess. Typical basic access control elements include users, roles and types and together they form a security context which is the basis for the security labels.\r
+\r
+This type of access control is what is employed in SELinux [2]. This form of MAC is considered the most flexible implementation, but it also is the most complex to deploy across the enterprise. Where multiple virtual machines (VM) are run together this type of access control is typically employed to ensure true isolation of processes and VMs.\r
+\r
+#### File path level controls\r
+A less fine-grained form of mandatory access control is to apply security labels that allow for access control at the file path level.  Access control is filesystem agnostic and no relabeling of resources is required. Pathname access control usually seems more natural for implementation and corresponding access audits.\r
+\r
+This type of MAC is what is employed in AppArmor [3]. AppArmor was developed to provide a simpler alternative MAC method with much less management overhead. A simple access policy is maintained that defines path resource access rules. Access control attributes are typically associated with programs instead of users.\r
+\r
+\r
+## Considerations\r
+Some implementations of security label mandatory access control contain complex rules set that are hard to verify and complex to maintain over time.\r
+\r
+Initial planning of access model and continuous monitoring of the available users, resources and object is necessary.\r
+\r
+## Implementations\r
+\r
+ * Linux C-Groups, and policy engines like SELinux and AppArmor\r
+ * Windows Mandatory Integrity Control introduced in Windows Vista\r
+\r
+\r
+### Citations\r
+1. [Implementation of Mandatory Access Control in Distributed Systems](https://link.springer.com/article/10.3103/S0146411618080357)\r
+2. [SELinux](https://selinuxproject.org/)\r
 3. [AppArmor](https://www.apparmor.net/)""" ;
     :kb-reference :Reference-AnalysisOfTheWindowsVistaSecurityModel_SymantecCorporation,
         :Reference-ArchitectureOfTransparentNetworkSecurityForApplicationContainers_NeuvectorInc .
@@ -12903,9 +12903,9 @@ Initial planning of access model and continuous monitoring of the available user
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-MML" ;
     :definition "Maximum-margin classifiers attempt to maximize the distance between the given data points and the decision boundary" ;
-    :kb-article """## References
-Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Learning, 109(2), 299-337. [Link](https://link.springer.com/article/10.1007/s10994-019-05855-6).
-
+    :kb-article """## References\r
+Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Learning, 109(2), 299-337. [Link](https://link.springer.com/article/10.1007/s10994-019-05855-6).\r
+\r
 Support Vector Machines for Machine Learning. [Link](https://machinelearningmastery.com/support-vector-machines-for-machine-learning/#:~:text=The%20distance%20between%20the%20line,called%20the%20Maximal%2DMargin%20hyperplane.)""" .
 
 :Mean a owl:Class,
@@ -12914,7 +12914,7 @@ Support Vector Machines for Machine Learning. [Link](https://machinelearningmast
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-MEA" ;
     :definition "The sum of all measurements divided by the number of observations in the data set." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :MeanAbsoluteDeviation a owl:Class,
@@ -12923,7 +12923,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :AverageAbsoluteDeviation ;
     :d3fend-id "D3A-MAD" ;
     :definition "The mean absolute deviation (MAD), also referred to as the \"mean deviation\" or sometimes \"average absolute deviation\", is the mean of the data's absolute deviations around the data's mean: the average (absolute) distance from the mean." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/wiki/Average_absolute_deviation)""" ;
     :synonym "MAD" .
 
@@ -12938,7 +12938,7 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-MED" ;
     :definition "The middle value that separates the higher half from the lower half of the data set. The median and the mode are the only measures of central tendency that can be used for ordinal data, in which values are ranked relative to each other but are not measured absolutely." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :MedianAbsoluteDeviation a owl:Class,
@@ -12947,7 +12947,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :AverageAbsoluteDeviation ;
     :d3fend-id "D3A-MAD" ;
     :definition "The median absolute deviation (also MAD) is the median of the absolute deviation from the median." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/wiki/Average_absolute_deviation)""" .
 
 :MediaServer a owl:Class ;
@@ -13003,10 +13003,10 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
             owl:someValuesFrom :ProcessCodeSegment ] ;
     :d3fend-id "D3-MBT" ;
     :definition "Analyzing a call stack for return addresses which point to unexpected  memory locations." ;
-    :kb-article """## How it works
-This technique monitors for indicators of whether a return address is outside memory previously allocated for an object (i.e. function, module, process, or thread). If so, code that the return address points to is treated as malicious code.
-
-## Considerations
+    :kb-article """## How it works\r
+This technique monitors for indicators of whether a return address is outside memory previously allocated for an object (i.e. function, module, process, or thread). If so, code that the return address points to is treated as malicious code.\r
+\r
+## Considerations\r
 Kernel malware can manipulate memory contents, for example modifying pointers to hide processes, and thereby impact the accuracy of memory allocation information used to perform the analysis.""" ;
     :kb-reference :Reference-InferentialExploitAttemptDetection_CrowdstrikeInc .
 
@@ -13075,10 +13075,10 @@ Kernel malware can manipulate memory contents, for example modifying pointers to
     :d3fend-id "D3-MA" ;
     :definition "Analyzing email or instant message content to detect unauthorized activity." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview
-
-Email and messaging are frequently used to deliver malicious content to targets. These enterprise capabilities are used to deliver software exploits or social engineering tricks. If the recipient of a message trusts the sender, attackers can avoid escalating suspicion.
-
+    :kb-article """## Technique Overview\r
+\r
+Email and messaging are frequently used to deliver malicious content to targets. These enterprise capabilities are used to deliver software exploits or social engineering tricks. If the recipient of a message trusts the sender, attackers can avoid escalating suspicion.\r
+\r
 Emails and messages are also complex data structures. They contain files and links, and complex data encodings which vary region to region. Thus the defensive techniques used to analyze emails and messages are highly varied ranging from deep content analysis and execution to social network graph-style analytics to analyze trust or risk.""" ;
     :synonym "Electronic Message Analysis",
         "Email Or Messaging Analysis" .
@@ -13093,17 +13093,17 @@ Emails and messages are also complex data structures. They contain files and lin
             owl:someValuesFrom :UserToUserMessage ] ;
     :d3fend-id "D3-MAN" ;
     :definition "Authenticating the sender of a message and ensuring message integrity." ;
-    :kb-article """## How it works
-
-### Digital Signature
-Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.
-
-### Message Authentication Code (MAC)
-MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.
-
-## Considerations
-- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.
-- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.
+    :kb-article """## How it works\r
+\r
+### Digital Signature\r
+Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.\r
+\r
+### Message Authentication Code (MAC)\r
+MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.\r
+\r
+## Considerations\r
+- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.\r
+- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.\r
 - Symmetric keys must be exchanged securely via a private channel and management of new symmetric keys are needed for each pair of participants wishing to exchange messages.""" ;
     :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
         :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
@@ -13118,16 +13118,16 @@ MAC is a fixed size string that is appended to a message to provide message auth
             owl:someValuesFrom :UserToUserMessage ] ;
     :d3fend-id "D3-MENCR" ;
     :definition "Encrypting a message body using a cryptographic key." ;
-    :kb-article """## How it works
-
-### Asymmetric Cryptography
-Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.
-### Symmetric Cryptography
-Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient.
-
-## Considerations
-- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).
-- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
+    :kb-article """## How it works\r
+\r
+### Asymmetric Cryptography\r
+Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.\r
+### Symmetric Cryptography\r
+Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient.\r
+\r
+## Considerations\r
+- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).\r
+- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.\r
 - Secure transfer of private keys between multiple devices.""" ;
     :kb-reference :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
 
@@ -13187,7 +13187,7 @@ Symmetric encryption uses the same cryptographic key by both the sender and rece
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-ML" ;
     :definition "Modal logic is a collection of formal systems developed to represent statements about necessity and possibility. It plays a major role in philosophy of language, epistemology, metaphysics, and natural language semantics." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Modal logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic)""" .
 
 :Mode a owl:Class,
@@ -13196,7 +13196,7 @@ Symmetric encryption uses the same cryptographic key by both the sender and rece
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-MOD" ;
     :definition "The most frequent value in the data set. This is the only central tendency measure that can be used with nominal data, which have purely qualitative category assignments." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :Model a :DefensiveTactic,
@@ -13214,7 +13214,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :Model-basedReinforcementLearning ;
     :d3fend-id "D3A-MBPO" ;
     :definition "Model-based policy optimization (MBPO) is a model-based, online, off-policy reinforcement learning algorithm. For more information on the different types of reinforcement learning agents" ;
-    :kb-article """## References
+    :kb-article """## References\r
 MBPO Agents. MathWorks.  [Link](https://www.mathworks.com/help/reinforcement-learning/ug/mbpo-agents.html).""" .
 
 :Model-basedReinforcementLearning a owl:Class,
@@ -13223,7 +13223,7 @@ MBPO Agents. MathWorks.  [Link](https://www.mathworks.com/help/reinforcement-lea
     rdfs:subClassOf :ReinforcementLearning ;
     :d3fend-id "D3A-MBRL" ;
     :definition "Model-based Reinforcement Learning refers to learning optimal behavior indirectly by learning a model of the environment by taking actions and observing the outcomes that include the next state and the immediate reward. The models predict the outcomes of actions and are used in lieu of or in addition to interaction with the environment to learn optimal policies." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Model-Based Reinforcement Learning. In *Encyclopedia of Machine Learning*, pp. 642-644. Springer, 2010.  [Link](https://link.springer.com/referenceworkentry/10.1007/978-0-387-30164-8_556#:~:text=Model%2Dbased%20Reinforcement%20Learning%20refers,state%20and%20the%20immediate%20reward).""" ;
     :todo "Review: Which definition to use" .
 
@@ -13233,7 +13233,7 @@ Model-Based Reinforcement Learning. In *Encyclopedia of Machine Learning*, pp. 6
     rdfs:subClassOf :Model-basedReinforcementLearning ;
     :d3fend-id "D3A-MBVI" ;
     :definition "Value Iteration effectively reducesthe evaluation stage down to a single sweep of the states. Additionally, to improve things further, it combines the Policy Evaluation and Policy Improvement stages into a single update." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Policy and Value Iteration. Towards Data Science.  [Link](https://towardsdatascience.com/policy-and-value-iteration-78501afb41d2).""" ;
     :synonym "MBVI" .
 
@@ -13243,7 +13243,7 @@ Policy and Value Iteration. Towards Data Science.  [Link](https://towardsdatasci
     rdfs:subClassOf :ReinforcementLearning ;
     :d3fend-id "D3A-MFRL" ;
     :definition "In reinforcement learning (RL), a model-free algorithm (as opposed to a model-based one) is an algorithm which does not use the transition probability distribution (and the reward function) associated with the Markov decision process (MDP),which, in RL, represents the problem to be solved. The transition probability distribution (or transition model) and the reward function are often collectively called the \"model\" of the environment (or MDP), hence the name \"model-free\". A model-free RL algorithm can be thought of as an \"explicit\" trial-and-error algorithm. An example of a model-free algorithm is Q-learning." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Model-free (reinforcement learning). Wikipedia. [Link](https://en.wikipedia.org/wiki/Model-free_(reinforcement_learning)).)""" .
 
 :Modem a owl:Class ;
@@ -13258,7 +13258,7 @@ Model-free (reinforcement learning). Wikipedia. [Link](https://en.wikipedia.org/
     rdfs:subClassOf :DistributionProperties ;
     :d3fend-id "D3A-MOM" ;
     :definition "With a probability distribution function, the the first moment is the expected value, the second central moment is the variance, the third standardized moment is the skewness, and the fourth standardized moment is the kurtosis." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Moment (mathematics). [Link](https://en.wikipedia.org/wiki/Moment_(mathematics))""" ;
     :todo "Split out the different moments as leaves under moments instead of having them and moments at the same level" .
 
@@ -13292,7 +13292,7 @@ Wikipedia. (n.d.). Moment (mathematics). [Link](https://en.wikipedia.org/wiki/Mo
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3A-MAM" ;
     :definition "the moving-average model (MA model) is an approach for modeling univariate time series and specifies that the output variable is cross-correlated with a non-identical to itself random-variable." ;
-    :kb-article """## Refrences
+    :kb-article """## Refrences\r
 Wikipedia. (n.d.). Moving average model. [Link](https://en.wikipedia.org/wiki/Moving_average_model)""" ;
     :synonym "MA Model" .
 
@@ -13306,10 +13306,10 @@ Wikipedia. (n.d.). Moving average model. [Link](https://en.wikipedia.org/wiki/Mo
             owl:someValuesFrom :UserAccount ] ;
     :d3fend-id "D3-MFA" ;
     :definition "Requiring proof of two or more pieces of evidence in order to authenticate a user." ;
-    :kb-article """## How it works
-When logging into an account users present two or more credentials that fall into different categories: something you know (password or PIN), something you have (smart card or phone), or something you are (fingerprint).
-
-## Considerations
+    :kb-article """## How it works\r
+When logging into an account users present two or more credentials that fall into different categories: something you know (password or PIN), something you have (smart card or phone), or something you are (fingerprint).\r
+\r
+## Considerations\r
 MFA configuration steps may vary across accounts and in some cases left up to users to activate and implement.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-MethodAndApparatusForUtilizingATokenForResourceAccess_RsaSecurityInc.> .
 
@@ -13323,7 +13323,7 @@ MFA configuration steps may vary across accounts and in some cases left up to us
     rdfs:subClassOf :ArtificialNeuralNetClassification ;
     :d3fend-id "D3A-MPC" ;
     :definition "A multilayer perceptron (MLP) is a fully connected class of feedforward artificial neural network (ANN).An MLP consists of at least three layers of nodes: an input layer, a hidden layer and an output layer." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Multilayer perceptron. Wikipedia. [Link](https://en.wikipedia.org/wiki/Multilayer_perceptron).""" .
 
 :MultimediaDocumentFile a owl:Class ;
@@ -13338,7 +13338,7 @@ Multilayer perceptron. Wikipedia. [Link](https://en.wikipedia.org/wiki/Multilaye
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-MR" ;
     :definition "Multiple (linear) regression attempts to model the relationship between two or more explanatory variables and a response variable by fitting a linear equation to observed data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Yale University Department of Statistics. (1997-98). Linear regression and multivariate analysis. [Link](http://www.stat.yale.edu/Courses/1997-98/101/linmult.htm)""" ;
     :synonym "Multiple Linear Regression" .
 
@@ -13348,7 +13348,7 @@ Yale University Department of Statistics. (1997-98). Linear regression and multi
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-MRL" ;
     :definition "A supervised learning method that builds a multiple regression model using training data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Yale University Department of Statistics. (1997-98). Linear regression and multivariate analysis. [Link](http://www.stat.yale.edu/Courses/1997-98/101/linmult.htm)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#MultipleRegression" .
 
@@ -13358,7 +13358,7 @@ Yale University Department of Statistics. (1997-98). Linear regression and multi
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-MA" ;
     :definition "Multivariate statistics encompassed the simultaneous observation and analysis of more than one outcome variable, i.e., multivariate random variables." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki/Multivariate_statistics)""" ;
     :todo "Looks like there may be lots to add here." .
 
@@ -13368,7 +13368,7 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-NBC" ;
     :definition "The Naïve Bayes classifier is a supervised machine learning algorithm, which is used for classification tasks, like text classification. It is also part of a family of generative learning algorithms, meaning that it seeks to model the distribution of inputs of a given class or category." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_a&mhq=naive%20bayes).""" .
 
 :Network a owl:Class ;
@@ -13480,21 +13480,21 @@ Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_
             owl:someValuesFrom :NetworkNode ] ;
     :d3fend-id "D3-NNI" ;
     :definition "Network node inventorying identifies and records all the network nodes (hosts, routers, switches, firewalls, etc.) in the organization's architecture." ;
-    :kb-article """## How it works
-Administrators collect information on network nodes in their architecture using a variety of administrative and management tools that query network devices and nodes for information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to include host discovery and scanning for active ports and services.
-
-## Considerations
-* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.
-* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools
-
-## Examples
-* Link-layer discovery
-   * Link-layer Discovery Protocol (LLDP)
-   * Cisco Discovery Protocol (CDP)
-* Application-layer discovery
-   * Simple Network Management Protocol (SNMP) collects MIB information
-   * Web-based Enterprise Management (WBEM) collects CIM information
-      * Windows Management Instrumentation (WMI)
+    :kb-article """## How it works\r
+Administrators collect information on network nodes in their architecture using a variety of administrative and management tools that query network devices and nodes for information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to include host discovery and scanning for active ports and services.\r
+\r
+## Considerations\r
+* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.\r
+* An adversary conducting network enumeration may engage in activities that parallel normal hardware inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools\r
+\r
+## Examples\r
+* Link-layer discovery\r
+   * Link-layer Discovery Protocol (LLDP)\r
+   * Cisco Discovery Protocol (CDP)\r
+* Application-layer discovery\r
+   * Simple Network Management Protocol (SNMP) collects MIB information\r
+   * Web-based Enterprise Management (WBEM) collects CIM information\r
+      * Windows Management Instrumentation (WMI)\r
       * Windows Management Infrastructure (MI)""" ;
     :kb-reference :Reference-IEEE-802_1AB-2016,
         :Reference-QualysNetworkPassiveSensorGettingStartedGuide,
@@ -13617,11 +13617,11 @@ Administrators collect information on network nodes in their architecture using 
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-NTCD" ;
     :definition "Establishing baseline communities of network hosts and identifying statistically divergent inter-community communication." ;
-    :kb-article """## How it works
-Hosts/users within a computer network are analyzed to identify communities of hosts which frequently communicate. Future communications between communities that don't usually communicate can then be detected.  For example, if a community of hosts that communicate in support of a company's finance division suddenly starts to access the code server usually accessed only by engineers, this may indicate unauthorized activity.
-
-## Considerations
-* Potential for false positives in very dynamic network environments.
+    :kb-article """## How it works\r
+Hosts/users within a computer network are analyzed to identify communities of hosts which frequently communicate. Future communications between communities that don't usually communicate can then be detected.  For example, if a community of hosts that communicate in support of a company's finance division suddenly starts to access the code server usually accessed only by engineers, this may indicate unauthorized activity.\r
+\r
+## Considerations\r
+* Potential for false positives in very dynamic network environments.\r
 * Attackers that move low and slow may not differentiate their behavior enough to trigger an alert.""" ;
     :kb-reference :Reference-SystemForImplementingThreatDetectionUsingDailyNetworkTrafficCommunityOutliers_VECTRANETWORKSInc .
 
@@ -13704,7 +13704,7 @@ Hosts/users within a computer network are analyzed to identify communities of ho
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-NML" ;
     :definition "Non-monotonic logic is a formal logic whose conclusion relation is not monotonic. In other words, non-monotonic logics are devised to capture and represent defeasible inferences (cf. defeasible reasoning), i.e., a kind of inference in which reasoners draw tentative conclusions, enabling reasoners to retract their conclusion(s) based on further evidence." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Non-monotonic logic. (2023, June 1). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Non-monotonic_logic)""" .
 
 :Non-ParametricTests a owl:Class,
@@ -13713,7 +13713,7 @@ Hosts/users within a computer network are analyzed to identify communities of ho
     rdfs:subClassOf :HypothesisTesting ;
     :d3fend-id "D3A-NPT" ;
     :definition "A non-parametric test relies is used when the underlying distribution of data is non-symmetric (non-normal distribution)." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.ncl.ac.uk/webtemplate/ask-assets/external/maths-resources/psychology/non-parametric-hypothesis-tests.html)""" .
 
 :NonlinearRegression a owl:Class,
@@ -13722,7 +13722,7 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
     rdfs:subClassOf :RegressionAnalysis ;
     :d3fend-id "D3A-NR" ;
     :definition "Nonlinear regression is a form of regression analysis in which observational data are modeled by a function which is a nonlinear combination of the model parameters and depends on one or more independent variables." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/Nonlinear_regression)""" .
 
 :NonlinearRegressionLearning a owl:Class,
@@ -13731,7 +13731,7 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
     rdfs:subClassOf :RegressionAnalysisLearning ;
     :d3fend-id "D3A-NRL" ;
     :definition "A supervised learning method that builds a non-linear regression model using training data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/Nonlinear_regression)""" ;
     rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#NonlinearRegression" .
 
@@ -13823,24 +13823,24 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
             owl:someValuesFrom :Password ] ;
     :d3fend-id "D3-OTP" ;
     :definition "A one-time password is valid for only one user authentication." ;
-    :kb-article """## How it works
-
-When a user initiates authentication, they are asked for a one-time password, often in addition to other credentials such as a traditional password or smart card. The one-time password may be from a list provided in advance, sent via a channel such as SMS or HTTPS to an app, or a generated token.
-
-In the case of a physical token which generates one-time passwords incrementally based on time elapsed, that token device need not be connected to the internet. In different implementations, an administrator of the system, or a user with additional verification, can adjust for clock skew between the token and the verification system as needed.
-
-## Considerations
-
-### Compromise of delivery channel
-- SIM Swapping
-- Secure token visual compromise
-- Insecure delivery channel
-
-### Compromise of delivery device
-Physical loss of One-time Password device.
-
-### Compromise of long-term backup codes
-These are often provided in the form of a downloadable document with a regular name, which can be searched for in the case that the user forgets where they put them.  This digital file or printed document could be stolen.
+    :kb-article """## How it works\r
+\r
+When a user initiates authentication, they are asked for a one-time password, often in addition to other credentials such as a traditional password or smart card. The one-time password may be from a list provided in advance, sent via a channel such as SMS or HTTPS to an app, or a generated token.\r
+\r
+In the case of a physical token which generates one-time passwords incrementally based on time elapsed, that token device need not be connected to the internet. In different implementations, an administrator of the system, or a user with additional verification, can adjust for clock skew between the token and the verification system as needed.\r
+\r
+## Considerations\r
+\r
+### Compromise of delivery channel\r
+- SIM Swapping\r
+- Secure token visual compromise\r
+- Insecure delivery channel\r
+\r
+### Compromise of delivery device\r
+Physical loss of One-time Password device.\r
+\r
+### Compromise of long-term backup codes\r
+These are often provided in the form of a downloadable document with a regular name, which can be searched for in the case that the user forgets where they put them.  This digital file or printed document could be stolen.\r
 Additionally, after the code file is printed, it could be recovered from the system printer spool unless the spooler cache is cleared.""" ;
     :kb-reference :Reference-RFC2289-AOne-TimePasswordSystem ;
     rdfs:seeAlso <http://dbpedia.org/resource/One-time_password> ;
@@ -13933,12 +13933,12 @@ Additionally, after the code file is printed, it could be recovered from the sys
     :d3fend-id "D3-OSM" ;
     :definition "The operating system software, for D3FEND's purposes, includes the kernel and its process management functions, hardware drivers, initialization or boot logic. It also includes and other key system daemons and their configuration. The monitoring or analysis of these components for unauthorized activity constitute **Operating System Monitoring**." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview
-
-"An operating system (OS) is system software that manages computer hardware and software resources and provides common services for computer programs." [1]
-
-Operating System Monitoring Techniques have varied implementations including built-in kernel modules, third-party privileged system daemons, or even standard systems administration tools included with an operating system.
-
+    :kb-article """## Technique Overview\r
+\r
+"An operating system (OS) is system software that manages computer hardware and software resources and provides common services for computer programs." [1]\r
+\r
+Operating System Monitoring Techniques have varied implementations including built-in kernel modules, third-party privileged system daemons, or even standard systems administration tools included with an operating system.\r
+\r
 1. http://dbpedia.org/resource/Operating_system""" ;
     :kb-reference :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
         :Reference-UserActivityFromClearingEventLogs_MITRE .
@@ -14176,31 +14176,31 @@ Operating System Monitoring Techniques have varied implementations including bui
             owl:someValuesFrom :OutboundNetworkTraffic ] ;
     :d3fend-id "D3-OTF" ;
     :definition "Restricting network traffic originating from a private host or enclave destined towards untrusted networks." ;
-    :kb-article """## How it works
-
-Outbound traffic, in this context, is network traffic originating from a private host or enclave destined towards untrusted networks.
-For example:
-
-* An enterprise desktop intranet user connecting to www.example.com
-* An internal mail server connecting to an external mail server, mail.example.com
-
-Filtering is commonly implemented as firewall rulesets to limit outbound traffic permitted to egress a host or network. Firewalls are deployed either directly on hosts through kernel level software implementations or installed in-line directly on network links. There are benefits and disadvantages to each approach.
-
-There are various strategies for developing filtering rulesets:
-
-* Block everything by default
-* Limit destination hosts
-* Limit destination transport or application protocols
-* Restrict content outbound (Ex. strings formatted as social security numbers, or proprietary data)
-
-## Considerations
-* Dynamic IP assignment creates challenges for Outbound Traffic Filtering because users are not necessarily associated with the same IP address. This can be addressed by linking IP address management information with the filtering logic.
-* Connections using non-standard transport layer ports may circumvent outbound traffic filtering technology which does not detect application protocol based on traffic content.
-* Business requirements typically drive the development of filtering rule sets.
-
-## Implementations
-- iptables (Linux)
-- Windows Firewall
+    :kb-article """## How it works\r
+\r
+Outbound traffic, in this context, is network traffic originating from a private host or enclave destined towards untrusted networks.\r
+For example:\r
+\r
+* An enterprise desktop intranet user connecting to www.example.com\r
+* An internal mail server connecting to an external mail server, mail.example.com\r
+\r
+Filtering is commonly implemented as firewall rulesets to limit outbound traffic permitted to egress a host or network. Firewalls are deployed either directly on hosts through kernel level software implementations or installed in-line directly on network links. There are benefits and disadvantages to each approach.\r
+\r
+There are various strategies for developing filtering rulesets:\r
+\r
+* Block everything by default\r
+* Limit destination hosts\r
+* Limit destination transport or application protocols\r
+* Restrict content outbound (Ex. strings formatted as social security numbers, or proprietary data)\r
+\r
+## Considerations\r
+* Dynamic IP assignment creates challenges for Outbound Traffic Filtering because users are not necessarily associated with the same IP address. This can be addressed by linking IP address management information with the filtering logic.\r
+* Connections using non-standard transport layer ports may circumvent outbound traffic filtering technology which does not detect application protocol based on traffic content.\r
+* Business requirements typically drive the development of filtering rule sets.\r
+\r
+## Implementations\r
+- iptables (Linux)\r
+- Windows Firewall\r
 - pf (BSD)""" ;
     :kb-reference :Reference-AutomaticallyGeneratingRulesForConnectionSecurity_Microsoft .
 
@@ -14216,12 +14216,12 @@ There are various strategies for developing filtering rulesets:
     rdfs:subClassOf :DescriptionLogic ;
     :d3fend-id "D3A-OWL" ;
     :definition "The Web Ontology Language (OWL) is a family of knowledge representation languages for authoring ontologies." ;
-    :kb-article """## How it works
-Ontologies are a formal way to describe taxonomies and classification networks, essentially defining the structure of knowledge for various domains: the nouns representing classes of objects and the verbs representing relations between the objects.
-
-The OWL languages are characterized by formal semantics. They are built upon the World Wide Web Consortium's (W3C) standard for objects called the Resource Description Framework (RDF). OWL classes correspond to description logic (DL) _concepts_.  OWL properties to DL _roles_, and individuals are named the same way in OWL and other DLs.
-
-## References
+    :kb-article """## How it works\r
+Ontologies are a formal way to describe taxonomies and classification networks, essentially defining the structure of knowledge for various domains: the nouns representing classes of objects and the verbs representing relations between the objects.\r
+\r
+The OWL languages are characterized by formal semantics. They are built upon the World Wide Web Consortium's (W3C) standard for objects called the Resource Description Framework (RDF). OWL classes correspond to description logic (DL) _concepts_.  OWL properties to DL _roles_, and individuals are named the same way in OWL and other DLs.\r
+\r
+## References\r
 1. Web Ontology Language. (2023, April 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Web_Ontology_Language)""" ;
     :synonym "Web Ontology Language" .
 
@@ -14267,7 +14267,7 @@ The OWL languages are characterized by formal semantics. They are built upon the
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-PBTL" ;
     :definition "The idea behind parameter-based methods is that a well-trained model on the source domain has learned a well-defined structure, and if two tasks are related, this structure can be transferred to the target model." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.com/georgian-impact-blog/transfer-learning-part-1-ed0c174ad6e7#:~:text=Homogeneous%20Transfer%20Learning-,1.,the%20target%20domain%20for%20training).""" .
 
 :ParametricTests a owl:Class,
@@ -14276,7 +14276,7 @@ Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.co
     rdfs:subClassOf :HypothesisTesting ;
     :d3fend-id "D3A-PT" ;
     :definition "A parametric test relies upon the assumption that the data you want to test is (or approximately is) normally distributed." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.ncl.ac.uk/webtemplate/ask-assets/external/maths-resources/psychology/parametric-hypothesis-tests.html)""" .
 
 :ParentProcess a owl:Class ;
@@ -14292,7 +14292,7 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
     rdfs:subClassOf :StringPatternMatching ;
     :d3fend-id "D3A-PM" ;
     :definition "Partial string pattern matching is a special case of string pattern matching where one seeks to find a pattern within a larger string (text). It allows for the detection of patterns that occur as substrings or partial segments within the full string, rather than requiring an exact match across the entire string." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""",
         "Numeric pattern matching is a method of matching some defined pattern specification against a numeric value." .
 
@@ -14324,34 +14324,34 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
     :d3fend-id "D3-PCA" ;
     :definition "Collecting host certificates from network traffic or other passive sources like a certificate transparency log and analyzing them for unauthorized activity.",
         "Passively collecting certificates and analyzing them." ;
-    :kb-article """## How it works
-Certificates are analyzed outside of a TLS server connection using third-party secure update logs, domain name analysis and analytics.
-
-### Secure update certificate logs
-* Certificate Logs
-The key enabling feature is a secure service that maintains record logs of certificate activities. The logs allow users to only append certificates and never to delete or modify the log entries. The logs use Merkle Tree Hashes to ensure they have not been tampered with. The logging service also allows for public auditing by any user.
-
-The logging service, upon receipt of a certificate to log, will respond with a signed certificate timestamp (SCT). The SCT guarantees the certificate will be added to the log within the time specified. The SCT must be present with the certificate during a TLS handshake.
-
-* Certificate Monitoring
-Certificate monitoring, of the logs, is typically done by the CA and they watch for suspicious certificate logging and unusual certificates or extensions or permissions. Monitors are also responsible for verifying the logs are accurate and public.
-
-* Certificate Auditors
-Log integrity is verified by log auditors. Auditors make use of log proofs are used to validate the cryptographic hashes (Merkle Trees) that the log employs are consistent. In order to ensure consistency throughout multiple monitors and auditors, sharing a common logging service, gossip protocol is employed.
-
-### Phishing domain name analysis
-* A curated corpus of known benign domains and phishing domain names is used as training text for machine learning. Through the use of feature set extraction, vectors labels are created with scoring to indicated if they are considered benign or phishing domains.
-
-* A stream of new or updated SSL certificates with fully qualified domain names (FQDN) is analyzed against the feature vectors and a predictive model determines a score for the domains. The scoring considers distance measures such as Levenshtein distance to help in determining the final label score. Supervised learning is also employed using the curated domains of benign and phishing domains.
-
-* Subdomain phishing analysis, prepending a trusted domain to a phishing domain, and regular expression comparisons  are also used in the label scoring model. A tunable measure is used to determine the threshold for alerting. This measure helps to balance between precision and recall measures.
-
-## Considerations
-* Some entity will need to run the logging service and a trusted entity is preferred.
-* Certificate Authorities will likely need to monitor the logging service for consistency.
-* Certificate revocation is unchanged and remains outside of Certificate Transparency, but certificates needing to be revoked are visible.
-* Technique dependent of reliable feed of new and updated certificates
-* Some certificate authorities allow for certificates to be registered with wildcards in the FQDN and thus will fail some of the subdomain scoring
+    :kb-article """## How it works\r
+Certificates are analyzed outside of a TLS server connection using third-party secure update logs, domain name analysis and analytics.\r
+\r
+### Secure update certificate logs\r
+* Certificate Logs\r
+The key enabling feature is a secure service that maintains record logs of certificate activities. The logs allow users to only append certificates and never to delete or modify the log entries. The logs use Merkle Tree Hashes to ensure they have not been tampered with. The logging service also allows for public auditing by any user.\r
+\r
+The logging service, upon receipt of a certificate to log, will respond with a signed certificate timestamp (SCT). The SCT guarantees the certificate will be added to the log within the time specified. The SCT must be present with the certificate during a TLS handshake.\r
+\r
+* Certificate Monitoring\r
+Certificate monitoring, of the logs, is typically done by the CA and they watch for suspicious certificate logging and unusual certificates or extensions or permissions. Monitors are also responsible for verifying the logs are accurate and public.\r
+\r
+* Certificate Auditors\r
+Log integrity is verified by log auditors. Auditors make use of log proofs are used to validate the cryptographic hashes (Merkle Trees) that the log employs are consistent. In order to ensure consistency throughout multiple monitors and auditors, sharing a common logging service, gossip protocol is employed.\r
+\r
+### Phishing domain name analysis\r
+* A curated corpus of known benign domains and phishing domain names is used as training text for machine learning. Through the use of feature set extraction, vectors labels are created with scoring to indicated if they are considered benign or phishing domains.\r
+\r
+* A stream of new or updated SSL certificates with fully qualified domain names (FQDN) is analyzed against the feature vectors and a predictive model determines a score for the domains. The scoring considers distance measures such as Levenshtein distance to help in determining the final label score. Supervised learning is also employed using the curated domains of benign and phishing domains.\r
+\r
+* Subdomain phishing analysis, prepending a trusted domain to a phishing domain, and regular expression comparisons  are also used in the label scoring model. A tunable measure is used to determine the threshold for alerting. This measure helps to balance between precision and recall measures.\r
+\r
+## Considerations\r
+* Some entity will need to run the logging service and a trusted entity is preferred.\r
+* Certificate Authorities will likely need to monitor the logging service for consistency.\r
+* Certificate revocation is unchanged and remains outside of Certificate Transparency, but certificates needing to be revoked are visible.\r
+* Technique dependent of reliable feed of new and updated certificates\r
+* Some certificate authorities allow for certificates to be registered with wildcards in the FQDN and thus will fail some of the subdomain scoring\r
 * Phishing HTTP domains will not be discovered""" ;
     :kb-reference :Reference-CertificateTransparency,
         :Reference-StreamingPhish .
@@ -14422,7 +14422,7 @@ Log integrity is verified by log auditors. Auditors make use of log proofs are u
     rdfs:subClassOf :LogicalRules ;
     :d3fend-id "D3A-PM" ;
     :definition "Pattern matching is the act of checking a given sequence of tokens for the presence of the constituents of some pattern." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Pattern matching. (2023, May 20). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Pattern_matching)""" .
 
 :PearsonsCorrelationCoefficient a owl:Class,
@@ -14431,7 +14431,7 @@ Log integrity is verified by log auditors. Auditors make use of log proofs are u
     rdfs:subClassOf :Correlation ;
     :comment "Pearson correlation coefficient (PCC), Pearson's r, the Perason product-moment correlation coefficient (PPMCC), or the bivariate correlation, is a quantity that gives the quality of a least squares fitting to the original data." ;
     :d3fend-id "D3A-PCC" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wolfram MathWorld. (n.d.). Correlation Coefficient. [Link](https://mathworld.wolfram.com/CorrelationCoefficient.html)""" .
 
 :PerHostDownload-UploadRatioAnalysis a :NetworkTrafficAnalysis,
@@ -14444,10 +14444,10 @@ Wolfram MathWorld. (n.d.). Correlation Coefficient. [Link](https://mathworld.wol
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-PHDURA" ;
     :definition "Detecting anomalies that indicate malicious activity by comparing the amount of data downloaded versus data uploaded by a host." ;
-    :kb-article """## How it works
-Aggregate pull vs. push ratios from metadata are used to develop a baseline for a given host over a specific time period, e.g., over a three-hour period, one day, one week, etc. Anomalies identified over a threshold produce an alert.
-
-## Considerations
+    :kb-article """## How it works\r
+Aggregate pull vs. push ratios from metadata are used to develop a baseline for a given host over a specific time period, e.g., over a three-hour period, one day, one week, etc. Anomalies identified over a threshold produce an alert.\r
+\r
+## Considerations\r
 Collection and analysis of large network packet captures requires large storage and intensive computing power. The time windows used to calculate the ratio may vary in implementations, this consideration should take into account a threat model and likely effects (impacts) delivered by an adversary.""" ;
     :kb-reference :Reference-SystemForDetectingThreatsUsingScenario-basedTrackingOfInternalAndExternalNetworkTraffic_VECTRANETWORKSInc .
 
@@ -14468,13 +14468,13 @@ Collection and analysis of large network packet captures requires large storage 
             owl:someValuesFrom :PeripheralFirmware ] ;
     :d3fend-id "D3-PFV" ;
     :definition "Cryptographically verifying peripheral firmware integrity." ;
-    :kb-article """# How it works
-Peripherial firmware is collected and  analyzed on a host either periodically or on demand. This information may be collected for future comparisons.
-
-Changes in firmware hash values may indicate that the firmware has been tampered with or that firmware images are not maintained to current baselined versions, or even known vulnerable versions are deployed.
-
-## Considerations
-* Trust baselines will need to be generated for specific devices
+    :kb-article """# How it works\r
+Peripherial firmware is collected and  analyzed on a host either periodically or on demand. This information may be collected for future comparisons.\r
+\r
+Changes in firmware hash values may indicate that the firmware has been tampered with or that firmware images are not maintained to current baselined versions, or even known vulnerable versions are deployed.\r
+\r
+## Considerations\r
+* Trust baselines will need to be generated for specific devices\r
 * Changes to trusted configurations will need to be managed across the enterprise""" ;
     :kb-reference :Reference-FirmwareVerificationEclypsium,
         :Reference-FirmwareVerificationTrapezoid .
@@ -14519,9 +14519,9 @@ Changes in firmware hash values may indicate that the firmware has been tampered
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-PBL" ;
     :definition "Perturbation based methods are proposed under the smoothness assumption, which indicates that two data points close to each other in feature space are likely to have the same label." ;
-    :kb-article """## References
-Zheng, Y., & Song, Y. (2021). An Effective Perturbation-Based Semi-Supervised Learning Method for Acoustic Event Classification. IEEE/ACM Transactions on Audio, Speech, and Language Processing, 29, 3580-3591. [Link](https://www.semanticscholar.org/paper/An-Effective-Perturbation-Based-Semi-Supervised-for-Zheng-Song/b75ae37d137ac354eb2ed42917e461b4dccdc977).
-
+    :kb-article """## References\r
+Zheng, Y., & Song, Y. (2021). An Effective Perturbation-Based Semi-Supervised Learning Method for Acoustic Event Classification. IEEE/ACM Transactions on Audio, Speech, and Language Processing, 29, 3580-3591. [Link](https://www.semanticscholar.org/paper/An-Effective-Perturbation-Based-Semi-Supervised-for-Zheng-Song/b75ae37d137ac354eb2ed42917e461b4dccdc977).\r
+\r
 Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Learning, 109(2), 299-337. [Link](https://link.springer.com/article/10.1007/s10994-019-05855-6).""" .
 
 :PhiCoefficient a owl:Class,
@@ -14530,7 +14530,7 @@ Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Le
     rdfs:subClassOf :Correlation ;
     :d3fend-id "D3A-PC" ;
     :definition "The phi coefficient (or mean square contingency coefficient is a measure of association for two binary variables." ;
-    :kb-article """## References
+    :kb-article """## References\r
 \\Wikipedia. (n.d.). Phi coefficient. [Link](https://en.wikipedia.org/wiki/Phi_coefficient)""" ;
     :synonym "Matthews Correlation Coefficient (in machine learning)",
         "MCC" .
@@ -14549,8 +14549,8 @@ Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Le
 :PhysicalLink a owl:Class ;
     rdfs:label "Physical Link" ;
     rdfs:subClassOf :Link ;
-    :definition """A physical link is a dedicated connection for communication that uses some physical media (electrical, electromagnetic, optical, to include clear spaces or vacuums.)  A physical link represents only a single hop (link) in any larger communcations path, circuit, or network.
-
+    :definition """A physical link is a dedicated connection for communication that uses some physical media (electrical, electromagnetic, optical, to include clear spaces or vacuums.)  A physical link represents only a single hop (link) in any larger communcations path, circuit, or network.\r
+\r
 NOTE: not synonymous with data link as a data link can be over a telecommunications circuit, which may be a virtual circuit composed of multiple phyical links.""" ;
     rdfs:seeAlso "https://dbpedia.org/resource/Physical_layer" ;
     :synonym "Layer-1 Link" .
@@ -14599,7 +14599,7 @@ NOTE: not synonymous with data link as a data link can be over a telecommunicati
     rdfs:subClassOf :Image-to-ImageTranslationGAN ;
     :d3fend-id "D3A-PIX" ;
     :definition "Pix2Pix is based on condtional GAN architecture and are trained on paired set of images or scenes from two domains to be used for translation." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Esri. (n.d.). How Pix2Pix Works. [Link](https://developers.arcgis.com/python/guide/how-pix2pix-works/)""" .
 
 :Planning a owl:Class ;
@@ -14632,12 +14632,12 @@ Esri. (n.d.). How Pix2Pix Works. [Link](https://developers.arcgis.com/python/gui
             owl:onProperty :enables ;
             owl:someValuesFrom :Harden ] ;
     :d3fend-id "D3-PH" ;
-    :definition """Hardening components of a Platform with the intention of making them more difficult to exploit.
-
-Platforms includes components such as:
-* BIOS UEFI Subsystems
-* Hardware security devices such as Trusted Platform Modules
-* Boot process logic or code
+    :definition """Hardening components of a Platform with the intention of making them more difficult to exploit.\r
+\r
+Platforms includes components such as:\r
+* BIOS UEFI Subsystems\r
+* Hardware security devices such as Trusted Platform Modules\r
+* Boot process logic or code\r
 * Kernel software components""" ;
     :enables :Harden ;
     :synonym "Endpoint Hardening",
@@ -14653,15 +14653,15 @@ Platforms includes components such as:
             owl:someValuesFrom :Detect ] ;
     :d3fend-id "D3-PM" ;
     :definition "Monitoring platform components such as operating systems software, hardware devices, or firmware." ;
-    :kb-article """Platform monitoring consists of the analysis and monitoring of system level devices and low-level components, including hardware devices, to detect unauthorized modifications or suspicious activity.
-
-Monitored platform components includes system files and embedded devices such as:
-
- * Kernel software modules
- * Boot process code and load logic
- * Operating system components and device files
- * System libraries and dynamically loaded files
- * Hardware device drivers
+    :kb-article """Platform monitoring consists of the analysis and monitoring of system level devices and low-level components, including hardware devices, to detect unauthorized modifications or suspicious activity.\r
+\r
+Monitored platform components includes system files and embedded devices such as:\r
+\r
+ * Kernel software modules\r
+ * Boot process code and load logic\r
+ * Operating system components and device files\r
+ * System libraries and dynamically loaded files\r
+ * Hardware device drivers\r
  * Embedded firmware devices""" .
 
 :Point-biserialCorrelationCoefficient a owl:Class,
@@ -14670,7 +14670,7 @@ Monitored platform components includes system files and embedded devices such as
     rdfs:subClassOf :Correlation ;
     :d3fend-id "D3A-PBCC" ;
     :definition "The point biserial correlation coefficient (rpb) is a correlation coefficient used when one variable (e.g. Y) is dichotomous; Y can either be \"naturally\" dichotomous, like whether a coin lands heads or tails, or an artificially dichotomized variable." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Point-biserial correlation coefficient. [Link](https://en.wikipedia.org/wiki/Point-biserial_correlation_coefficient)""" .
 
 :Pointer a owl:Class ;
@@ -14689,19 +14689,19 @@ Wikipedia. (n.d.). Point-biserial correlation coefficient. [Link](https://en.wik
             owl:someValuesFrom :Pointer ] ;
     :d3fend-id "D3-PAN" ;
     :definition "Comparing the cryptographic hash or derivative of a pointer's value to an expected value." ;
-    :kb-article """## How It Works
-
-Pointer Authentication (frequently referred to as PAC, although the technique is properly Pointer Authentication) is a security feature to provide protection against attackers with memory read/write access.  A Pointer Authentication Code (PAC) is a cryptographic hash or derivative computed on the value of a pointer and some additional context information which can then provide a cryptographically strong guarantee about the likelihood that a pointer has been tampered with by an attacker.
-
-Although pointers are 64 bits, most systems have a substantially smaller virtual address space, leaving unused bits in pointers that can store the value of the PAC, this can be done to reduce memory space requirements. One implementation is in ARMv8.3-A.  A PAC is computed over the 64-bit pointer value and a 64-bit context value.  Instructions are introduced to deal with pointers: one category to compute and insert the PAC into a pointer, another category to verify the pointer and invalidate the pointer if the PAC does not check, and a third category to remove the pointer and restore the original value without verifying.
-
-The ARM standard specifies a cryptographic algorithm called QARMA-64 (designed by Qualcomm) to compute the signature, although this algorithm is not required.  The architecture provides for five secret 128-bit Pointer Authentication keys: two for instruction pointers, two for data pointers, and a general key for signing larger blocks of data.
-
-## Considerations
-
-In the ARM implementation, the mechanisms above for manipulating PACS are provided, but it is up to the code developer to manage the keys for the cryptographic algorithm.
-
-
+    :kb-article """## How It Works\r
+\r
+Pointer Authentication (frequently referred to as PAC, although the technique is properly Pointer Authentication) is a security feature to provide protection against attackers with memory read/write access.  A Pointer Authentication Code (PAC) is a cryptographic hash or derivative computed on the value of a pointer and some additional context information which can then provide a cryptographically strong guarantee about the likelihood that a pointer has been tampered with by an attacker.\r
+\r
+Although pointers are 64 bits, most systems have a substantially smaller virtual address space, leaving unused bits in pointers that can store the value of the PAC, this can be done to reduce memory space requirements. One implementation is in ARMv8.3-A.  A PAC is computed over the 64-bit pointer value and a 64-bit context value.  Instructions are introduced to deal with pointers: one category to compute and insert the PAC into a pointer, another category to verify the pointer and invalidate the pointer if the PAC does not check, and a third category to remove the pointer and restore the original value without verifying.\r
+\r
+The ARM standard specifies a cryptographic algorithm called QARMA-64 (designed by Qualcomm) to compute the signature, although this algorithm is not required.  The architecture provides for five secret 128-bit Pointer Authentication keys: two for instruction pointers, two for data pointers, and a general key for signing larger blocks of data.\r
+\r
+## Considerations\r
+\r
+In the ARM implementation, the mechanisms above for manipulating PACS are provided, but it is up to the code developer to manage the keys for the cryptographic algorithm.\r
+\r
+\r
 A known potential limitation of PACs concerns signing gadgets. Under certain circumstances PACs can be bypassed by forcing the system to run a signing gadget which will allow the signing of arbitrary pointers to occur.""" ;
     :kb-reference :Reference-PointerAuthenticationOnARMv8.3,
         :Reference-PointerAuthenticationProjectZero .
@@ -14724,7 +14724,7 @@ A known potential limitation of PACs concerns signing gadgets. Under certain cir
     rdfs:subClassOf :Estimation ;
     :d3fend-id "D3A-PE" ;
     :definition "A point estimation is a single value that estimates the parameter. Point estimates are single values calculated from the sample" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Link](https://online.stat.psu.edu/stat504/lesson/statistical-inference-and-estimation)""" .
 
 :Policy a owl:Class ;
@@ -14737,7 +14737,7 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
     rdfs:subClassOf :Model-freeReinforcementLearning ;
     :d3fend-id "D3A-PG" ;
     :definition "The objective of a Reinforcement Learning Policy Gradient agent is to maximize the “expected” reward when following a policy" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdatascience.com/policy-gradients-in-a-nutshell-8b72f9743c5d).""" .
 
 :PolicyReference a owl:Class ;
@@ -14771,9 +14771,9 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-PL" ;
     :definition "Predicate logic is is collection of formal systems used in mathematics, philosophy, linguistics, and computer science. First-order logic and Higher-order logic both incorporate predicate logic." ;
-    :kb-article """## References
-1. First-order logic. (2023, May 26). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/First-order_logic)
-2. Higher-order logic. (2023, May 13)
+    :kb-article """## References\r
+1. First-order logic. (2023, May 26). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/First-order_logic)\r
+2. Higher-order logic. (2023, May 13)\r
 [Link](https://en.wikipedia.org/wiki/Higher-order_logic)""" .
 
 :PrimaryStorage a owl:Class ;
@@ -14796,7 +14796,7 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     rdfs:subClassOf :MultivariateAnalysis ;
     :d3fend-id "D3A-PCA" ;
     :definition "Principal components analysis (PCA) creates a new set of orthogonal variables that contain the same information as the original set. It rotates the axes of variation to give a new set of orthogonal axes, ordered so that they summarize decreasing proportions of the variation." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki/Multivariate_statistics)""" ;
     :synonym "PCA" .
 
@@ -14806,7 +14806,7 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     rdfs:subClassOf :DimensionReduction ;
     :d3fend-id "D3A-PCA" ;
     :definition "Principal Component Analysis (PCA) is a statistic-based method of identifying patterns in a large dataset while increasing interpretability and preserving information." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org/wiki/Principal_component_analysis)""" .
 
 :PrintServer a owl:Class ;
@@ -14848,7 +14848,7 @@ Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-PL" ;
     :definition "Probabilistic logic extends traditional logic truth tables with probabilistic expressions." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Probabilistic logic. (2023, June 5). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Probabilistic_logic)""" .
 
 :Procedure a owl:Class ;
@@ -14933,42 +14933,42 @@ Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org
             owl:someValuesFrom :ProcessCodeSegment ] ;
     :d3fend-id "D3-PCSV" ;
     :definition "Comparing the \"text\" or \"code\" memory segments to a source of truth." ;
-    :kb-article """## How it works
-A process code segment is an executable portion of computer memory allocated to a particular process. Process Code Segment Verification implements verification to compare a process code segment to some expected value.
-
-### Verification logic
-Verification can occur during application startup, or continuously during execution. The logic which verifies the process code may be separate in a third-party process, embedded in the application itself at compile time, or dynamically linked at runtime.
-
-### System of record
-Examples of systems of record:
-
- * On-disk application binary files or checksums
- * Remotely stored binary data or checksums
- * Embedded binary data or checksums
-
-### Post Verification Actions
-If the verification function determines a process code segment may have been altered, a capability may invoke Eviction techniques  as **Process Termination** to end the current process, or **Executable Blacklisting** to prevent the executable from launching in the future.
-
-## Considerations
-
-### False positives
-
-False positives commonly occur in the case that the layout of code in the process segment is legitimately modified:
-
-*  Operating system features or third-party security software may modify the layout of process code, for example in the defensive technique **Segment Address Offset Randomization**, or in the case that a module is rebased.  In both of these cases, the alteration occurs before the code is fully loaded into memory, and it would be possible to avoid the false positive by securely feeding this constant offset and any relocation data into the verification logic.
-
-* Process code segments may be written to modify themselves or other process code segments; however, this goes against widely-accepted current practices in software development.
-
-### False negatives
-
-False negatives can occur via alteration of the verification logic or source of truth, or insufficient verification logic.
-
-* Verification techniques which are executed only locally may be defeated by altering the local verification logic.
-
-* Verification that is run only on a recurring basis could be evaded if the malicious alteration is completed before verification is run.
-
-* Verification that requests an operation to be performed on a subset of the code segment could be evaded by performing that operation on a copy of the relevant bytes of the code segment.
-
+    :kb-article """## How it works\r
+A process code segment is an executable portion of computer memory allocated to a particular process. Process Code Segment Verification implements verification to compare a process code segment to some expected value.\r
+\r
+### Verification logic\r
+Verification can occur during application startup, or continuously during execution. The logic which verifies the process code may be separate in a third-party process, embedded in the application itself at compile time, or dynamically linked at runtime.\r
+\r
+### System of record\r
+Examples of systems of record:\r
+\r
+ * On-disk application binary files or checksums\r
+ * Remotely stored binary data or checksums\r
+ * Embedded binary data or checksums\r
+\r
+### Post Verification Actions\r
+If the verification function determines a process code segment may have been altered, a capability may invoke Eviction techniques  as **Process Termination** to end the current process, or **Executable Blacklisting** to prevent the executable from launching in the future.\r
+\r
+## Considerations\r
+\r
+### False positives\r
+\r
+False positives commonly occur in the case that the layout of code in the process segment is legitimately modified:\r
+\r
+*  Operating system features or third-party security software may modify the layout of process code, for example in the defensive technique **Segment Address Offset Randomization**, or in the case that a module is rebased.  In both of these cases, the alteration occurs before the code is fully loaded into memory, and it would be possible to avoid the false positive by securely feeding this constant offset and any relocation data into the verification logic.\r
+\r
+* Process code segments may be written to modify themselves or other process code segments; however, this goes against widely-accepted current practices in software development.\r
+\r
+### False negatives\r
+\r
+False negatives can occur via alteration of the verification logic or source of truth, or insufficient verification logic.\r
+\r
+* Verification techniques which are executed only locally may be defeated by altering the local verification logic.\r
+\r
+* Verification that is run only on a recurring basis could be evaded if the malicious alteration is completed before verification is run.\r
+\r
+* Verification that requests an operation to be performed on a subset of the code segment could be evaded by performing that operation on a copy of the relevant bytes of the code segment.\r
+\r
 * Verification based on a system of record that can be altered may fail if that system of record is modifiable by a malicious user.""" ;
     :kb-reference :Reference-Anti-tamperSystemWithSelf-adjustingGuards_ARXANTECHNOLOGIESInc,
         :Reference-GuardsForApplicationInSoftwareTamperproofing_PurdueResearchFoundation,
@@ -15026,14 +15026,14 @@ False negatives can occur via alteration of the verification logic or source of 
             owl:someValuesFrom :ProcessTree ] ;
     :d3fend-id "D3-PLA" ;
     :definition "Identification of suspicious processes executing on an end-point device by examining the ancestry and siblings of a process, and the associated metadata of each node on the tree, such as process execution, duration, and order relative to siblings and ancestors." ;
-    :kb-article """## How it works
-Process tree analysis techniques gather information on how a process was initiated to determine if a process is malicious. For example, if a process was not initiated from boot or not initiated by another process, that process is identified as suspicious. Also, if a new process was started before a process initiated by the device (ex. during boot) and that new process was not initiated by a user (which can be determined by examining process parameters such as type of process, its creator, source, etc.) the process is identified as suspicious.
-
-For example, Microsoft Word may block execution of any subprocess that is not in an approved path.
-
-## Considerations
-* Attackers may spoof the parent PID (https://attack.mitre.org/techniques/T1502/), rendering such after-the-fact analysis on process lineage ineffective.
-* Processes may hide from various means of detection; an example on Linux is where a rootkit might remove key files for the process from its directory in /proc.
+    :kb-article """## How it works\r
+Process tree analysis techniques gather information on how a process was initiated to determine if a process is malicious. For example, if a process was not initiated from boot or not initiated by another process, that process is identified as suspicious. Also, if a new process was started before a process initiated by the device (ex. during boot) and that new process was not initiated by a user (which can be determined by examining process parameters such as type of process, its creator, source, etc.) the process is identified as suspicious.\r
+\r
+For example, Microsoft Word may block execution of any subprocess that is not in an approved path.\r
+\r
+## Considerations\r
+* Attackers may spoof the parent PID (https://attack.mitre.org/techniques/T1502/), rendering such after-the-fact analysis on process lineage ineffective.\r
+* Processes may hide from various means of detection; an example on Linux is where a rootkit might remove key files for the process from its directory in /proc.\r
 * Zombie processes.""" ;
     :kb-reference :Reference-CAR-2020-11-002%3ALocalNetworkSniffing_MITRE,
         :Reference-CAR-2020-11-004%3AProcessesStartedFromIrregularParent_MITRE,
@@ -15090,25 +15090,25 @@ For example, Microsoft Word may block execution of any subprocess that is not in
             owl:someValuesFrom :ProcessSegment ] ;
     :d3fend-id "D3-PSEP" ;
     :definition "Preventing execution of any address in a memory region other than the code segment." ;
-    :kb-article """## How it works
-
-During execution of a process, the instruction pointer register should only point to addresses in a code segment (also called the .text segment), as this is the sole segment which should contain program code.
-
-When this technique detects an attempt to execute something that has been designated as non-executable, other techniques such as those in **Process Eviction** might be invoked, such as **Process Termination** to end the current process, or **Executable Blacklisting** to blacklist the potentially vulnerable or malfunctioning executable.
-
-### Software-based implementations
-The software-based implementation in Windows XP SP2 might not check that every time the instruction pointer is changed, and does not check on each jump or return.  Before calling an exception handler, Windows XP SP2 software-enforced DEP checks whether the exception handler is located in a memory region marked as executable.  If the program was also built with SafeSEH, this implementation also checks before changing control to the exception handler whether it is a registered exception handler in the program's file on disk.
-
-### Hardware-based implementations
-The NX (No Execute) or XD (Execute Disable) bit on the processor specifies whether a certain part of memory is executable.  Early implementations set this bit by the memory segment, while modern implementations which are built on the flat memory model often store this bit in each entry of the page table, to control execution by the page.
-
-
-## Considerations
-
-Non-hardware process data segment execution prevention is more susceptible to being able to be turned off for a page of memory.
-
-Different implementations of this defense have been in place since the 1980s, but implementation stalled when larger 16-bit programs began stuffing code in the segments usually reserved for data. Many modern programs follow the best practice of separation of code and data, are able to run under this defense.
-
+    :kb-article """## How it works\r
+\r
+During execution of a process, the instruction pointer register should only point to addresses in a code segment (also called the .text segment), as this is the sole segment which should contain program code.\r
+\r
+When this technique detects an attempt to execute something that has been designated as non-executable, other techniques such as those in **Process Eviction** might be invoked, such as **Process Termination** to end the current process, or **Executable Blacklisting** to blacklist the potentially vulnerable or malfunctioning executable.\r
+\r
+### Software-based implementations\r
+The software-based implementation in Windows XP SP2 might not check that every time the instruction pointer is changed, and does not check on each jump or return.  Before calling an exception handler, Windows XP SP2 software-enforced DEP checks whether the exception handler is located in a memory region marked as executable.  If the program was also built with SafeSEH, this implementation also checks before changing control to the exception handler whether it is a registered exception handler in the program's file on disk.\r
+\r
+### Hardware-based implementations\r
+The NX (No Execute) or XD (Execute Disable) bit on the processor specifies whether a certain part of memory is executable.  Early implementations set this bit by the memory segment, while modern implementations which are built on the flat memory model often store this bit in each entry of the page table, to control execution by the page.\r
+\r
+\r
+## Considerations\r
+\r
+Non-hardware process data segment execution prevention is more susceptible to being able to be turned off for a page of memory.\r
+\r
+Different implementations of this defense have been in place since the 1980s, but implementation stalled when larger 16-bit programs began stuffing code in the segments usually reserved for data. Many modern programs follow the best practice of separation of code and data, are able to run under this defense.\r
+\r
 ROP or ret2libc/return-to-function attacks could bypass this defense, as although they may pass attacker-controlled data or stack frames to a function, they abuse functions that are legitimately located in the .text segment (code segment) of the program.  For those, more advanced defenses such as a table of valid jump addresses, function call analysis, or return depth analysis could be used.""" ;
     :kb-reference :Reference-DataExecutionPrevention_Microsoft,
         :Reference-WhatIsNX_XDFeature_RedHat ;
@@ -15125,15 +15125,15 @@ ROP or ret2libc/return-to-function attacks could bypass this defense, as althoug
             owl:someValuesFrom :Process ] ;
     :d3fend-id "D3-PSMD" ;
     :definition "Detects processes that modify, change, or replace their own code at runtime." ;
-    :kb-article """## How it Works
-A security agent installed on the host machine intercepts API calls between a process and operating system. Intercepted API calls are then compared against attack signatures/patterns to identify API calls that modify executable memory or modify the entry point address of a suspended child process. Attack patterns include:
-
-* Executable code of a suspended child process removed from memory by one or more API calls.
-* New executable code injected and / or loaded into memory of a suspended child process by one or more API calls.
-* Executable code modified by one or more API calls.
-* Next instruction pointer value in memory modified by one or more API calls.
-
-## Considerations
+    :kb-article """## How it Works\r
+A security agent installed on the host machine intercepts API calls between a process and operating system. Intercepted API calls are then compared against attack signatures/patterns to identify API calls that modify executable memory or modify the entry point address of a suspended child process. Attack patterns include:\r
+\r
+* Executable code of a suspended child process removed from memory by one or more API calls.\r
+* New executable code injected and / or loaded into memory of a suspended child process by one or more API calls.\r
+* Executable code modified by one or more API calls.\r
+* Next instruction pointer value in memory modified by one or more API calls.\r
+\r
+## Considerations\r
 Comparing loaded code segments of processes with what is expected to have been loaded from a file can result in false positives, due to legitimate uses of self-modification for decrypting or uncompressing code segments.""" ;
     :kb-reference :Reference-SystemAndMethodForProcessHollowingDetection_CarbonBlackInc .
 
@@ -15150,21 +15150,21 @@ Comparing loaded code segments of processes with what is expected to have been l
             owl:someValuesFrom :SpawnProcess ] ;
     :d3fend-id "D3-PSA" ;
     :definition "Analyzing spawn arguments or attributes of a process to detect processes that are unauthorized." ;
-    :kb-article """## How it works
-Process attributes are established when an operating system spawns a new process. These attributes are analyzed to look for the presence or absence of specific values or patterns.
-
-Some attributes of interest are:
- - user
- - process name
- - image path
- - security content
-
-## Considerations
-
- - Attackers can spoof the parent process identifier (PPID), which could bypass this defense to allow execution of a malicious process from an arbitrary parent process.
- - Attackers could have legitimately compromised any of the process properties, such as the user, to make the execution appear legitimate.
- - Location: If the full image path is not checked, there could be a conflict with an executable that appears earlier due to resolution involving the system environment path/classpath variable.
- - Parsing issues: If the raw command from a shell is analyzed, rather than the actual function call, it is important to identify the actual command  being run from its arguments.  In Windows, services with unquoted file paths containing spaces will try to use the first token as the executable and the rest as arguments -- and shift tokens to the executable until a valid one is found.
+    :kb-article """## How it works\r
+Process attributes are established when an operating system spawns a new process. These attributes are analyzed to look for the presence or absence of specific values or patterns.\r
+\r
+Some attributes of interest are:\r
+ - user\r
+ - process name\r
+ - image path\r
+ - security content\r
+\r
+## Considerations\r
+\r
+ - Attackers can spoof the parent process identifier (PPID), which could bypass this defense to allow execution of a malicious process from an arbitrary parent process.\r
+ - Attackers could have legitimately compromised any of the process properties, such as the user, to make the execution appear legitimate.\r
+ - Location: If the full image path is not checked, there could be a conflict with an executable that appears earlier due to resolution involving the system environment path/classpath variable.\r
+ - Parsing issues: If the raw command from a shell is analyzed, rather than the actual function call, it is important to identify the actual command  being run from its arguments.  In Windows, services with unquoted file paths containing spaces will try to use the first token as the executable and the rest as arguments -- and shift tokens to the executable until a valid one is found.\r
  - Some [operating systems](/dao/artifact/d3f:OperatingSystem) can spawn processes without forking.""" ;
     :kb-reference :Reference-ActiveDirectoryDumpingViaNTDSUtil_MITRE,
         :Reference-CAR-2020-04-001%3AShadowCopyDeletion_MITRE,
@@ -15227,13 +15227,13 @@ Some attributes of interest are:
             owl:someValuesFrom :Process ] ;
     :d3fend-id "D3-PS" ;
     :definition "Suspending a running process on a computer system." ;
-    :kb-article """## How it works
-
-A running process might be suspended to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior. Defenders may choose to suspend rather than terminate to analyze the process first and resume the process if deemed benign.
-
-### System-provided functions
-
-#### Windows tools
+    :kb-article """## How it works\r
+\r
+A running process might be suspended to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior. Defenders may choose to suspend rather than terminate to analyze the process first and resume the process if deemed benign.\r
+\r
+### System-provided functions\r
+\r
+#### Windows tools\r
 In Windows, the `PsSuspend` command line utility from the SysInternals Suite provides functionality to suspend processes on a local or remote system.""" ;
     :kb-reference :Reference-PsSuspend .
 
@@ -15247,95 +15247,95 @@ In Windows, the `PsSuspend` command line utility from the SysInternals Suite pro
             owl:someValuesFrom :Process ] ;
     :d3fend-id "D3-PT" ;
     :definition "Terminating a running application process on a computer system." ;
-    :kb-article """## How it works
-
-Processes are managed by the operating system kernel.  Different operating system kernels manage the creation and termination of processes in a different manner, and expose this functionality via the kernel API.
-
-A running process might be terminated to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior; such as after detecting anomalous behavior via <a href="https://d3fend.mitre.org/technique/d3f:AdministrativeNetworkActivityAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#AdministrativeNetworkActivityAnalysis">Administrative Network Activity Analysis</a>, after a failed check from <a href="https://d3fend.mitre.org/technique/d3f:StackFrameCanaryVerification" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#StackFrameCanaryValidation">Stack Frame Canary Validation</a>, or after <a href="https://d3fend.mitre.org/technique/d3f:SystemCallAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#SystemCallAnalysis">System Call Analysis</a> finds an attempt to execute an unauthorized system call.
-
-### Proprietary technology
-Security software might use proprietary technology to terminate processes, instead of the system-provided functions.    Further research may provide specific detail on such methods used.
-
-### System-provided functions
-
-#### Windows tools
-In Windows, `ExitProcess()` is used to send a signal to a process to request it to exit, and `TerminateProcess()` is used to force a process to exit.
-
-The `taskkill` executable available in the cmd shell is used to kill a process, with the `/F` switch forcing termination as with `TerminateProcess()`.  In PowerShell, `Stop-Process` is used, which is aliased by default to `spps` and `kill`.  Processes started in the Windows Subsystem for Linux (WSL) environment may be terminated there with the `kill` command.
-
-In some cases, existing drivers can also be leveraged to kill processes.
-
-#### Unix/Linux tools
-In Unix-like systems, all process termination requests are handled using signals.  The `kill` function takes the Process ID and signal to send, and is accessible with the `kill` command.  Some shells have a `kill` builtin function which is separate than the `kill` binary, which can also kill background jobs in the shell and additionally perform the function faster, and can run from an existing instance of the shell if the process table is full.  The signal SIGTERM specifies that the process to terminate may invoke a handler that it has defined instead of terminating, and the signal SIGKILL forces immediate termination.
-
-The related command `xkill` terminates the connection of a program to the X window server, after which the user process may decide to terminate itself; however, termination is not guaranteed as the process, which could be on the same or different host, could then run in a terminal or reconnect to a different X server on any host.  Emacs is such a program that would not terminate itself after its connection to the X server is terminated.
-
-## Considerations
-
-### Persistence Mechanisms
-Terminating a malicious process is not enough to stop an adversary that has already gained persistence in the host via any initial access mechanism, including through that process or another access mechanism.
-
-### Terminating Multiple Processes
-On most operating systems, process termination operations typically occur independently of each other, without functionality provided to atomically terminate multiple processes.  If there are multiple malicious processes which can make system calls to spawn other processes once one of them is closed, user session termination or system restart might be required.
-
-### Process Access Permissions
-Users must have permissions to kill the process.  On Unix-like systems, either root or the process user can kill the process.  On Windows systems, process permissions are managed separately via process security tokens.
-
-### Process Resource Handles
-
-#### Terminating Processes with Open Resource Handles
-
-Processes may have open resource handles, which could leave those resources in an undesired state if the process is forced to terminate.  As such, most operating systems provide a means to send a signal to a process to inform it to gracefully terminate, and on most of these operating systems, it is the typical first step used to terminate a process.
-
-#### Signal Traps
-As the process may have open resource handles, commonly-used methods of process termination involve sending a signal to the process to terminate.
-On Windows, the `ExitProcess()` function is used for this purpose.  Process instructions, as well as a third-party DLL can also cause the process to exit.
-On Linux, the process is sent a signal on the occurrence of various events: when it loses the console, `SIGHUP`; when termination is requested, `SIGTERM`.  The processor then redirects execution to the function registered to handle the signal.
-
-Therefore, sending a signal to the process to ask it to terminate may not always work.
-
-##### Avoiding Signal Traps
-
-On Unix-like systems, sending the `SIGKILL` signal for a process does not send a message to the process or invoke an implementation-defined handler; instead, it immediately does not allow the process to execute any further processor instructions.   On Windows `TerminateProcess()` instead of `ExitProcess()` performs the equivalent.
-
-#### Hang on System Call Execution
-
-Even still, as the operating system kernel manages the processes, kernel code may block process signals, including those which cannot be trapped, and does in certain circumstances.  Signals are blocked and queued for the duration of the system call when interrupting the system call would result in a kernel invariant being violated, such as when an action results in a malformed data structure; this blocking is common for filesystem requests.  Such system calls can hang when a filesystem has gone offline, leading to a long-term uninterruptible sleep, represented in POSIX command `ps` output as D state.
-Any malicious system calls or system call handlers are issues of a much larger problem (a kernel-level rootkit) and the system should be redeployed entirely or restored from a backup known to be prior to compromise, and other systems accessible directly and indirectly from that one should also be examined.
-
-A process that is truly hung in a system call may prevent the system from shutting down and leave it in an unresponsive state; a hard power off is required.
-
-To speed up the action of terminating a process in uninterruptible sleep, the process resource accesses (handles) could be analyzed.
-
-On Linux, [`sync` followed by `echo 3 > /proc/sys/vm/drop_caches`](https://www.kernel.org/doc/Documentation/sysctl/vm.txt) is a safe way to free up some inactive resource handles.
-
-
-#### Kernel Processes and Threads
-The kernel may not allow kernel processes, which are created via methods other than user-space processes, to be terminated.
-
-#### Other Code using the Process
-
-Terminating a shared library can lead to unexpected errors; such shared libraries have their own mechanisms for termination.
-
-On Windows, a DLL is unloaded when the reference count of the library reaches 0.
-
-#### Zombie process
-
-After a process has been terminated, it may still take up an entry in the operating system process table until another event occurs.
-
-##### Windows
-In Windows, a process object is deleted when the last handle to the process is closed.
-
-##### Linux
-In Linux, a process is removed from the process table when it is reaped by its parent process.  If the parent terminates, historically the parent has been changed to pid 1; however, in the Linux kernel 3.4 and above, processes can set a different process as the subreaper using the `prctl()` system call.
-
-Zombie processes and hung processes could be resolved with a restart of the system.
-
-#### System restart
-Finally a system restart might be required to kill a process.
-Systems which are only accessible via a remote in-band connection may become inaccessible if a process termination operation that is necessary for reboot does not complete.
-
-### Subsystems
+    :kb-article """## How it works\r
+\r
+Processes are managed by the operating system kernel.  Different operating system kernels manage the creation and termination of processes in a different manner, and expose this functionality via the kernel API.\r
+\r
+A running process might be terminated to mitigate its immediate effects if it is exhibiting anomalous, unauthorized, or malicious behavior; such as after detecting anomalous behavior via <a href="https://d3fend.mitre.org/technique/d3f:AdministrativeNetworkActivityAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#AdministrativeNetworkActivityAnalysis">Administrative Network Activity Analysis</a>, after a failed check from <a href="https://d3fend.mitre.org/technique/d3f:StackFrameCanaryVerification" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#StackFrameCanaryValidation">Stack Frame Canary Validation</a>, or after <a href="https://d3fend.mitre.org/technique/d3f:SystemCallAnalysis" rdf:about="https://d3fend.mitre.org/ontologies/d3fend.owl#SystemCallAnalysis">System Call Analysis</a> finds an attempt to execute an unauthorized system call.\r
+\r
+### Proprietary technology\r
+Security software might use proprietary technology to terminate processes, instead of the system-provided functions.    Further research may provide specific detail on such methods used.\r
+\r
+### System-provided functions\r
+\r
+#### Windows tools\r
+In Windows, `ExitProcess()` is used to send a signal to a process to request it to exit, and `TerminateProcess()` is used to force a process to exit.\r
+\r
+The `taskkill` executable available in the cmd shell is used to kill a process, with the `/F` switch forcing termination as with `TerminateProcess()`.  In PowerShell, `Stop-Process` is used, which is aliased by default to `spps` and `kill`.  Processes started in the Windows Subsystem for Linux (WSL) environment may be terminated there with the `kill` command.\r
+\r
+In some cases, existing drivers can also be leveraged to kill processes.\r
+\r
+#### Unix/Linux tools\r
+In Unix-like systems, all process termination requests are handled using signals.  The `kill` function takes the Process ID and signal to send, and is accessible with the `kill` command.  Some shells have a `kill` builtin function which is separate than the `kill` binary, which can also kill background jobs in the shell and additionally perform the function faster, and can run from an existing instance of the shell if the process table is full.  The signal SIGTERM specifies that the process to terminate may invoke a handler that it has defined instead of terminating, and the signal SIGKILL forces immediate termination.\r
+\r
+The related command `xkill` terminates the connection of a program to the X window server, after which the user process may decide to terminate itself; however, termination is not guaranteed as the process, which could be on the same or different host, could then run in a terminal or reconnect to a different X server on any host.  Emacs is such a program that would not terminate itself after its connection to the X server is terminated.\r
+\r
+## Considerations\r
+\r
+### Persistence Mechanisms\r
+Terminating a malicious process is not enough to stop an adversary that has already gained persistence in the host via any initial access mechanism, including through that process or another access mechanism.\r
+\r
+### Terminating Multiple Processes\r
+On most operating systems, process termination operations typically occur independently of each other, without functionality provided to atomically terminate multiple processes.  If there are multiple malicious processes which can make system calls to spawn other processes once one of them is closed, user session termination or system restart might be required.\r
+\r
+### Process Access Permissions\r
+Users must have permissions to kill the process.  On Unix-like systems, either root or the process user can kill the process.  On Windows systems, process permissions are managed separately via process security tokens.\r
+\r
+### Process Resource Handles\r
+\r
+#### Terminating Processes with Open Resource Handles\r
+\r
+Processes may have open resource handles, which could leave those resources in an undesired state if the process is forced to terminate.  As such, most operating systems provide a means to send a signal to a process to inform it to gracefully terminate, and on most of these operating systems, it is the typical first step used to terminate a process.\r
+\r
+#### Signal Traps\r
+As the process may have open resource handles, commonly-used methods of process termination involve sending a signal to the process to terminate.\r
+On Windows, the `ExitProcess()` function is used for this purpose.  Process instructions, as well as a third-party DLL can also cause the process to exit.\r
+On Linux, the process is sent a signal on the occurrence of various events: when it loses the console, `SIGHUP`; when termination is requested, `SIGTERM`.  The processor then redirects execution to the function registered to handle the signal.\r
+\r
+Therefore, sending a signal to the process to ask it to terminate may not always work.\r
+\r
+##### Avoiding Signal Traps\r
+\r
+On Unix-like systems, sending the `SIGKILL` signal for a process does not send a message to the process or invoke an implementation-defined handler; instead, it immediately does not allow the process to execute any further processor instructions.   On Windows `TerminateProcess()` instead of `ExitProcess()` performs the equivalent.\r
+\r
+#### Hang on System Call Execution\r
+\r
+Even still, as the operating system kernel manages the processes, kernel code may block process signals, including those which cannot be trapped, and does in certain circumstances.  Signals are blocked and queued for the duration of the system call when interrupting the system call would result in a kernel invariant being violated, such as when an action results in a malformed data structure; this blocking is common for filesystem requests.  Such system calls can hang when a filesystem has gone offline, leading to a long-term uninterruptible sleep, represented in POSIX command `ps` output as D state.\r
+Any malicious system calls or system call handlers are issues of a much larger problem (a kernel-level rootkit) and the system should be redeployed entirely or restored from a backup known to be prior to compromise, and other systems accessible directly and indirectly from that one should also be examined.\r
+\r
+A process that is truly hung in a system call may prevent the system from shutting down and leave it in an unresponsive state; a hard power off is required.\r
+\r
+To speed up the action of terminating a process in uninterruptible sleep, the process resource accesses (handles) could be analyzed.\r
+\r
+On Linux, [`sync` followed by `echo 3 > /proc/sys/vm/drop_caches`](https://www.kernel.org/doc/Documentation/sysctl/vm.txt) is a safe way to free up some inactive resource handles.\r
+\r
+\r
+#### Kernel Processes and Threads\r
+The kernel may not allow kernel processes, which are created via methods other than user-space processes, to be terminated.\r
+\r
+#### Other Code using the Process\r
+\r
+Terminating a shared library can lead to unexpected errors; such shared libraries have their own mechanisms for termination.\r
+\r
+On Windows, a DLL is unloaded when the reference count of the library reaches 0.\r
+\r
+#### Zombie process\r
+\r
+After a process has been terminated, it may still take up an entry in the operating system process table until another event occurs.\r
+\r
+##### Windows\r
+In Windows, a process object is deleted when the last handle to the process is closed.\r
+\r
+##### Linux\r
+In Linux, a process is removed from the process table when it is reaped by its parent process.  If the parent terminates, historically the parent has been changed to pid 1; however, in the Linux kernel 3.4 and above, processes can set a different process as the subreaper using the `prctl()` system call.\r
+\r
+Zombie processes and hung processes could be resolved with a restart of the system.\r
+\r
+#### System restart\r
+Finally a system restart might be required to kill a process.\r
+Systems which are only accessible via a remote in-band connection may become inaccessible if a process termination operation that is necessary for reboot does not complete.\r
+\r
+### Subsystems\r
 Processes that are started in a subsystem might not be fully terminated if they are terminated using the command for that subsystem.  For example, in the Windows Subsystem for Linux (WSL), processes started and terminated via WSL calls such as with the `kill` command in Bash may still have an entry in the Windows process table.""" ;
     :kb-reference :Reference-InstantProcessTerminationToolToRecoverControlOfAnInformationHandlingSystem_DellProductsLP,
         :Reference-MalwareDetectionUsingLocalComputationalModels_CrowdstrikeInc ;
@@ -15370,8 +15370,8 @@ Processes that are started in a subsystem might not be fully terminated if they 
     rdfs:subClassOf :ImageSynthesisGAN ;
     :d3fend-id "D3A-PGG" ;
     :definition "Progressive Growing GAN (ProGAN) is an extension to the GAN training process that allows for the stable training of generator models that can output large high-quality images." ;
-    :kb-article """## References
-
+    :kb-article """## References\r
+\r
 Machine Learning Mastery. (n.d.). Introduction to Progressive Growing Generative Adversarial Networks. [Link](https://machinelearningmastery.com/introduction-to-progressive-growing-generative-adversarial-networks/)""" ;
     :synonym "ProGAN" .
 
@@ -15381,7 +15381,7 @@ Machine Learning Mastery. (n.d.). Introduction to Progressive Growing Generative
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-PC" ;
     :definition "Projected clustering is a dimension reduction subspace clustering method." ;
-    :kb-article """## References
+    :kb-article """## References\r
 GeeksforGeeks. (n.d.). Projected Clustering in Data Analytics. [Link](https://www.geeksforgeeks.org/projected-clustering-in-data-analytics/)""" .
 
 :Projection-basedClustering a owl:Class,
@@ -15390,9 +15390,9 @@ GeeksforGeeks. (n.d.). Projected Clustering in Data Analytics. [Link](https://ww
     rdfs:subClassOf :High-dimensionClustering ;
     :d3fend-id "D3A-PBC" ;
     :definition "Projection Based Clustering is a clustering framework based on a chosen projection method and projection method a parameter-free high-dimensional data visualization technique." ;
-    :kb-article """## References
-R Core Team. (2021). ProjectionBasedClustering: Projection Based Clustering. [Link](https://cran.r-project.org/web/packages/ProjectionBasedClustering/ProjectionBasedClustering.pdf)
-
+    :kb-article """## References\r
+R Core Team. (2021). ProjectionBasedClustering: Projection Based Clustering. [Link](https://cran.r-project.org/web/packages/ProjectionBasedClustering/ProjectionBasedClustering.pdf)\r
+\r
 Lai, J. H., Liu, Y., & Wu, W. (2017). Projection Based Clustering. [Link](https://www.researchgate.net/publication/319006501_Projection_Based_Clustering)""" .
 
 :Prolog a owl:Class,
@@ -15401,10 +15401,10 @@ Lai, J. H., Liu, Y., & Wu, W. (2017). Projection Based Clustering. [Link](https:
     rdfs:subClassOf :LogicProgramming ;
     :d3fend-id "D3A-PRO" ;
     :definition "Prolog has its roots in first-order logic, a formal logic, and unlike many other programming languages." ;
-    :kb-article """## How it works
-Prolog is intended primarily as a declarative programming language: the program logic is expressed in terms of relations, represented as facts and rules. A computation is initiated by running a query over these relations.
-
-## References
+    :kb-article """## How it works\r
+Prolog is intended primarily as a declarative programming language: the program logic is expressed in terms of relations, represented as facts and rules. A computation is initiated by running a query over these relations.\r
+\r
+## References\r
 1. Prolog. (2023, April 5). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Prolog)""" .
 
 :PropertyListFile a owl:Class ;
@@ -15425,10 +15425,10 @@ Prolog is intended primarily as a declarative programming language: the program 
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-PL" ;
     :definition "Propositional logic deals with statements (i.e., propositions, which can be true or false) and relations between propositions, including the construction of arguments based on them." ;
-    :kb-article """## How it works
-Compound propositions are formed by connecting propositions by logical connectives. Propositions that contain no logical connectives are called atomic propositions.
-
-## References
+    :kb-article """## How it works\r
+Compound propositions are formed by connecting propositions by logical connectives. Propositions that contain no logical connectives are called atomic propositions.\r
+\r
+## References\r
 1. Propositional Calculus. (2022, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Propositional_calculus)""" ;
     :synonym "Propositional Calculus" .
 
@@ -15446,10 +15446,10 @@ Compound propositions are formed by connecting propositions by logical connectiv
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-PMAD" ;
     :definition "Collecting network communication protocol metadata and identifying statistical outliers." ;
-    :kb-article """## How it works
-Network protocol metadata is first collected and processed in real-time or post-facto. Metadata may include packet header information or information about a session (ex. time between requests/responses). Metadata is then grouped based on shared characteristics and those groups are compared to each other. If particular metadata differs significantly from other data, an alert is generated, identifying the network event as anomalous. Anomalous activity may indicate unauthorized activity.
-
-## Considerations
+    :kb-article """## How it works\r
+Network protocol metadata is first collected and processed in real-time or post-facto. Metadata may include packet header information or information about a session (ex. time between requests/responses). Metadata is then grouped based on shared characteristics and those groups are compared to each other. If particular metadata differs significantly from other data, an alert is generated, identifying the network event as anomalous. Anomalous activity may indicate unauthorized activity.\r
+\r
+## Considerations\r
 Metadata collection on enterprises can yield large data sets. Storage, indexing, querying, and aging should be considered prior to implementation.""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingThreatsUsingMetadataVectors_VECTRANETWORKSInc,
         :Reference-MethodAndSystemForDetectingThreatsUsingPassiveClusterMapping_VectraNetworksInc,
@@ -15492,7 +15492,7 @@ Metadata collection on enterprises can yield large data sets. Storage, indexing,
     rdfs:subClassOf :Model-freeReinforcementLearning ;
     :d3fend-id "D3A-QL" ;
     :definition "Q-learning is a model-free reinforcement learning algorithm to learn the value of an action in a particular state. It does not require a model of the environment (hence \"model-free\"), and it can handle problems with stochastic transitions and rewards without requiring adaptations." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Q-learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Q-learning).""" .
 
 :QueryByCommittee a owl:Class,
@@ -15501,7 +15501,7 @@ Q-learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Q-learning).""" .
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-QBC" ;
     :definition "Query by Committee (QBC) takes inspiration from ensemble methods. Instead of just one classifier, it takes into account the decision of a committee 𝐶=ℎ1,…,ℎc of classifiers ℎ𝑖. Each classifier has the same target classes, but a different underlying model or a different view on the data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :RadioModem a owl:Class ;
@@ -15523,7 +15523,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :BootstrapAggregating ;
     :d3fend-id "D3A-RF" ;
     :definition "Random Forest is a ML method that combines several other ML methods. At its core, Random Forest is an ensemble method of multiple bootstrapped decision trees filled with training data and random feature selection." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Random forest. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Random_forest).""" .
 
 :RandomSplits a owl:Class,
@@ -15532,7 +15532,7 @@ Random forest. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Random_forest)."
     rdfs:subClassOf :ResamplingEnsemble ;
     :d3fend-id "D3A-RS" ;
     :definition "The dataset is repeatedly sampled with a random split of the data into train and test sets." ;
-    :kb-article """## References
+    :kb-article """## References\r
 How to Create a Random Split Cross-Validation and Bagging Ensemble for Deep Learning in Keras."*Machine Learning Mastery*.  [Link](https://machinelearningmastery.com/how-to-create-a-random-split-cross-validation-and-bagging-ensemble-for-deep-learning-in-keras/).""" .
 
 :Range a owl:Class,
@@ -15541,7 +15541,7 @@ How to Create a Random Split Cross-Validation and Bagging Ensemble for Deep Lear
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-RAN" ;
     :definition "The range of a set of data is the difference between the largest and smallest value." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Range_(statistics))""" .
 
 :RangeMatching a owl:Class,
@@ -15586,8 +15586,9 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
     rdfs:seeAlso <http://dbpedia.org/resource/Read_(system_call)> .
 
 :Reconnaissance a owl:Class ;
+    rdfs:label "Reconnaissance" ;
     rdfs:subClassOf :OffensiveTactic ;
-    :display-order 0 .
+    :display-order -1 .
 
 :ReconnaissanceTechnique a owl:Class ;
     rdfs:label "Reconnaissance Technique" ;
@@ -15608,7 +15609,7 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
     rdfs:subClassOf :DeepNeuralNetClassification ;
     :d3fend-id "D3A-RNN" ;
     :definition "Recurrent Nerual Networks (RNN) are a class of artificial neural networks where connections between nodes can create a cycle, allowing output from some nodes to affect subsequent input to the same nodes. This allows it to exhibit temporal dynamic behavior." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (2021, September 7). Recurrent Neural Network. [Link](https://en.wikipedia.org/wiki/Recurrent_neural_network)""" ;
     :todo "Review: Which Definition" .
 
@@ -15626,8 +15627,8 @@ Wikipedia. (2021, September 7). Recurrent Neural Network. [Link](https://en.wiki
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-RM" ;
     :definition "Regular expression matching is type of partial string matching using a regular expression, which is a sequence of characters that specifies a match pattern in text." ;
-    :kb-article """## References
-1. Regular expression. (2023, June 1). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Regular_expression)
+    :kb-article """## References\r
+1. Regular expression. (2023, June 1). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Regular_expression)\r
 2. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""" ;
     :synonym "Regex",
         "Regexp" .
@@ -15638,7 +15639,7 @@ Wikipedia. (2021, September 7). Recurrent Neural Network. [Link](https://en.wiki
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-RA" ;
     :definition "Regression analysis is a set of statistical processes for estimating the relationships between a dependent variable (often called the 'outcome' or 'response' variable, or a 'label' in machine learning parlance) and one or more independent variables (often called 'predictors', 'covariates', 'explanatory variables' or 'features')." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Regression analysis. [Link](https://en.wikipedia.org/wiki/Regression_analysis)""" .
 
 :RegressionAnalysisLearning a owl:Class,
@@ -15647,7 +15648,7 @@ Wikipedia. (n.d.). Regression analysis. [Link](https://en.wikipedia.org/wiki/Reg
     rdfs:subClassOf :SupervisedLearning ;
     :d3fend-id "D3A-RAL" ;
     :definition "Regression is used to understand the relationship between dependent and independent variables which is then used to make projections, such as for sales revenue for a given business." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning).""" .
 
 :ReinforcementLearning a owl:Class,
@@ -15656,7 +15657,7 @@ Supervised Learning. IBM. [Link](https://www.ibm.com/topics/supervised-learning)
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-RL" ;
     :definition "Reinforcement Learning is a subjugate technique of machine learning that uses feedback to reinforce good or valid rules and lessen the reliance of bad or ineffective rules" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Reinforcement learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Reinforcement_learning).""" .
 
 :Relational-basedTransferLearning a owl:Class,
@@ -15665,7 +15666,7 @@ Reinforcement learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Reinfor
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-RBTL" ;
     :definition "Relational-based Transfer Learning is a subfield of machine learning where knowledge and patterns learned from one domain, characterized by relational and structured data, are transferred to enhance the learning of another related domain. This approach leverages shared concepts, relations, and structures across domains, taking advantage of the rich semantic knowledge within relational data to improve learning performance in the target task." ;
-    :kb-article """## References
+    :kb-article """## References\r
 V7 Labs. (n.d.). Transfer Learning Guide. [Link](https://www.v7labs.com/blog/transfer-learning-guide#:~:text=Relational%2Dbased%20transfer%20learning%20approaches,domain%20to%20the%20target%20domain).""" .
 
 :RelayPatternAnalysis a :NetworkTrafficAnalysis,
@@ -15678,11 +15679,11 @@ V7 Labs. (n.d.). Transfer Learning Guide. [Link](https://www.v7labs.com/blog/tra
             owl:someValuesFrom :OutboundInternetNetworkTraffic ] ;
     :d3fend-id "D3-RPA" ;
     :definition "The detection of an internal host relaying traffic between the internal network and the external network." ;
-    :kb-article """## How it works
-A relay may use a variety of proxying, forwarding, or routing technologies to bridge a protected network with an external network. A defensive analytic to detect a relay network may compare the network sessions among multiple hosts. Hosts which have nearly similar network statistics may be part of a relay network. The statistics may include number of bytes sent to and from, time of session initiation, packet size, or packet arrival time data.
-
-## Considerations
-
+    :kb-article """## How it works\r
+A relay may use a variety of proxying, forwarding, or routing technologies to bridge a protected network with an external network. A defensive analytic to detect a relay network may compare the network sessions among multiple hosts. Hosts which have nearly similar network statistics may be part of a relay network. The statistics may include number of bytes sent to and from, time of session initiation, packet size, or packet arrival time data.\r
+\r
+## Considerations\r
+\r
 Complex intranet VPNs or routing encapsulation may affect the detection analytics.  In addition, unwanted packets might not be forwarded, and additional packets may be added at the relay, further complicating detection.""" ;
     :kb-reference :Reference-MaliciousRelayDetectionOnNetworks_VECTRANETWORKSInc ;
     :synonym "Relay Network Detection" .
@@ -15743,25 +15744,25 @@ Complex intranet VPNs or routing encapsulation may affect the detection analytic
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-RTSD" ;
     :definition "Detection of an unauthorized remote live terminal console session by examining network traffic to a network host." ;
-    :kb-article """## How it works
-An external attacker takes remote control of a host inside a company or organization's network and manually directs offensive techniques. Nonstandard terminal sessions and abnormal behaviors are analyzed in this technique. Abnormal behavior detection includes analysis of user input patterns in the real-time session, keyboard output and packet inspection.
-
-### Network Traffic Inspection
-Network traffic from internal hosts is the main concern and focus for the traffic inspection. The network traffic is collected into inspection groups. The groups of traffic are assembled into distinct pair flows (outbound/inbound) and the pair flows are further divided into sessions. Only sessions originated inside of the network are considered for the inspection. Traffic inspection includes analysis to determine if a human is involved in the session exchanges. Time-based statistics are captured for each session being analyzed by the detection engine.
-
-### Algorithm Analysis Description
-Analysis algorithms look for patterns in the network traffic captured from the session data.  A detection engine groups the session traffic data, between the hosts, into rapid exchange instances. Analysis of rapid exchange traffic patterns can lead to the discovery of abnormal behavior which is indicative of a compromised internal host. The analysis algorithms look for patterns in the traffic which correlate to known activity (e.g., relay attacks, bot activity, bitcoin mining). Some metrics used during inspection include the following.
-
-* Number of rapid-exchange instances
-* Time interval between packets
-* Fixed cadence of traffic
-* Rhythm and direction of the initiation of instances
-* Volume of data flowing from internal to external controlling host
-* Data transfer characteristics
-* Variability in length of silent periods
-
-## Considerations
-* Full packet capture is required which can be process intensive to analyze
+    :kb-article """## How it works\r
+An external attacker takes remote control of a host inside a company or organization's network and manually directs offensive techniques. Nonstandard terminal sessions and abnormal behaviors are analyzed in this technique. Abnormal behavior detection includes analysis of user input patterns in the real-time session, keyboard output and packet inspection.\r
+\r
+### Network Traffic Inspection\r
+Network traffic from internal hosts is the main concern and focus for the traffic inspection. The network traffic is collected into inspection groups. The groups of traffic are assembled into distinct pair flows (outbound/inbound) and the pair flows are further divided into sessions. Only sessions originated inside of the network are considered for the inspection. Traffic inspection includes analysis to determine if a human is involved in the session exchanges. Time-based statistics are captured for each session being analyzed by the detection engine.\r
+\r
+### Algorithm Analysis Description\r
+Analysis algorithms look for patterns in the network traffic captured from the session data.  A detection engine groups the session traffic data, between the hosts, into rapid exchange instances. Analysis of rapid exchange traffic patterns can lead to the discovery of abnormal behavior which is indicative of a compromised internal host. The analysis algorithms look for patterns in the traffic which correlate to known activity (e.g., relay attacks, bot activity, bitcoin mining). Some metrics used during inspection include the following.\r
+\r
+* Number of rapid-exchange instances\r
+* Time interval between packets\r
+* Fixed cadence of traffic\r
+* Rhythm and direction of the initiation of instances\r
+* Volume of data flowing from internal to external controlling host\r
+* Data transfer characteristics\r
+* Variability in length of silent periods\r
+\r
+## Considerations\r
+* Full packet capture is required which can be process intensive to analyze\r
 * Attackers that move low and slow may blend in with existing traffic resulting in false negatives""" ;
     :kb-reference :Reference-MethodAndSystemForDetectingExternalControlOfCompromisedHosts_VECTRANETWORKSInc,
         :Reference-RDPConnectionDetection_MITRE,
@@ -15779,9 +15780,9 @@ Analysis algorithms look for patterns in the network traffic captured from the s
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-RE" ;
     :definition "In the method, the small classes are oversampled and large classes are undersampled. The resampling scale is determined by the ratio of the min class number and max class number. And multiple machine learning methods are selected to construct the ensemble" ;
-    :kb-article """## References
-Ensemble learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Ensemble_learning).
-
+    :kb-article """## References\r
+Ensemble learning. Wikipedia. [Link](https://en.wikipedia.org/wiki/Ensemble_learning).\r
+\r
 Torgo, L. (2014). A resampling ensemble algorithm for improved accuracy. *Neurocomputing*, 134, 55-66.  [Link](https://www.sciencedirect.com/science/article/pii/S0925231214007644#:~:text=A%20resampling%20ensemble%20algorithm%20is,and%20undersampling%20are%20empirically%20analyzed).""" .
 
 :ResidualNeuralNetwork a owl:Class,
@@ -15790,7 +15791,7 @@ Torgo, L. (2014). A resampling ensemble algorithm for improved accuracy. *Neuroc
     rdfs:subClassOf :ConvolutionalNeuralNetwork ;
     :d3fend-id "D3A-RNN" ;
     :definition "A residual neural network (ResNet) is an artificial neural network (ANN). It is a gateless or open-gated variant of the HighwayNet, the first working very deep feedforward neural network with hundreds of layers, much deeper than previous neural networks." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia contributors. (2021, August 23). Residual neural network. In Wikipedia, The Free Encyclopedia. [Link](https://en.wikipedia.org/wiki/Residual_neural_network)""" .
 
 :Resource a owl:Class ;
@@ -15819,12 +15820,12 @@ Wikipedia contributors. (2021, August 23). Residual neural network. In Wikipedia
             owl:someValuesFrom :Authorization ] ;
     :d3fend-id "D3-RAPA" ;
     :definition "Analyzing the resources accessed by a user to identify unauthorized activity." ;
-    :kb-article """## How it works
-This technique analyzes a user's resource accesses by comparing the user's recent activity against a baseline activity model. Major differences between the current activity and the baseline model might indicate unauthorized activity if they are severe enough.
-
-
-## Considerations
-* Potential for false positives from anomalies that are not associated with malicious activity.
+    :kb-article """## How it works\r
+This technique analyzes a user's resource accesses by comparing the user's recent activity against a baseline activity model. Major differences between the current activity and the baseline model might indicate unauthorized activity if they are severe enough.\r
+\r
+\r
+## Considerations\r
+* Potential for false positives from anomalies that are not associated with malicious activity.\r
 * Attackers that move low and slow may not differentiate their resource access activity behavior enough to trigger an alert.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
@@ -15834,14 +15835,15 @@ This technique analyzes a user's resource accesses by comparing the user's recen
 
 :ResourceDevelopment a owl:Class ;
     rdfs:label "Resource Development" ;
-    rdfs:subClassOf :OffensiveTactic .
+    rdfs:subClassOf :OffensiveTactic ;
+    :display-order 0 .
 
 :ResourceDevelopmentTechnique a owl:Class ;
     rdfs:label "Resource Development Technique" ;
     rdfs:subClassOf :OffensiveTechnique,
         [ a owl:Restriction ;
             owl:onProperty :enables ;
-            owl:someValuesFrom :Reconnaissance ] .
+            owl:someValuesFrom :ResourceDevelopment ] .
 
 :ResourceFork a owl:Class ;
     rdfs:label "Resource Fork" ;
@@ -15865,22 +15867,22 @@ This technique analyzes a user's resource accesses by comparing the user's recen
             owl:someValuesFrom :InboundInternetDNSResponseTraffic ] ;
     :d3fend-id "D3-RRDD" ;
     :definition "Blocking a reverse DNS lookup's answer's domain name value." ;
-    :kb-article """## How it works
-
-In reverse resolution requests, the client sends to a nameserver (such as a DNS server) a query of an IP address, to get a response of the associated domain name(s). This technique drops reverse lookup responses where a domain name matches an entry in the blacklist, either verbatim or as a wildcard subdomain of a higher-level domain on the list. Such domain names might be unwanted because Forward Domain Name Resolution requests to such a blacklisted domain might return an unwanted IP address.
-
-This technique is useful because relying solely on Forward Resolution Domain Blacklisting will miss instances where the domain in question is forward-resolved in a manner that is not inspected via a subsequent technique (as is likely the case if that resolution is performed with DoH (DNS over HTTPS) or DoT (DNS over TLS)). Additionally, note that responses to forward lookups of that domain are *not* necessarily equal to the original IP in the reverse lookup request, and that future lookups of a string based on this domain may even employ a less-common name resolution protocol, such as NBNS.
-
-The DNS response can either be blocked by dropping the network traffic with an inline device, or by modifying the value of the response sent by the DNS server.  To prevent client applications from hanging on a request, it is common practice to replace malicious values, either with names like "localhost." or the address of a honeypot maintained by the network administrators.
-
-## Considerations
-
-* This technique does not prevent the client from contacting the blacklisted domain or any IP addresses that it might resolve to, only from learning about this domain name via a nameserver lookup.
-* DNS response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer domain name value(s).
-  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.
-  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.
-* This technique must be deployed between the application that receives the response and the server which sent the response.
-  * DNS responses sent in an encrypted manner, such as using DoH or DoT, will require interception of the TLS connections in order to determine the domain name(s) in the response.
+    :kb-article """## How it works\r
+\r
+In reverse resolution requests, the client sends to a nameserver (such as a DNS server) a query of an IP address, to get a response of the associated domain name(s). This technique drops reverse lookup responses where a domain name matches an entry in the blacklist, either verbatim or as a wildcard subdomain of a higher-level domain on the list. Such domain names might be unwanted because Forward Domain Name Resolution requests to such a blacklisted domain might return an unwanted IP address.\r
+\r
+This technique is useful because relying solely on Forward Resolution Domain Blacklisting will miss instances where the domain in question is forward-resolved in a manner that is not inspected via a subsequent technique (as is likely the case if that resolution is performed with DoH (DNS over HTTPS) or DoT (DNS over TLS)). Additionally, note that responses to forward lookups of that domain are *not* necessarily equal to the original IP in the reverse lookup request, and that future lookups of a string based on this domain may even employ a less-common name resolution protocol, such as NBNS.\r
+\r
+The DNS response can either be blocked by dropping the network traffic with an inline device, or by modifying the value of the response sent by the DNS server.  To prevent client applications from hanging on a request, it is common practice to replace malicious values, either with names like "localhost." or the address of a honeypot maintained by the network administrators.\r
+\r
+## Considerations\r
+\r
+* This technique does not prevent the client from contacting the blacklisted domain or any IP addresses that it might resolve to, only from learning about this domain name via a nameserver lookup.\r
+* DNS response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer domain name value(s).\r
+  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.\r
+  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.\r
+* This technique must be deployed between the application that receives the response and the server which sent the response.\r
+  * DNS responses sent in an encrypted manner, such as using DoH or DoT, will require interception of the TLS connections in order to determine the domain name(s) in the response.\r
 * Replacing the response is not effective in the case that the nameserver uses a technique to provide integrity of its responses, such as DNSSEC for DNS responses.""" ;
     :synonym "Reverse Resolution Domain Blacklisting" .
 
@@ -15894,15 +15896,15 @@ The DNS response can either be blocked by dropping the network traffic with an i
             owl:someValuesFrom :OutboundInternetDNSLookupTraffic ] ;
     :d3fend-id "D3-RRID" ;
     :definition "Blocking a reverse lookup based on the query's IP address value." ;
-    :kb-article """## How it works
-This technique prevents a client from learning domains deemed to be potentially malicious, which would have been delivered via reverse resolution responses over the DNS protocol.
-
-Queries for reverse resolution requests (that is, requests where IP(s) are sent and a domain is returned) are collected, and the IP address(es) included in the query are examined. If the IP address(es) are in a range included in the blacklist, then the query is dropped.
-
-## Considerations
-- The blacklist will have to be maintained and will need to be kept up to date with identified maintenance cycles to ensure lists are not stale.
-- DNS query traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS query IP address value(s).
-  - DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.
+    :kb-article """## How it works\r
+This technique prevents a client from learning domains deemed to be potentially malicious, which would have been delivered via reverse resolution responses over the DNS protocol.\r
+\r
+Queries for reverse resolution requests (that is, requests where IP(s) are sent and a domain is returned) are collected, and the IP address(es) included in the query are examined. If the IP address(es) are in a range included in the blacklist, then the query is dropped.\r
+\r
+## Considerations\r
+- The blacklist will have to be maintained and will need to be kept up to date with identified maintenance cycles to ensure lists are not stale.\r
+- DNS query traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS query IP address value(s).\r
+  - DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.\r
   - Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS queries. These protocols have often been enabled in browser settings transparently after a browser update, with DNS queries proxied over one of these cryptographic protocols through a specified host.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Reverse Resolution IP Blacklisting" .
@@ -15961,28 +15963,28 @@ Queries for reverse resolution requests (that is, requests where IP(s) are sent 
             owl:someValuesFrom :RPCNetworkTraffic ] ;
     :d3fend-id "D3-RTA" ;
     :definition "Monitoring the activity of remote procedure calls in communication traffic to establish standard protocol operations and potential attacker activities." ;
-    :kb-article """## How it works
-A remote procedure call (RPC) enables one computer to execute a specific function on another computer, as if it were a local application process. There are numerous RPC specifications and implementations. RPC capabilities can be abused by attackers in order to achieve a variety of tactical objectives including execution, persistence, initial access, and more. RPC proxies may be used to collect and store RPC traffic. RPCs can occur over network sockets or named pipes.
-
-Analytics look for unauthorized behavior such as:
-
-* Processes being launched or scheduled remotely
-* System configurations being changed remotely
-* Unauthorized file read activity
-
-Example RPC Protocols:
-
-* DCE/RPC
-* CORBA
-* Open Network Computing Remote Procedure Call
-* D-Bus
-* XML-RPC
-* JSON-RPC
-* SOAP
-* Apache Thrift
-
-## Considerations
-* RPC is widely used in enterprise environments, and significant data filtering may be required in large environments to enable analytic processing.
+    :kb-article """## How it works\r
+A remote procedure call (RPC) enables one computer to execute a specific function on another computer, as if it were a local application process. There are numerous RPC specifications and implementations. RPC capabilities can be abused by attackers in order to achieve a variety of tactical objectives including execution, persistence, initial access, and more. RPC proxies may be used to collect and store RPC traffic. RPCs can occur over network sockets or named pipes.\r
+\r
+Analytics look for unauthorized behavior such as:\r
+\r
+* Processes being launched or scheduled remotely\r
+* System configurations being changed remotely\r
+* Unauthorized file read activity\r
+\r
+Example RPC Protocols:\r
+\r
+* DCE/RPC\r
+* CORBA\r
+* Open Network Computing Remote Procedure Call\r
+* D-Bus\r
+* XML-RPC\r
+* JSON-RPC\r
+* SOAP\r
+* Apache Thrift\r
+\r
+## Considerations\r
+* RPC is widely used in enterprise environments, and significant data filtering may be required in large environments to enable analytic processing.\r
 * RPC traffic may occur over a pipe, or within a host over loopback interface, thus making network collection difficult.""" ;
     :kb-reference :Reference-CAR-2014-05-001%3ARPCActivity_MITRE,
         :Reference-CAR-2014-11-007-RemoteWindowsManagementInstrumentation_WMI_OverRPC_MITRE,
@@ -16001,7 +16003,7 @@ Example RPC Protocols:
     rdfs:isDefinedBy "https://dbpedia.org/page/State%E2%80%93action%E2%80%93reward%E2%80%93state%E2%80%93action" ;
     :d3fend-id "D3A-SAR" ;
     :definition "State-action-reward-state-action (SARSA) is an algorithm for learning a Markov decision process policy, used in the reinforcement learning area of machine learning." ;
-    :kb-article """## References
+    :kb-article """## References\r
 State-action-reward-state-action. Wikipedia.  [Link](https://en.wikipedia.org/wiki/State%E2%80%93action%E2%80%93reward%E2%80%93state%E2%80%93action).""" .
 
 :SavedInstructionPointer a owl:Class ;
@@ -16041,12 +16043,12 @@ State-action-reward-state-action. Wikipedia.  [Link](https://en.wikipedia.org/wi
             owl:someValuesFrom :JobSchedule ] ;
     :d3fend-id "D3-SJA" ;
     :definition "Analysis of source files, processes, destination files, or destination servers associated with a scheduled job to detect unauthorized use of job scheduling." ;
-    :kb-article """## How it works
-Scheduled job execution can be utilized by adversaries for the purpose of persistence, conducting remote execution, or gaining privileges. Details of a scheduled job such as associated source files, processes, destination files, or destination servers are first identified and analyzed and then compared against an anti-malware signature database, whitelist, or reputation server. For example, a file associated with a scheduled job to be executed at a specified time or a remote server that is accessed as part of a scheduled task is compared against an anti-malware signature database, whitelist, or reputation server, and if a match is found, execution is denied and an alert is generated.
-
-In addition to traditional scheduled jobs, triggers can be set to execute a specific command after detecting a specific event in the system, such as with WMI Event Subscriptions in Windows.
-
-## Considerations
+    :kb-article """## How it works\r
+Scheduled job execution can be utilized by adversaries for the purpose of persistence, conducting remote execution, or gaining privileges. Details of a scheduled job such as associated source files, processes, destination files, or destination servers are first identified and analyzed and then compared against an anti-malware signature database, whitelist, or reputation server. For example, a file associated with a scheduled job to be executed at a specified time or a remote server that is accessed as part of a scheduled task is compared against an anti-malware signature database, whitelist, or reputation server, and if a match is found, execution is denied and an alert is generated.\r
+\r
+In addition to traditional scheduled jobs, triggers can be set to execute a specific command after detecting a specific event in the system, such as with WMI Event Subscriptions in Windows.\r
+\r
+## Considerations\r
 Jobs can be scheduled in many different and sometimes creative ways through operating system capabilities.""" ;
     :kb-reference :Reference-ExecutionWithAT_MITRE,
         :Reference-ExecutionWithSchtasks_MITRE,
@@ -16077,10 +16079,10 @@ Jobs can be scheduled in many different and sometimes creative ways through oper
             owl:someValuesFrom :ScriptApplicationProcess ] ;
     :d3fend-id "D3-SEA" ;
     :definition "Analyzing the execution of a script to detect unauthorized user activity." ;
-    :kb-article """## How it works
-Software installed on the host system hooks into a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. Pattern matching is used to identify unauthorized commands or in the case of script files, a hash of the file is compared against hashes of known unauthorized script files.
-
-## Considerations
+    :kb-article """## How it works\r
+Software installed on the host system hooks into a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. Pattern matching is used to identify unauthorized commands or in the case of script files, a hash of the file is compared against hashes of known unauthorized script files.\r
+\r
+## Considerations\r
 List of known unauthorized script files or regular expression patterns must be kept up to date to ensure detection of new threats.""" ;
     :kb-reference :Reference-DetectingScript-basedMalware_CrowdstrikeInc .
 
@@ -16116,21 +16118,21 @@ List of known unauthorized script files or regular expression patterns must be k
             owl:someValuesFrom :ProcessSegment ] ;
     :d3fend-id "D3-SAOR" ;
     :definition "Randomizing the base (start) address of one or more segments of memory during the initialization of a process." ;
-    :kb-article """## How it works
-
-Many application exploits rely on an attacker specifying a location in memory, which points to data or code used by the attacker.  If the addresses are changed each time the program is run, then it becomes more difficult for the attacker to determine the location that will contain the code they wish to run.
-
-Imported modules may be similarly realigned if their default memory addresses conflict with other modules, in a process known as "rebasing."  Just as not all code is built for participation in ASLR, not all modules can be rebased; instead, modules must indicate whether they implement support for rebasing.  Such information to relocate the executable is typically stored in the ".reloc" segment -- each of the addresses pointed to in this segment has its address increased by the amount of the offset.
-(An alternative method for relocation would be to add an amount to a global variable each time -- leading to less overhead in the module load, but more for each access.  Still another implementation could instead contain code to deference each changeable memory location on the fly, so that each of the references do not need to be updated.
-
-
-## Considerations
-
-As the offset for each segment is constant, it is possible to guess at the value of the address given the address of another variable.  Alternatively, memory pointers may be kept around, which contain the address of another variable.
-Another bypass technique is known as an "egg hunt," whereby the attacker searches for a rather unique piece of the data or code in memory to determine its likely address.
-
-The program needs to store these addresses for the functions somewhere.  In Linux, the PLT contains a "trampoline" to these addresses.  If an attacker desires to jump to the start of an existing function, they can jump directly to the trampoline anyway, and may have the opportunity to provide their own stack frame to the function with a write to the stack. If they overwrite a saved stack pointer which is loaded back into memory, or execute a function, that changes the address of a stack pointer.
-
+    :kb-article """## How it works\r
+\r
+Many application exploits rely on an attacker specifying a location in memory, which points to data or code used by the attacker.  If the addresses are changed each time the program is run, then it becomes more difficult for the attacker to determine the location that will contain the code they wish to run.\r
+\r
+Imported modules may be similarly realigned if their default memory addresses conflict with other modules, in a process known as "rebasing."  Just as not all code is built for participation in ASLR, not all modules can be rebased; instead, modules must indicate whether they implement support for rebasing.  Such information to relocate the executable is typically stored in the ".reloc" segment -- each of the addresses pointed to in this segment has its address increased by the amount of the offset.\r
+(An alternative method for relocation would be to add an amount to a global variable each time -- leading to less overhead in the module load, but more for each access.  Still another implementation could instead contain code to deference each changeable memory location on the fly, so that each of the references do not need to be updated.\r
+\r
+\r
+## Considerations\r
+\r
+As the offset for each segment is constant, it is possible to guess at the value of the address given the address of another variable.  Alternatively, memory pointers may be kept around, which contain the address of another variable.\r
+Another bypass technique is known as an "egg hunt," whereby the attacker searches for a rather unique piece of the data or code in memory to determine its likely address.\r
+\r
+The program needs to store these addresses for the functions somewhere.  In Linux, the PLT contains a "trampoline" to these addresses.  If an attacker desires to jump to the start of an existing function, they can jump directly to the trampoline anyway, and may have the opportunity to provide their own stack frame to the function with a write to the stack. If they overwrite a saved stack pointer which is loaded back into memory, or execute a function, that changes the address of a stack pointer.\r
+\r
 If an attacker wants to inject some data into the program, for example as a parameter to a known function that is not under ASLR or a pointer to a trampoline function in the PLT, then they can repeat the data until they exceed the range of ASLR coverage, which on 32-bit systems is accomplishable in a few seconds with a heap spray.  Microsoft's EMET and Windows 10 Exploit Guard can pre-allocate particular addresses that are commonly used in heap sprays.  However, in many products, there does not seem to be nearly a complete coverage of such addresses, which only need to be executable and in the range of the heap; 0x0c0c0c0c is such an address that is commonly used for the x86 processor architecture, as when executed it only performs a numeric operation to a register four times.""" ;
     :kb-reference :Reference-DYNAMICBASE_UseAddressSpaceLayoutRandomization_MicrosoftDocs,
         :Reference-HowASLRProtectsLinuxSystemsFromBufferOverflowAttacks_NetworkWorld ;
@@ -16143,7 +16145,7 @@ If an attacker wants to inject some data into the program, for example as a para
     rdfs:subClassOf :ANN-basedClustering ;
     :d3fend-id "D3A-SOM" ;
     :definition "A Self-Organizing Map (SOM) is a unsupervised learning model in Artificial Neural Network where the feature maps are the generated two-dimensional discretized form of an input space during the model training (based on competitive learning)" ;
-    :kb-article """## References
+    :kb-article """## References\r
 GeeksforGeeks. (n.d.). ANN - Self Organizing Neural Network (SONN). [Link](https://www.geeksforgeeks.org/ann-self-organizing-neural-network-sonn/)""" ;
     :todo "May be called SONN based on citation" .
 
@@ -16153,7 +16155,7 @@ GeeksforGeeks. (n.d.). ANN - Self Organizing Neural Network (SONN). [Link](https
     rdfs:subClassOf :Semi-supervisedWrapperMethod ;
     :d3fend-id "D3A-SSB" ;
     :definition "Boosting methods can be readily extended to the semi-supervised setting, by introducing pseudo-labeled data after each learning step; which gives rise to the idea of semi-supervised boosting methods. The pseudo-labeling approach of self- training and co-training can be easily extended to boosting methods. Several boosting methods such as SSMBoost, ASSEMBLE, SemiBoost, RegBoost, etc can be found which can be applied for utilizing unlabeled datasets for supervised classifiers." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedCluster-then-label a owl:Class,
@@ -16162,7 +16164,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :UnsupervisedPreprocessing ;
     :d3fend-id "D3A-SSCTL" ;
     :definition "Pre-training methods are aimed to guide the parameters of a network towards interesting regions in model space using unlabeled data, before fine-tuning the parameters with the labeled data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedCo-training a owl:Class,
@@ -16171,7 +16173,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :Semi-supervisedWrapperMethod ;
     :d3fend-id "D3A-SSCT" ;
     :definition "Multi-view co-training involves training the classifiers in completely different views of training data. On the other hand, single-view co-training methods are generally applied as ensemble methods." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedFeatureExtraction a owl:Class,
@@ -16180,7 +16182,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :UnsupervisedPreprocessing ;
     :d3fend-id "D3A-SSFE" ;
     :definition "Feature extraction refers to reducing the number of dimensions in a data point so that it is computationally feasible and effective to learn a model." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedGenerativeModelLearning a owl:Class,
@@ -16189,7 +16191,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-SSGML" ;
     :definition "A Semi Supervised Machine Learning model which assume that the distributions take some particular form p(x|y,theta) parameterized by the vector. If these assumptions are incorrect, the unlabeled data may actually decrease the accuracy of the solution relative to what would have been obtained from labeled data alone. However, if the assumptions are correct, then the unlabeled data necessarily improves performance." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervision#Generative_models).""" .
 
 :Semi-supervisedInductiveLearning a owl:Class,
@@ -16197,11 +16199,11 @@ Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervis
     rdfs:label "Semi-supervised Inductive Learning" ;
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-SSIL" ;
-    :definition """The goal of inductive learning is to infer the correct mapping from
+    :definition """The goal of inductive learning is to infer the correct mapping from\r
 X to Y""" ;
-    :kb-article """## References
-Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).
-
+    :kb-article """## References\r
+Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).\r
+\r
 Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularization. In Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL) (pp. 1-9).  [Link](https://www.cs.sfu.ca/~anoop/papers/pdf/semisup_naacl.pdf).""" .
 
 :Semi-SupervisedLearning a owl:Class,
@@ -16210,7 +16212,7 @@ Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularizati
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-SSL" ;
     :definition "Semi-supervised learning is a branch of machine learning that combines a small amount of labeled data with a large amount of unlabeled data during training." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning).""" ;
     rdfs:seeAlso "https://link.springer.com/article/10.1007/s10994-019-05855-6" .
 
@@ -16220,7 +16222,7 @@ Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-
     rdfs:subClassOf :IntrinsicallySemi-supervisedLearning ;
     :d3fend-id "D3A-SSML" ;
     :definition "A version of Semi-Supervised Learning that applies the Manifold assumption that the data like approximately on a manifold of much lower dimension than the input space." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervision#Generative_models).""" .
 
 :Semi-supervisedPre-training a owl:Class,
@@ -16229,7 +16231,7 @@ Weak supervision. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Weak_supervis
     rdfs:subClassOf :UnsupervisedPreprocessing ;
     :d3fend-id "D3A-SSPT" ;
     :definition "Pre-training methods are aimed to guide the parameters of a network towards interesting regions in model space using unlabeled data, before fine-tuning the parameters with the labeled data" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/)""" .
 
 :Semi-supervisedSelf-training a owl:Class,
@@ -16238,7 +16240,7 @@ Jashish Shrestha. (n.d.). Beginner's Guide to Semi-Supervised Learning. [Link](h
     rdfs:subClassOf :Semi-supervisedWrapperMethod ;
     :d3fend-id "D3A-SSST" ;
     :definition "Self-training is the procedure in which a supervised method for classification or regression is modified it to work in a semi-supervised manner, taking advantage of labeled and unlabeled data" ;
-    :kb-article """## References
+    :kb-article """## References\r
 AltexSoft. (n.d.). Semi-Supervised Learning: A Technical Guide with Python Examples. [Link](https://www.altexsoft.com/blog/semi-supervised-learning/#:~:text=One%20of%20the%20simplest%20examples,of%20labeled%20and%20unlabeled%20data.)""" .
 
 :Semi-supervisedTransductiveLearning a owl:Class,
@@ -16246,11 +16248,11 @@ AltexSoft. (n.d.). Semi-Supervised Learning: A Technical Guide with Python Examp
     rdfs:label "Semi-supervised Transductive Learning" ;
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-SSTL" ;
-    :definition """The goal of transductive learning is to infer the correct labels for the given unlabeled data
+    :definition """The goal of transductive learning is to infer the correct labels for the given unlabeled data\r
 x_{l+1},... ,x_{l+u} only""" ;
-    :kb-article """## References
-Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).
-
+    :kb-article """## References\r
+Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning#Semi-supervised_learning).\r
+\r
 Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularization. In Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL) (pp. 1-9). [Link](https://www.cs.sfu.ca/~anoop/papers/pdf/semisup_naacl.pdf).""" .
 
 :Semi-supervisedWrapperMethod a owl:Class,
@@ -16259,7 +16261,7 @@ Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularizati
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-SSWM" ;
     :definition "The principle behind wrapper methods is that we train a model with labeled data and then generate pseudo-labels for the unlabeled data using the trained model iteratively." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Jashish, M. (n.d.). Beginner's Guide to Semi-Supervised Learning. Jashish Blog.  [Link](http://jashish.com.np/blog/posts/beginners-guide-to-semi-supervised-learning/).""" .
 
 :SenderMTAReputationAnalysis a :MessageAnalysis,
@@ -16272,20 +16274,20 @@ Jashish, M. (n.d.). Beginner's Guide to Semi-Supervised Learning. Jashish Blog. 
             owl:someValuesFrom :Email ] ;
     :d3fend-id "D3-SMRA" ;
     :definition "Characterizing the reputation of mail transfer agents (MTA) to determine the security risk in emails." ;
-    :kb-article """## How it works
-The sender message transfer agent (MTA) trust rating can be considered an indicator of the level of security risk and/or a trust level associated with sender MTAs in an email header.
-
-The features considered in determining the trust rating may include:
-
-* Length of time MTA has interacted with the enterprise
-* Number of sender domains sending emails from the MTA
-* Number of recipients in the enterprise the MTA sends emails to
-* Number of emails received from this MTA
-* Number of email replies received from this MTA
-
-For example, higher values for the length of time an MTA has interacted with the enterprise, or number of emails received from an MTA can result in a higher trust rating. The trust rating categorizes the sender MTA as unrated, neutral, trusted, suspicious, or malicious.
-
-## Considerations
+    :kb-article """## How it works\r
+The sender message transfer agent (MTA) trust rating can be considered an indicator of the level of security risk and/or a trust level associated with sender MTAs in an email header.\r
+\r
+The features considered in determining the trust rating may include:\r
+\r
+* Length of time MTA has interacted with the enterprise\r
+* Number of sender domains sending emails from the MTA\r
+* Number of recipients in the enterprise the MTA sends emails to\r
+* Number of emails received from this MTA\r
+* Number of email replies received from this MTA\r
+\r
+For example, higher values for the length of time an MTA has interacted with the enterprise, or number of emails received from an MTA can result in a higher trust rating. The trust rating categorizes the sender MTA as unrated, neutral, trusted, suspicious, or malicious.\r
+\r
+## Considerations\r
 Legitimate emails from a sender MTA may receive a lower trust rating over time if the sender's domain gets spoofed and is used to send unauthorized emails.""" ;
     :kb-reference :Reference-SystemsAndMethodsForDetectingAnd_orHandlingTargetedAttacksInTheEmailChannel_GraphusInc .
 
@@ -16299,25 +16301,25 @@ Legitimate emails from a sender MTA may receive a lower trust rating over time i
             owl:someValuesFrom :Email ] ;
     :d3fend-id "D3-SRA" ;
     :definition "Ascertaining sender reputation based on information associated with a message (e.g. email/instant messaging)." ;
-    :kb-article """## How it works
-
-Sender trust rating can be considered an indicator of the level of security risk and/or a trust level associated with a sender. The features considered in determining the trust rating include:
-
-* Length of time sender has sent emails to the enterprise
-* Number of recipients in the enterprise the sender interacts with
-* Sender vs. enterprise originated message ratio
-* Sender messages opened vs. not-opened ratio
-* Number of emails received from this sender
-* Number of emails replied to this sender
-* Number of emails from this sender not opened
-* Number of emails from this sender not opened that contain an attachment
-* Number of emails from this sender not opened that contain a URL
-* Number of emails sent to this sender
-* Number of email replies received from this sender.
-
-Higher values for the number of recipients the sender has interacted with or the number of emails received from the sender, for example, results in a higher trust rating. The trust rating can categorize the sender as unrated, neutral, trusted, suspicious, or malicious.
-
-## Considerations
+    :kb-article """## How it works\r
+\r
+Sender trust rating can be considered an indicator of the level of security risk and/or a trust level associated with a sender. The features considered in determining the trust rating include:\r
+\r
+* Length of time sender has sent emails to the enterprise\r
+* Number of recipients in the enterprise the sender interacts with\r
+* Sender vs. enterprise originated message ratio\r
+* Sender messages opened vs. not-opened ratio\r
+* Number of emails received from this sender\r
+* Number of emails replied to this sender\r
+* Number of emails from this sender not opened\r
+* Number of emails from this sender not opened that contain an attachment\r
+* Number of emails from this sender not opened that contain a URL\r
+* Number of emails sent to this sender\r
+* Number of email replies received from this sender.\r
+\r
+Higher values for the number of recipients the sender has interacted with or the number of emails received from the sender, for example, results in a higher trust rating. The trust rating can categorize the sender as unrated, neutral, trusted, suspicious, or malicious.\r
+\r
+## Considerations\r
 Legitimate emails from a sender may receive a lower trust rating over time if the sender's domain gets spoofed and is used to send unauthorized emails.""" ;
     :kb-reference :Reference-SystemsAndMethodsForDetectingAnd_orHandlingTargetedAttacksInTheEmailChannel_GraphusInc .
 
@@ -16332,7 +16334,7 @@ Legitimate emails from a sender may receive a lower trust rating over time if th
     rdfs:subClassOf :GenerativeAdversarialNetwork ;
     :d3fend-id "D3A-SEQ" ;
     :definition "Sequence Generation Framework (SeqGAN) models the data generator as a stochastic policy in reinforcement learning (RL), SeqGAN bypasses the generator differentiation problem by directly performing gradient policy update." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Yu, L., Zhang, W., Wang, J., & Yu, Y. (2017). SeqGAN: Sequence Generative Adversarial Nets with Policy Gradient. ArXiv preprint ArXiv:1609.05473. [Link](https://arxiv.org/abs/1609.05473)""" ;
     :synonym "Sequence GAN" .
 
@@ -16379,11 +16381,11 @@ Yu, L., Zhang, W., Wang, J., & Yu, Y. (2017). SeqGAN: Sequence Generative Advers
             owl:someValuesFrom :ServiceApplication ] ;
     :d3fend-id "D3-SBV" ;
     :definition "Analyzing changes in service binary files by comparing to a source of truth." ;
-    :kb-article """## How it works
-System service applications may originate from the operating system installation or third-party applications installed with administrative privileges. These services have an entry point of some executable file-- a binary or a script. Attackers sometimes modify these executables to launch their own code. Analyzing changes in these files may uncover unauthorized activity.
-
-## Considerations
-* These files change for legitimate reasons when the system or software updates.
+    :kb-article """## How it works\r
+System service applications may originate from the operating system installation or third-party applications installed with administrative privileges. These services have an entry point of some executable file-- a binary or a script. Attackers sometimes modify these executables to launch their own code. Analyzing changes in these files may uncover unauthorized activity.\r
+\r
+## Considerations\r
+* These files change for legitimate reasons when the system or software updates.\r
 * The source of truth must not be corrupted in order for this method to work.""" ;
     :kb-reference :Reference-ServiceBinaryModifications_MITRE .
 
@@ -16402,12 +16404,12 @@ System service applications may originate from the operating system installation
             owl:someValuesFrom :ServiceDependency ] ;
     :d3fend-id "D3-SVCDM" ;
     :definition "Service dependency mapping determines the services on which each given service relies." ;
-    :kb-article """## How it works
-The organization collects and models architectural information about the services and consumers of services and maps the dependencies between the services.
-
-## Considerations
-* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.
-* Service dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.
+    :kb-article """## How it works\r
+The organization collects and models architectural information about the services and consumers of services and maps the dependencies between the services.\r
+\r
+## Considerations\r
+* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.\r
+* Service dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.\r
 * Service dependencies in cloud or microservice architectures may be discovered using distributed tracing capabilities""" ;
     :kb-reference :Reference-CatiaUAFPlugin,
         :Reference-TivoliApplicationDependencyDiscoverManager7_3_0DependenciesBetweenResources,
@@ -16453,11 +16455,11 @@ The organization collects and models architectural information about the service
             owl:someValuesFrom :Authorization ] ;
     :d3fend-id "D3-SDA" ;
     :definition "Analyzing the duration of user sessions in order to detect unauthorized  activity." ;
-    :kb-article """## How it works
-Detecting unauthorized user sessions by comparing the duration of a user logon session with a baseline behavior model. The behavior model comprises historical user session duration times.  Abnormalities between session duration and the behavior model may indicate suspicious activity.
-
-## Considerations
-* Potential for false positives from anomalies that are not associated with malicious activity.
+    :kb-article """## How it works\r
+Detecting unauthorized user sessions by comparing the duration of a user logon session with a baseline behavior model. The behavior model comprises historical user session duration times.  Abnormalities between session duration and the behavior model may indicate suspicious activity.\r
+\r
+## Considerations\r
+* Potential for false positives from anomalies that are not associated with malicious activity.\r
 * Attackers may not differentiate their session duration enough to trigger an alert.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC .
@@ -16490,10 +16492,10 @@ Detecting unauthorized user sessions by comparing the duration of a user logon s
             owl:someValuesFrom :StackFrame ] ;
     :d3fend-id "D3-SSC" ;
     :definition "Comparing a call stack in system memory with a shadow call stack maintained by the processor to determine unauthorized shellcode activity." ;
-    :kb-article """## How it works
-This technique compares the call stack stored in system memory with the shadow call stack maintained in the cache memory of the processor.  Mismatches between the two are compared since a return oriented programming attack may only be able to control or spoof the call stack and not the shadow call stack. Mismatches are counted and if the number of mismatches exceeds a certain threshold it is an indication of unauthorized activity and a security response action is performed.
-
-## Considerations
+    :kb-article """## How it works\r
+This technique compares the call stack stored in system memory with the shadow call stack maintained in the cache memory of the processor.  Mismatches between the two are compared since a return oriented programming attack may only be able to control or spoof the call stack and not the shadow call stack. Mismatches are counted and if the number of mismatches exceeds a certain threshold it is an indication of unauthorized activity and a security response action is performed.\r
+\r
+## Considerations\r
 If the threshold for detecting a stack anomaly is low, it may not detect a return-oriented attack with just one gadget, such as a return-to-libc or return-to-plt attack.  Additionally, this technique may not detect JOP (Jump-oriented programming), as the return instruction is not executed.""" ;
     :kb-reference :Reference-ThreatDetectionForReturnOrientedProgramming_CrowdstrikeInc .
 
@@ -16533,20 +16535,20 @@ If the threshold for detecting a stack anomaly is low, it may not detect a retur
 :ShortcutFile a owl:Class ;
     rdfs:label "Shortcut File" ;
     rdfs:subClassOf :File ;
-    :definition """A shortcut file, or shortcut, is a handle that allows the user to find a file or resource located in a different directory or folder from the place where the shortcut is located.
-
-Shortcuts, which are supported by the graphical file browsers of some operating systems, may resemble symbolic links but differ in a number of important ways. One difference is what type of software is able to follow them:
-
- - Symbolic links are automatically resolved by the file system. Any software program, upon accessing a symbolic link, will see the target instead, whether the program is aware of symbolic links or not.
-
- - Shortcuts are treated like ordinary files by the file system and by software programs that are not aware of them. Only software programs that understand shortcuts (such as the Windows shell and file browsers) treat them as references to other files.
-
-Another difference are the capabilities of the mechanism:
-
- - Microsoft Windows shortcuts normally refer to a destination by an absolute path (starting from the root directory), whereas POSIX symbolic links can refer to destinations via either an absolute or a relative path. The latter is useful if both the location and destination of the symbolic link share a common path prefix[clarification needed], but that prefix is not yet known when the symbolic link is created (e.g., in an archive file that can be unpacked anywhere).
-
-- Microsoft Windows application shortcuts contain additional metadata that can be associated with the destination, whereas POSIX symbolic links are just strings that will be interpreted as absolute or relative pathnames.
-
+    :definition """A shortcut file, or shortcut, is a handle that allows the user to find a file or resource located in a different directory or folder from the place where the shortcut is located.\r
+\r
+Shortcuts, which are supported by the graphical file browsers of some operating systems, may resemble symbolic links but differ in a number of important ways. One difference is what type of software is able to follow them:\r
+\r
+ - Symbolic links are automatically resolved by the file system. Any software program, upon accessing a symbolic link, will see the target instead, whether the program is aware of symbolic links or not.\r
+\r
+ - Shortcuts are treated like ordinary files by the file system and by software programs that are not aware of them. Only software programs that understand shortcuts (such as the Windows shell and file browsers) treat them as references to other files.\r
+\r
+Another difference are the capabilities of the mechanism:\r
+\r
+ - Microsoft Windows shortcuts normally refer to a destination by an absolute path (starting from the root directory), whereas POSIX symbolic links can refer to destinations via either an absolute or a relative path. The latter is useful if both the location and destination of the symbolic link share a common path prefix[clarification needed], but that prefix is not yet known when the symbolic link is created (e.g., in an archive file that can be unpacked anywhere).\r
+\r
+- Microsoft Windows application shortcuts contain additional metadata that can be associated with the destination, whereas POSIX symbolic links are just strings that will be interpreted as absolute or relative pathnames.\r
+\r
 - Unlike symbolic links, Windows shortcuts maintain their references to their targets even when the target is moved or renamed. Windows domain clients may subscribe to a Windows service called Distributed Link Tracking to track the changes in files and folders to which they are interested. The service maintains the integrity of shortcuts, even when files and folders are moved across the network.[14] Additionally, in Windows 9x and later, Windows shell tries to find the target of a broken shortcut before proposing to delete it.""" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Shortcut_(computing)>,
         <http://dbpedia.org/resource/Symbolic_link#Shortcuts> .
@@ -16561,7 +16563,7 @@ Another difference are the capabilities of the mechanism:
     rdfs:subClassOf :DimensionReduction ;
     :d3fend-id "D3A-SVD" ;
     :definition "Singular Value Decomposition (SVD) is an algorithm that represents a matrix as a linear series of data and to find the set of factors that will best predict an outcome" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Singular value decomposition. [Link](https://en.wikipedia.org/wiki/Singular_value_decomposition)""" .
 
 :Skewness a owl:Class,
@@ -16570,7 +16572,7 @@ Wikipedia. (n.d.). Singular value decomposition. [Link](https://en.wikipedia.org
     rdfs:subClassOf :DistributionProperties ;
     :d3fend-id "D3A-SKE" ;
     :definition "Skewness is a measure of the asymmetry of the probability distribution of a real-valued random variable about its mean. The standardized moment of a probability distribution function." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
 
 :SlowSymbolicLink a owl:Class ;
@@ -16618,20 +16620,20 @@ Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
             owl:someValuesFrom :Software ] ;
     :d3fend-id "D3-SWI" ;
     :definition "Software inventorying identifies and records the software items in the organization's architecture." ;
-    :kb-article """## How it works
-Administrators collect information on software items in their architecture using a variety of administrative and management tools that query network nodes for information.  In limited cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to determine services responding on network nodes.
-
-## Considerations
-* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.
-* An adversary conducting network enumeration may engage in activities that parallel normal software inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools.
-
-## Examples
-
-Application-layer discovery:
-
-* Simple Network Management Protocol (SNMP) collects MIB information
-* Web-based Enterprise Management (WBEM) collects CIM information
-   * Windows Management Instrumentation (WMI)
+    :kb-article """## How it works\r
+Administrators collect information on software items in their architecture using a variety of administrative and management tools that query network nodes for information.  In limited cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through network enumeration methods to determine services responding on network nodes.\r
+\r
+## Considerations\r
+* Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.\r
+* An adversary conducting network enumeration may engage in activities that parallel normal software inventorying activities, but would require escalating to admin privileges for most of the operations requiting administrative tools.\r
+\r
+## Examples\r
+\r
+Application-layer discovery:\r
+\r
+* Simple Network Management Protocol (SNMP) collects MIB information\r
+* Web-based Enterprise Management (WBEM) collects CIM information\r
+   * Windows Management Instrumentation (WMI)\r
    * Windows Management Infrastructure (MI)""" ;
     :kb-reference :Reference-Web-BasedEnterpriseManagement,
         :Reference-Windows-Management-Infrastructure,
@@ -16716,10 +16718,10 @@ Application-layer discovery:
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-SM" ;
     :definition "Soundex is a phonetic algorithm for indexing names by sound, as pronounced in English." ;
-    :kb-article """## How it works
-The goal is for homophones to be encoded to the same representation so that they can be matched despite minor differences in spelling. The algorithm mainly encodes consonants; a vowel will not be encoded unless it is the first letter. Soundex is the most widely known of all phonetic algorithms (in part because it is a standard feature of popular database software. Improvements to Soundex are the basis for many modern phonetic algorithms.
-
-## References
+    :kb-article """## How it works\r
+The goal is for homophones to be encoded to the same representation so that they can be matched despite minor differences in spelling. The algorithm mainly encodes consonants; a vowel will not be encoded unless it is the first letter. Soundex is the most widely known of all phonetic algorithms (in part because it is a standard feature of popular database software. Improvements to Soundex are the basis for many modern phonetic algorithms.\r
+\r
+## References\r
 1. Soundex. (2023, April 19). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Soundex)""" .
 
 :SourceCode a owl:Class,
@@ -16770,7 +16772,7 @@ The goal is for homophones to be encoded to the same representation so that they
     rdfs:subClassOf :Graph-basedClustering ;
     :d3fend-id "D3A-SC" ;
     :definition "Spectral clustering is a technique that identifies communities of nodes in a graph based on the edges connecting them." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Towards Data Science. (n.d.). Spectral Clustering. [Link](https://towardsdatascience.com/spectral-clustering-aba2640c0d5b)""" .
 
 :SSHSession a owl:Class ;
@@ -16817,33 +16819,33 @@ Towards Data Science. (n.d.). Spectral Clustering. [Link](https://towardsdatasci
             owl:someValuesFrom :StackFrame ] ;
     :d3fend-id "D3-SFCV" ;
     :definition "Comparing a value stored in a stack frame with a known good value in order to prevent or detect a memory segment overwrite." ;
-    :kb-article """## How it works
-
-This defense must be applied at compile-time, or via a patch to the program binary.  Stack Frame Canary Verification inserts instructions at the prologue and epilogue of desired functions.  In the prologue, a canary value, typically with the same size as the register size, is stored in the system of record and on the stack.  Typically, the canary is loaded to where it has a memory address just below that of the saved instruction pointer and base pointer.  In the epilogue, the canary value stored on the stack and, is compared to the canary value in the system of record.  If the values are different, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.
-
-Stack Frame Canary Verification is commonly used to detect potential tampering of a saved register value on the stack before it has been restored.  Examples of registers with values commonly saved to the stack include the instruction pointer and the base pointer.
-
-The canary should be stored between where the start of a buffer overrun is likely, and the data to protect, in cases where the buffer size increases it will overwrite the data to be protected.
-
-On most processor architectures, including x86, x64, and ARM, a "push" operation to store data to the stack grows the stack towards a lower memory address.  As in these architectures, saved register values are stored to the stack at a point in time just before space is made for the local function variables, the saved register values have a higher address than that of the local function variables.  Values at increasing indexes of a buffer are written to increasing memory addresses; therefore, an overwrite in the local variable buffer could overwrite saved register values, and a stack canary between these two would be useful in detecting an overwrite.
-
-On some other processor architectures such as the B5000, the stack grows towards increasing memory addresses, and some architectures, such as System Z and RCA1802A, stack direction can be chosen.  If the stack grows towards increasing memory addresses, while this architecture inherently provides more protection against a saved register being overwritten, other data including local function variables might be overwritten.
-
-
-## Considerations
-
-There are several ways that the protection provided by a canary could be rendered ineffective.
-
-### Performing a malicious action before the canary is checked
-
-If the attacker alters the memory in such a way that it performs a malicious action before the epilogue is called, then this protection will not be effective.  This includes altering the logic of the program by altering the values of local variables stored on the function stack, or by causing an exception and exploiting the exception mechanism such as the SEH (Structured Exception Handling) mechanism on Windows.
-
-### Determining the canary value
-
-Determining the canary value is possible through reading memory either for the code used to check the canary, or from the stored canary value itself in a stack frame.
-
-### Changing the canary value
-
+    :kb-article """## How it works\r
+\r
+This defense must be applied at compile-time, or via a patch to the program binary.  Stack Frame Canary Verification inserts instructions at the prologue and epilogue of desired functions.  In the prologue, a canary value, typically with the same size as the register size, is stored in the system of record and on the stack.  Typically, the canary is loaded to where it has a memory address just below that of the saved instruction pointer and base pointer.  In the epilogue, the canary value stored on the stack and, is compared to the canary value in the system of record.  If the values are different, other techniques such as those in Process Eviction might be invoked, such as Process Termination to end the current process, or Executable Blacklisting to blacklist the potentially vulnerable or malfunctioning executable.\r
+\r
+Stack Frame Canary Verification is commonly used to detect potential tampering of a saved register value on the stack before it has been restored.  Examples of registers with values commonly saved to the stack include the instruction pointer and the base pointer.\r
+\r
+The canary should be stored between where the start of a buffer overrun is likely, and the data to protect, in cases where the buffer size increases it will overwrite the data to be protected.\r
+\r
+On most processor architectures, including x86, x64, and ARM, a "push" operation to store data to the stack grows the stack towards a lower memory address.  As in these architectures, saved register values are stored to the stack at a point in time just before space is made for the local function variables, the saved register values have a higher address than that of the local function variables.  Values at increasing indexes of a buffer are written to increasing memory addresses; therefore, an overwrite in the local variable buffer could overwrite saved register values, and a stack canary between these two would be useful in detecting an overwrite.\r
+\r
+On some other processor architectures such as the B5000, the stack grows towards increasing memory addresses, and some architectures, such as System Z and RCA1802A, stack direction can be chosen.  If the stack grows towards increasing memory addresses, while this architecture inherently provides more protection against a saved register being overwritten, other data including local function variables might be overwritten.\r
+\r
+\r
+## Considerations\r
+\r
+There are several ways that the protection provided by a canary could be rendered ineffective.\r
+\r
+### Performing a malicious action before the canary is checked\r
+\r
+If the attacker alters the memory in such a way that it performs a malicious action before the epilogue is called, then this protection will not be effective.  This includes altering the logic of the program by altering the values of local variables stored on the function stack, or by causing an exception and exploiting the exception mechanism such as the SEH (Structured Exception Handling) mechanism on Windows.\r
+\r
+### Determining the canary value\r
+\r
+Determining the canary value is possible through reading memory either for the code used to check the canary, or from the stored canary value itself in a stack frame.\r
+\r
+### Changing the canary value\r
+\r
 A vulnerability such as a write-what-where condition that allows one to write data after the canary in the stack, would allow control of the value of the saved instruction pointer without needing to know the canary value.""" ;
     :kb-reference :Reference-GS_BufferSecurityCheck_MicrosoftDocs,
         :Reference-StackSmashingProtection_StackGuard_RedHat .
@@ -16854,7 +16856,7 @@ A vulnerability such as a write-what-where condition that allows one to write da
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-STA" ;
     :definition "Stacking is a method of using the results and predictions from one layer of ML models as inputs to another layer of ML models. Stacking (sometimes called stacked generalization) involves training a model to combine the predictions of several other learning algorithms." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :StackSegment a owl:Class ;
@@ -16877,10 +16879,10 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
             owl:someValuesFrom :IntranetNetwork ] ;
     :d3fend-id "D3-SHN" ;
     :definition "An environment created for the purpose of attracting attackers and eliciting their behaviors that is not connected to any production enterprise systems." ;
-    :kb-article """## How it works
-A standalone honeynet does not directly interact with the real enterprise environment. It may be located near or in some portion of the enterprise address space, but it does not interact with enterprise resources.
-
-## Considerations
+    :kb-article """## How it works\r
+A standalone honeynet does not directly interact with the real enterprise environment. It may be located near or in some portion of the enterprise address space, but it does not interact with enterprise resources.\r
+\r
+## Considerations\r
 A standalone honeynet is a lower risk to deploy compared to connected or integrated honeynets due to its isolation from the enterprise network. However, this comes at cost in loss of fidelity and realism. Significant extra effort must be made in order to make the environment look realistic.""" ;
     :kb-reference :Reference-DynamicSelectionAndGenerationOfAVirtualCloneForDetonationOfSuspiciousContentWithinAHoneyNetwork_PaloAltoNetworksInc .
 
@@ -16890,7 +16892,7 @@ A standalone honeynet is a lower risk to deploy compared to connected or integra
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-SD" ;
     :definition "The standard deviation is a measure of the amount of variation or dispersion of a set of values." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Standard deviation. [Link](https://en.wikipedia.org/wiki/Standard_deviation)""" ;
     :synonym "SD" .
 
@@ -16922,7 +16924,7 @@ Wikipedia. (n.d.). Standard deviation. [Link](https://en.wikipedia.org/wiki/Stan
     rdfs:subClassOf :AnalyticTechnique ;
     :d3fend-id "D3A-SM" ;
     :definition "Building methods using the mathematical study of the likelihood and probability of events occurring based on known information and inferred by taking a limited number of samples." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Statistics.html)""" .
 
 :Step a owl:Class ;
@@ -16964,8 +16966,8 @@ Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Stat
         :StringPatternMatching ;
     :d3fend-id "D3A-SEM" ;
     :definition "String equivalence matching is a type of string pattern matching which is exact; that is, the strings being compared must have the same value for each character in their sequence and be of the same length." ;
-    :kb-article """## References
-1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)
+    :kb-article """## References\r
+1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)\r
 2. Types of Equality. (2007, March 2). In _WikiWikiWeb_. [Link](https://wiki.c2.com/?TypesOfEquality)""" .
 
 :StringFormatFunction a owl:Class ;
@@ -16979,12 +16981,12 @@ Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Stat
     rdfs:subClassOf :PatternMatching ;
     :d3fend-id "D3A-SPM" ;
     :definition "String pattern-matching algorithms, also known as string-matching algorithms, are an important class of string algorithms that try to find a place where one or several strings (also called patterns) are found within a larger string or text" ;
-    :kb-article """## How it works
-A basic example of string searching is when the pattern and the searched text are arrays of elements of an alphabet (finite set) Σ. Σ may be a human language alphabet, for example, the letters A through Z and other applications may use a binary alphabet (Σ = {0,1}) or a DNA alphabet (Σ = {A,C,G,T}) in bioinformatics.
-
-In practice, the method of feasible string-search algorithm may be affected by the string encoding. In particular, if a variable-width encoding is in use, then it may be slower to find the Nth character, perhaps requiring time proportional to N. This may significantly slow some search algorithms. One of many possible solutions is to search for the sequence of code units instead, but doing so may produce false matches unless the encoding is specifically designed to avoid it.
-
-## References
+    :kb-article """## How it works\r
+A basic example of string searching is when the pattern and the searched text are arrays of elements of an alphabet (finite set) Σ. Σ may be a human language alphabet, for example, the letters A through Z and other applications may use a binary alphabet (Σ = {0,1}) or a DNA alphabet (Σ = {A,C,G,T}) in bioinformatics.\r
+\r
+In practice, the method of feasible string-search algorithm may be affected by the string encoding. In particular, if a variable-width encoding is in use, then it may be slower to find the Nth character, perhaps requiring time proportional to N. This may significantly slow some search algorithms. One of many possible solutions is to search for the sequence of code units instead, but doing so may produce false matches unless the encoding is specifically designed to avoid it.\r
+\r
+## References\r
 1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""" .
 
 :StrongPasswordPolicy a :CredentialHardening,
@@ -17000,9 +17002,9 @@ In practice, the method of feasible string-search algorithm may be affected by t
             owl:someValuesFrom :UserAccount ] ;
     :d3fend-id "D3-SPP" ;
     :definition "Modifying system configuration to increase password strength." ;
-    :kb-article """## How it works
-Password strength guidelines include increasing password length, permitting passwords that contain ASCII or Unicode characters, and requiring systems to screen new passwords against lists of commonly used or compromised passwords.
-## Considerations
+    :kb-article """## How it works\r
+Password strength guidelines include increasing password length, permitting passwords that contain ASCII or Unicode characters, and requiring systems to screen new passwords against lists of commonly used or compromised passwords.\r
+## Considerations\r
 Extremely complex password requirements may lead users to saving passwords in text files or picking obvious passwords that meet the policy.""" ;
     :kb-reference :Reference-DigitalIdentityGuidelines800-63-3,
         :Reference-Testing_Metrics_for_Password_Creation_Policies_by_Attacking_Large_Sets_of_Revealed_Passwords .
@@ -17013,7 +17015,7 @@ Extremely complex password requirements may lead users to saving passwords in te
     rdfs:subClassOf :ImageSynthesisGAN ;
     :d3fend-id "D3A-STY" ;
     :definition "Successor to the ProGAN." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). StyleGAN. [Link](https://en.wikipedia.org/wiki/StyleGAN)""" ;
     :synonym "Style GAN" .
 
@@ -17031,7 +17033,7 @@ Wikipedia. (n.d.). StyleGAN. [Link](https://en.wikipedia.org/wiki/StyleGAN)""" ;
     rdfs:subClassOf :CorrelationClustering ;
     :d3fend-id "D3A-SC" ;
     :definition "Subspace clustering is an extension of traditional clustering that seeks to find clusters in different subspaces within a dataset." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Parsons, L., Haque, E., & Liu, H. (2004). Subspace Clustering for High Dimensional Data: A Review. [Link](https://www.kdd.org/exploration_files/parsons.pdf)""" .
 
 :SubstringMatching a owl:Class,
@@ -17040,7 +17042,7 @@ Parsons, L., Haque, E., & Liu, H. (2004). Subspace Clustering for High Dimension
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-SM" ;
     :definition "String-searching algorithms, sometimes called string-matching algorithms, are an important class of string algorithms that try to find a place where one or several strings (also called patterns) are found within a larger string or text." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm)""" .
 
 :Summarizing a owl:Class ;
@@ -17053,7 +17055,7 @@ Parsons, L., Haque, E., & Liu, H. (2004). Subspace Clustering for High Dimension
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-SL" ;
     :definition "Supervised learning establishes a relationship between the known input and output variables to conduct a predictive analysis." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Supervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Supervised_learning).""" .
 
 :SupportVectorMachineClassification a owl:Class,
@@ -17062,7 +17064,7 @@ Supervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Supervised
     rdfs:subClassOf :Classification ;
     :d3fend-id "D3A-SVMC" ;
     :definition "Support Vector Machine (SVM) is a robust classification and regression technique that maximizes the predictive accuracy of a model without overfitting the training data. SVM is particularly suited to analyzing data with very large numbers (for example, thousands) of predictor fields." ;
-    :kb-article """## References
+    :kb-article """## References\r
 About Support Vector Machine (SVM). IBM SPSS Modeler SaaS Documentation. [Link](https://www.ibm.com/docs/en/spss-modeler/saas?topic=models-about-svm&mhsrc=ibmsearch_a&mhq=support%20vector%20machine).""" .
 
 :SuspendProcess a owl:Class ;
@@ -17097,10 +17099,10 @@ About Support Vector Machine (SVM). IBM SPSS Modeler SaaS Documentation. [Link](
     rdfs:subClassOf :SymbolicLogic ;
     :d3fend-id "D3A-SR" ;
     :definition "Symbolic artificial intelligence is the term for the collection of all methods in artificial intelligence that are based on high-level symbolic (human-readable) representations of problems, logic, and search." ;
-    :kb-article """## How it works
-Symbolic artificial intelligence is used in tools such as logic programming, production rules, semantic nets and frames, and it developed applications such as knowledge-based systems (in particular, expert systems), symbolic mathematics, automated theorem provers, ontologies, the semantic web, and automated planning and scheduling systems. The Symbolic AI paradigm led to seminal ideas in search, symbolic programming languages, agents, multi-agent systems, the semantic web, and the strengths and limitations of formal knowledge and reasoning systems.
-
-## References
+    :kb-article """## How it works\r
+Symbolic artificial intelligence is used in tools such as logic programming, production rules, semantic nets and frames, and it developed applications such as knowledge-based systems (in particular, expert systems), symbolic mathematics, automated theorem provers, ontologies, the semantic web, and automated planning and scheduling systems. The Symbolic AI paradigm led to seminal ideas in search, symbolic programming languages, agents, multi-agent systems, the semantic web, and the strengths and limitations of formal knowledge and reasoning systems.\r
+\r
+## References\r
 1. Symbolic artifical intelligence. (2023, May 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Symbolic_artificial_intelligence)""" ;
     :synonym "Symbolic Artificial Intelligence" .
 
@@ -17123,11 +17125,11 @@ Symbolic artificial intelligence is used in tools such as logic programming, pro
     rdfs:subClassOf :AnalyticTechnique ;
     :d3fend-id "D3A-SL" ;
     :definition "Symbolic Logic, also known as formal logic, is a branch of mathematics that uses symbolic representations for logical expressions and relationships. It provides a systematic method for examining the structure of arguments and reasoning, focusing on the relationships between propositions rather than the content of those propositions." ;
-    :kb-article """## How it Works
-
-## References
-1. Symbolic Logic. (2023, June 6). In _Wolfram Mathworld_. [Link](https://mathworld.wolfram.com/SymbolicLogic.html)
-2. Hughes, G. and Schagrin, M. (2023, Apr 19). Formal Logic. _Encyclopedia Brittanica_. [Link](https://www.britannica.com/topic/formal-logic)
+    :kb-article """## How it Works\r
+\r
+## References\r
+1. Symbolic Logic. (2023, June 6). In _Wolfram Mathworld_. [Link](https://mathworld.wolfram.com/SymbolicLogic.html)\r
+2. Hughes, G. and Schagrin, M. (2023, Apr 19). Formal Logic. _Encyclopedia Brittanica_. [Link](https://www.britannica.com/topic/formal-logic)\r
 3. Carnap, R. (1953). Introduction to Symbolic Logic and Its Applications. Dover Publications. [Link](https://archive.org/details/rudolf-carnap-introduction-to-symbolic-logic-and-its-applications/page/3/mode/2up)""" .
 
 :SymmetricFeature-basedTransferLearning a owl:Class,
@@ -17136,7 +17138,7 @@ Symbolic artificial intelligence is used in tools such as logic programming, pro
     rdfs:subClassOf :HomogenousTransferLearning ;
     :d3fend-id "D3A-SFTL" ;
     :definition "Homogeneous symmetric transformation takes both the source feature space Xs and target feature space Xt and learns feature transformations as to project each onto a common subspace Xc for adaptation purposes. This derived subspace becomes a domain-invariant feature subspace to associate cross-domain data, and in effect, reduces marginal distribution differences." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learning. *Journal of Big Data, 4*(1), 29. [Link](https://doi.org/10.1186/s40537-017-0089-0).""" .
 
 :SymmetricKey a owl:Class ;
@@ -17172,37 +17174,37 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
             owl:someValuesFrom :SystemCall ] ;
     :d3fend-id "D3-SCA" ;
     :definition "Analyzing system calls to determine whether a process is exhibiting unauthorized behavior." ;
-    :kb-article """## How it works
-
-System calls are APIs between a user application and the operating system [1].
-
-By analyzing a process's use of these APIs, it is, in some cases, possible to ascertain whether a program is exhibiting unauthorized behavior, including trying to escalate its privileges.
-
-### Gathering System Calls
-A common method to capture system calls is to use kernel APIs to hook [2] a process's system call invocations.
-
-The Linux system call `ptrace` tracks other system calls in a process and allows their alteration; this is made use of by GDB.  `strace` utilizes `ptrace` and will print to stdout each system call invoked. Other applications record this data in local or remote databases.
-
-The log entry for each system call, which may reference additional information such as the date and time, and the process tree for the process which made the system call, is relayed, in real time or post-facto, to an analysis module which consults a catalog or model to determine whether the distribution matches a known-good or known-bad pattern.
-
-
-### Analysis
-
-System calls are analyzed with a variety of methods. Some analytics look for specific sequences of instructions, others may apply statistical methods to identify abnormal behavior. Sequences of instructions can be abstracted into conceptually higher order user activities, for example:
-
-* An attacker executes many system calls in a short period of time, with several sequences which could be used to escalate privileges.
-* Getting the contents from a URL, writing to a new file, and then executing the same file.
-* A ransomware program which either uses a loop or creates many threads to: read a specified file, encrypt its contents, create an output file with a similar name to the original file, and delete the unencrypted original.
-
-## Considerations
-
-* Duplicative or extraneous system calls may be added to malware to defeat analytics.
-* Malware could replace API hooking instructions to allow system calls to be made without being monitored.
-* A model built from a training set of system calls and related data may not be updated fast enough to detect new threats.
-
-
-[1] [Syscalls](http://man7.org/linux/man-pages/man2/syscalls.2.html)
-
+    :kb-article """## How it works\r
+\r
+System calls are APIs between a user application and the operating system [1].\r
+\r
+By analyzing a process's use of these APIs, it is, in some cases, possible to ascertain whether a program is exhibiting unauthorized behavior, including trying to escalate its privileges.\r
+\r
+### Gathering System Calls\r
+A common method to capture system calls is to use kernel APIs to hook [2] a process's system call invocations.\r
+\r
+The Linux system call `ptrace` tracks other system calls in a process and allows their alteration; this is made use of by GDB.  `strace` utilizes `ptrace` and will print to stdout each system call invoked. Other applications record this data in local or remote databases.\r
+\r
+The log entry for each system call, which may reference additional information such as the date and time, and the process tree for the process which made the system call, is relayed, in real time or post-facto, to an analysis module which consults a catalog or model to determine whether the distribution matches a known-good or known-bad pattern.\r
+\r
+\r
+### Analysis\r
+\r
+System calls are analyzed with a variety of methods. Some analytics look for specific sequences of instructions, others may apply statistical methods to identify abnormal behavior. Sequences of instructions can be abstracted into conceptually higher order user activities, for example:\r
+\r
+* An attacker executes many system calls in a short period of time, with several sequences which could be used to escalate privileges.\r
+* Getting the contents from a URL, writing to a new file, and then executing the same file.\r
+* A ransomware program which either uses a loop or creates many threads to: read a specified file, encrypt its contents, create an output file with a similar name to the original file, and delete the unencrypted original.\r
+\r
+## Considerations\r
+\r
+* Duplicative or extraneous system calls may be added to malware to defeat analytics.\r
+* Malware could replace API hooking instructions to allow system calls to be made without being monitored.\r
+* A model built from a training set of system calls and related data may not be updated fast enough to detect new threats.\r
+\r
+\r
+[1] [Syscalls](http://man7.org/linux/man-pages/man2/syscalls.2.html)\r
+\r
 [2] [Hooking](http://dbpedia.org/resource/Hooking)""" ;
     :kb-reference :Reference-CAR-2020-05-001%3AMiniDumpOfLSASS_MITRE,
         :Reference-CAR-2021-05-011%3ACreateRemoteThreadIntoLSASS_MITRE,
@@ -17281,7 +17283,7 @@ System calls are analyzed with a variety of methods. Some analytics look for spe
             owl:someValuesFrom :OperatingSystemProcess ] ;
     :d3fend-id "D3-SDM" ;
     :definition "Tracking changes to the state or configuration of critical system level processes." ;
-    :kb-article """## How it works
+    :kb-article """## How it works\r
 Attackers may manipulate system settings or services to disable system logging or monitoring of security tools and events. Firewall and antivirus services are popular targets for attackers. Disabling system logs will also allow an attacker's actions to go unnoticed. Analysis of logs, registries, and process monitoring help defenders locate signs of tampering. Two possible approaches are to monitor hardened system services or to monitor registry updates for modifications to security settings.""" ;
     :kb-reference :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
         :Reference-MethodUsingKernelModeAssistanceForTheDetectionAndRemovalOfThreatsWhichAreActivelyPreventingDetectionAndRemovalFromARunningSystem_SymantecCorporation,
@@ -17305,15 +17307,15 @@ Attackers may manipulate system settings or services to disable system logging o
             owl:someValuesFrom :SystemDependency ] ;
     :d3fend-id "D3-SYSDM" ;
     :definition "System dependency mapping identifies and models the dependencies of system components on each other to carry out their function." ;
-    :kb-article """## How it works
-The organization collects and models architectural information about the software, hardware, and products and maps the dependencies between systems, including each system's internal components and dependencies.
-
-## Considerations
-* Data exchanges identified in the network mapping efforts usually indicate such dependencies, but may not be part of the intended design.
-* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.
-* System depedency mapping can identify internal dependencies of standard and pre-built systems that should be incorporated into a complete system dependency model.
-* System dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.
-* System dependencies should identify the integral components of a given named system and their structure to form a system.
+    :kb-article """## How it works\r
+The organization collects and models architectural information about the software, hardware, and products and maps the dependencies between systems, including each system's internal components and dependencies.\r
+\r
+## Considerations\r
+* Data exchanges identified in the network mapping efforts usually indicate such dependencies, but may not be part of the intended design.\r
+* Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.\r
+* System depedency mapping can identify internal dependencies of standard and pre-built systems that should be incorporated into a complete system dependency model.\r
+* System dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.\r
+* System dependencies should identify the integral components of a given named system and their structure to form a system.\r
 * System dependencies with a given system may be fixed by a particular product's configuration, and leveraging external knowledge bases about dependencies available (e.g., from package managers) is essential.""" ;
     :kb-reference :Reference-CatiaUAFPlugin,
         :Reference-SoftwareVulnerabilityGraphDatabase,
@@ -17330,13 +17332,13 @@ The organization collects and models architectural information about the softwar
             owl:someValuesFrom :OperatingSystemFile ] ;
     :d3fend-id "D3-SFA" ;
     :definition "Monitoring system files such as authentication databases, configuration files, system logs, and system executables for modification or tampering." ;
-    :kb-article """## How it works
-This technique ensures the integrity of system owned file resources. System files can impact the behavior below the user level.
-
-
-## Considerations
-* Need to manage the size of log file analysis.
-* False positives are a concern with this technique and filtering will need to be given additional thought.
+    :kb-article """## How it works\r
+This technique ensures the integrity of system owned file resources. System files can impact the behavior below the user level.\r
+\r
+\r
+## Considerations\r
+* Need to manage the size of log file analysis.\r
+* False positives are a concern with this technique and filtering will need to be given additional thought.\r
 * A baseline or snapshot of file checksums should be established for future comparison.""" ;
     :kb-reference :Reference-AccessPermissionModification_MITRE,
         :Reference-AutorunDifferences_MITRE,
@@ -17369,13 +17371,13 @@ This technique ensures the integrity of system owned file resources. System file
             owl:someValuesFrom :SystemFirmware ] ;
     :d3fend-id "D3-SFV" ;
     :definition "Cryptographically verifying installed system firmware integrity." ;
-    :kb-article """## How it works
-Cryptographic hash values are computed for system firmware. The hash values are compared against precomputed firmware hash values to determine if the firmware has been tampered with.
-
-When system firmware verification fails a set of predefined responses is typically invoked. The responses may direct the system to disable some devices or operations.
-
-## Considerations
-* Requires the use of system provided security modules
+    :kb-article """## How it works\r
+Cryptographic hash values are computed for system firmware. The hash values are compared against precomputed firmware hash values to determine if the firmware has been tampered with.\r
+\r
+When system firmware verification fails a set of predefined responses is typically invoked. The responses may direct the system to disable some devices or operations.\r
+\r
+## Considerations\r
+* Requires the use of system provided security modules\r
 * Secure hash values will need to be computed for firmware""" ;
     :kb-reference :Reference-FirmwareVerificationEclypsium,
         :Reference-PlatformFirmwareResiliencyGuidelines_NIST .
@@ -22653,7 +22655,7 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :Projection-basedClustering ;
     :d3fend-id "D3A-TSC" ;
     :definition "T-distributed Stochastic Neighbor Embedding (t-SNE) is a statistical method for visualizing high-dimensional data by giving each datapoint a location in a two or three-dimensional map." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). T-distributed stochastic neighbor embedding. [Link](https://en.wikipedia.org/wiki/T-distributed_stochastic_neighbor_embedding)""" .
 
 :TabletComputer a owl:Class ;
@@ -22699,7 +22701,7 @@ Wikipedia. (n.d.). T-distributed stochastic neighbor embedding. [Link](https://e
     rdfs:comment "Temporal difference (TD) learning refers to a class of model-free reinforcement learning methods which learn by bootstrapping from the current estimate of the value function." ;
     :d3fend-id "D3A-TDL" ;
     :definition "Temporal difference (TD) learning refers to a class of model-free reinforcement learning methods which learn by bootstrapping from the current estimate of the value function. These methods sample from the environment, like Monte Carlo methods, and perform updates based on current estimates, like dynamic programming methods" ;
-    :kb-article """## References
+    :kb-article """## References\r
 Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Temporal_difference_learning).""" .
 
 :TemporalLogic a owl:Class,
@@ -22708,7 +22710,7 @@ Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/T
     rdfs:subClassOf :ModalLogic ;
     :d3fend-id "D3A-TL" ;
     :definition "Temporal logic addresses the semantics of tense; i.e., qualifying expressions of when." ;
-    :kb-article """## References
+    :kb-article """## References\r
 1. Temporal logic. (2023, June 4). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Modal_logic#Temporal_logic)""" .
 
 :TerminateProcess a owl:Class ;
@@ -22780,7 +22782,7 @@ Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/T
     rdfs:subClassOf :StatisticalMethod ;
     :d3fend-id "D3A-TSA" ;
     :definition "Time series analysis comprises methods for analyzing time series data in order to extract meaningful statistics and other characteristics of the data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Time series. [Link](https://en.wikipedia.org/wiki/Time_series)""" ;
     :todo "Lots of time series leaves couls be put here." .
 
@@ -22791,18 +22793,18 @@ Wikipedia. (n.d.). Time series. [Link](https://en.wikipedia.org/wiki/Time_series
     rdfs:subClassOf :PlatformHardening ;
     :d3fend-id "D3-TBI" ;
     :definition "Assuring the integrity of a platform by demonstrating that the boot process starts from a trusted combination of hardware and software and continues until the operating system has fully booted and applications are running.  Sometimes called Static Root of Trust Measurement (STRM)." ;
-    :kb-article """## How it works
-During the boot process, the BIOS boot block (which with this defense enabled, is the Core Root of Trust for Measurement) measures boot components (firmware, ROM). The TPM hashes those measurements and stores the hashes in Platform Configuration Registers (PCRs).  Upon a subsequent boot, these hashes are provided to a verifier which compares the stored measurements to the new boot measurements. Integrity of the boot components is assured if they match.
-
-Attestation of the secure boot occurs when a verifying entity requests a Quote which is a concatenation of the requested PCR values, hashed and signed by the TPM's unique RSA key.  The TPM signature is trusted because the private key is stored securely in hardware and never leaves the TPM.
-
-## Considerations
-
-* The TPM does not perform the follow-on actions of acting on the PCR value information, it just provides the PCR stored information.
-* The current version of TPM is 2.0.; most existing implementations use TPM 1.2.
-
-## Citations
-[1] [TPM 2.0 Library](https://trustedcomputinggroup.org/resource/tpm-library-specification/)
+    :kb-article """## How it works\r
+During the boot process, the BIOS boot block (which with this defense enabled, is the Core Root of Trust for Measurement) measures boot components (firmware, ROM). The TPM hashes those measurements and stores the hashes in Platform Configuration Registers (PCRs).  Upon a subsequent boot, these hashes are provided to a verifier which compares the stored measurements to the new boot measurements. Integrity of the boot components is assured if they match.\r
+\r
+Attestation of the secure boot occurs when a verifying entity requests a Quote which is a concatenation of the requested PCR values, hashed and signed by the TPM's unique RSA key.  The TPM signature is trusted because the private key is stored securely in hardware and never leaves the TPM.\r
+\r
+## Considerations\r
+\r
+* The TPM does not perform the follow-on actions of acting on the PCR value information, it just provides the PCR stored information.\r
+* The current version of TPM is 2.0.; most existing implementations use TPM 1.2.\r
+\r
+## Citations\r
+[1] [TPM 2.0 Library](https://trustedcomputinggroup.org/resource/tpm-library-specification/)\r
 [2] [TCG Trusted Attestation Protocol (TAP) Use Cases for TPM Families 1.2 and 2.0 and DICE](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TNC_TAP_Use_Cases_v1r0p35_published.pdf)""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-TPM2.0LibrarySpecification_TrustedComputingGroup,Incorporated>,
         :Reference-TCGTrustedAttestationProtocolUseCasesForTPMFamilies1.2And2.0AndDICE,
@@ -22832,22 +22834,22 @@ Attestation of the secure boot occurs when a verifying entity requests a Quote w
     rdfs:subClassOf :MessageHardening ;
     :d3fend-id "D3-TAAN" ;
     :definition "Validating that server components of a messaging infrastructure are authorized to send a particular message." ;
-    :kb-article """## How it works
-Transfer Agent Authentication can be accomplished in different ways for depending on the protocol. In Email,  Sender Policy Framework (SPF), Domain Key Identified Email (DKIM) or Domain-based Message Authentication Reporting and Conformance (DMARC) to validate sender domain ownership.
-
-### SPF
-SPF protocol allows for mail domain owners to specify the mail servers they use when sending email. SPF requires the use of SPF records published in the Domain Name System (DNS). The records record the authorized IPs for email senders. SPF uses the return-path address for domain IP identification. Email that is forwarded may cause the return-path validation problems.
-### DKIM
-DKIM also uses a record entry in DNS for authentication but does not rely on the simple return-path for validation. A signature header is added to email and encryption is used for security. This adds an additional layer of complexity and requires that DKIM servers be configured identified cryptographic signatures. The additional complexity results in a validation process that can survive complex routing of emails.
-
-### DMARC
-DMARC is an email policy and authentication protocol that seeks to ensure that the "From" field of emails is not spoofed. DMARC makes use of both SPF records and DKIM published key validation. DMARC also has a decision policy framework, contained in a DMARC record, for handling of rejected email. The DMARC framework also updates DMARC domains with authentication statues for allowed senders of that domain.
-
-## Considerations
-- Additional work is required to ensure that all SPF, DKIM and DMARC records are current and up to date.
-- Maintenance of DKIM signing keys is needed.
-- Using SPF without DKIM and DMARC verifies the Return-Path domain however does not prevent spoofing of the displayed From: address.
-- Parts of an email that are not signed or verified by email authentication methods, such as the message body or the header To: and Subject: fields, can be altered or modified.
+    :kb-article """## How it works\r
+Transfer Agent Authentication can be accomplished in different ways for depending on the protocol. In Email,  Sender Policy Framework (SPF), Domain Key Identified Email (DKIM) or Domain-based Message Authentication Reporting and Conformance (DMARC) to validate sender domain ownership.\r
+\r
+### SPF\r
+SPF protocol allows for mail domain owners to specify the mail servers they use when sending email. SPF requires the use of SPF records published in the Domain Name System (DNS). The records record the authorized IPs for email senders. SPF uses the return-path address for domain IP identification. Email that is forwarded may cause the return-path validation problems.\r
+### DKIM\r
+DKIM also uses a record entry in DNS for authentication but does not rely on the simple return-path for validation. A signature header is added to email and encryption is used for security. This adds an additional layer of complexity and requires that DKIM servers be configured identified cryptographic signatures. The additional complexity results in a validation process that can survive complex routing of emails.\r
+\r
+### DMARC\r
+DMARC is an email policy and authentication protocol that seeks to ensure that the "From" field of emails is not spoofed. DMARC makes use of both SPF records and DKIM published key validation. DMARC also has a decision policy framework, contained in a DMARC record, for handling of rejected email. The DMARC framework also updates DMARC domains with authentication statues for allowed senders of that domain.\r
+\r
+## Considerations\r
+- Additional work is required to ensure that all SPF, DKIM and DMARC records are current and up to date.\r
+- Maintenance of DKIM signing keys is needed.\r
+- Using SPF without DKIM and DMARC verifies the Return-Path domain however does not prevent spoofing of the displayed From: address.\r
+- Parts of an email that are not signed or verified by email authentication methods, such as the message body or the header To: and Subject: fields, can be altered or modified.\r
 - Email message authentication does not replace the need to do email content analysis since executables, attachments, or links or other parts of the email beyond the sender domain are not verified.""" ;
     :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
         :Reference-RFC7208-SenderPolicyFramework-SPF-ForAuthorizingUseOfDomainsInEmail-IETF,
@@ -22859,7 +22861,7 @@ DMARC is an email policy and authentication protocol that seeks to ensure that t
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-TL" ;
     :definition "Transfer learning (TL) is a research problem in machine learning (ML) that focuses on storing knowledge gained while solving one problem and applying it to a different but related problem." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Transfer learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Transfer_learning).""" ;
     rdfs:seeAlso "https://arxiv.org/abs/1808.01974",
         "https://arxiv.org/abs/1911.02685",
@@ -22871,7 +22873,7 @@ Transfer learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Transfer_lea
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-TBL" ;
     :definition "A transformer is a deep learning model. It is distinguished by its adoption of self-attention, differentially weighting the significance of each part of the input (which includes the recursive output) data." ;
-    :kb-article """## References
+    :kb-article """## References\r
 "Transformer (machine learning model)." Wikipedia. [Link](https://en.wikipedia.org/wiki/Transformer_(machine_learning_model)).""" .
 
 :Transformer-XL a owl:Class,
@@ -22880,7 +22882,7 @@ Transfer learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Transfer_lea
     rdfs:subClassOf :Transformer-basedLearning ;
     :d3fend-id "D3A-TX" ;
     :definition "Transformer-XL is a transformer architecture that introduces the notion of recurrence to the deep self-attention network. Instead of computing the hidden states from scratch for each new segment, Transformer-XL reuses the hidden states obtained in previous segments." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Transformer-XL. (n.d.). Papers with Code. [Link](https://paperswithcode.com/method/transformer-xl)""" .
 
 :TranslationLookasideBuffer a owl:Class ;
@@ -22899,7 +22901,7 @@ Transformer-XL. (n.d.). Papers with Code. [Link](https://paperswithcode.com/meth
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-TM" ;
     :definition "The arithmetic mean of data values after a certain number or proportion of the highest and lowest data values have been discarded." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" ;
     :synonym "Truncated mean" .
 
@@ -22917,7 +22919,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-US" ;
     :definition "Makes the utility inversely proportional to the uncertainty of the model with respect to the sample and will work with any  model provided it can assess its uncertainty of a predection." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :UnitTestExecutionTool a owl:Class ;
@@ -22944,7 +22946,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :MachineLearning ;
     :d3fend-id "D3A-UL" ;
     :definition "Unsupervised learning creates relationships with unlabeled data without the input of a human or other outside actor. Uses only input data. " ;
-    :kb-abstract """## References
+    :kb-abstract """## References\r
 Unsupervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Unsupervised_learning).""" .
 
 :UnsupervisedPreprocessing a owl:Class,
@@ -22953,7 +22955,7 @@ Unsupervised learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Unsuperv
     rdfs:subClassOf :Semi-SupervisedLearning ;
     :d3fend-id "D3A-UP" ;
     :definition "When performing unsupervised learning, the machine is presented with unlabeled data. (Unlabeled data has no target.) Unsupervised learning algorithms seek to discover intrinsic patterns that underlie the data, such as a clustering parameter or a redundant parameter (dimension) that can be reduced." ;
-    :kb-article """## References
+    :kb-article """## References\r
 SAS Institute Inc. (n.d.). Decision Trees. In SAS® Visual Data Mining and Machine Learning.[Link](https://documentation.sas.com/doc/en/vdmmlcdc/8.4/vdmmladvug/n1e4spzcnv1f0fn1vsxhbzgdp1bb.htm).""" .
 
 :URL a owl:Class ;
@@ -22977,32 +22979,32 @@ SAS Institute Inc. (n.d.). Decision Trees. In SAS® Visual Data Mining and Machi
             owl:someValuesFrom :URL ] ;
     :d3fend-id "D3-UA" ;
     :definition "Determining if a URL is benign or malicious by analyzing the URL or its components." ;
-    :kb-article """## How it works
-
-URLs may contain components, for example:
-
- * scheme
- * userinfo
- * host name
- * port
- * path
- * query
- * fragment
-
-These components are used as features in analysis algorithms.
-
-Contextual information about a URL such as where it is embedded (ex. emails, files, network protocols), header, path, location, and origin information, as well as information about the content returned from the URL request, may be incorporated into an analytic for URL analysis. For example, if a URL indicates a .pdf file but an executable is actually returned, the combination of these two pieces of information indicates suspicious activity.
-
-Additional techniques include:
-
-* Extracting features of a URL such as domain name length, ratio of consecutive consonants, percentage of digits in a domain, and number of vowels. Values for each feature are combined to develop a score for the URL.
-* Determining the probability of a character occurring in the URL given the preceding two characters. For example, for google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an o" occurring after a 'g' and "o, and so forth. A dictionary or a list of known good domains is used to determine probability. Probabilities are multiplied to develop a score for the URL.
-
-URL analysis may trigger follow-on analytics such as **File Analysis**
-
-## Considerations
-
-* Volume of URLs being analyzed, combined with the speed at which they are analyzed
+    :kb-article """## How it works\r
+\r
+URLs may contain components, for example:\r
+\r
+ * scheme\r
+ * userinfo\r
+ * host name\r
+ * port\r
+ * path\r
+ * query\r
+ * fragment\r
+\r
+These components are used as features in analysis algorithms.\r
+\r
+Contextual information about a URL such as where it is embedded (ex. emails, files, network protocols), header, path, location, and origin information, as well as information about the content returned from the URL request, may be incorporated into an analytic for URL analysis. For example, if a URL indicates a .pdf file but an executable is actually returned, the combination of these two pieces of information indicates suspicious activity.\r
+\r
+Additional techniques include:\r
+\r
+* Extracting features of a URL such as domain name length, ratio of consecutive consonants, percentage of digits in a domain, and number of vowels. Values for each feature are combined to develop a score for the URL.\r
+* Determining the probability of a character occurring in the URL given the preceding two characters. For example, for google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an o" occurring after a 'g' and "o, and so forth. A dictionary or a list of known good domains is used to determine probability. Probabilities are multiplied to develop a score for the URL.\r
+\r
+URL analysis may trigger follow-on analytics such as **File Analysis**\r
+\r
+## Considerations\r
+\r
+* Volume of URLs being analyzed, combined with the speed at which they are analyzed\r
 * Fidelity of analysis technique at detecting brand new URLs versus analyzing URLs of established domains""" ;
     :kb-reference :Reference-MethodAndApparatusForDetectingMaliciousWebsites_EndgameInc,
         :Reference-MethodAndSystemForDetectingRestrictedContentAssociatedWithRetrievedContent_SophosLtd .
@@ -23104,10 +23106,10 @@ URL analysis may trigger follow-on analytics such as **File Analysis**
     :d3fend-id "D3-UBA" ;
     :definition "User behavior analytics (\"UBA\") as defined by Gartner, is a cybersecurity process about detection of insider threats, targeted attacks, and financial fraud. UBA solutions look at patterns of human behavior, and then apply algorithms and statistical analysis to detect meaningful anomalies from those patterns-anomalies that indicate potential threats.' Instead of tracking devices or security events, UBA tracks a system's users. Big data platforms are increasing UBA functionality by allowing them to analyze petabytes worth of data to detect insider threats and advanced persistent threats." ;
     :enables :Detect ;
-    :kb-article """## Technique Overview
-
-Some techniques monitor patterns of human behavior and then apply algorithms and to identify patterns such as repeated login attempts from a single IP address or large file downloads, or abnormal accesses.
-
+    :kb-article """## Technique Overview\r
+\r
+Some techniques monitor patterns of human behavior and then apply algorithms and to identify patterns such as repeated login attempts from a single IP address or large file downloads, or abnormal accesses.\r
+\r
 Other techniques may have explicit or rigid definitions of "bad behavior" which are then matched against instances in a computer network environment.""" ;
     :synonym "Credential Monitoring",
         "UBA" .
@@ -23122,11 +23124,11 @@ Other techniques may have explicit or rigid definitions of "bad behavior" which 
             owl:someValuesFrom :ResourceAccess ] ;
     :d3fend-id "D3-UDTA" ;
     :definition "Analyzing the amount of data transferred by a user." ;
-    :kb-article """## How it works
-Unusual data transfer activity may indicate unauthorized activity. Data transfers can be analyzed by collecting network traffic or application logs.
-
-## Considerations
-* There is a potential for false positives from anomalies that are not associated with unauthorized activity.
+    :kb-article """## How it works\r
+Unusual data transfer activity may indicate unauthorized activity. Data transfers can be analyzed by collecting network traffic or application logs.\r
+\r
+## Considerations\r
+* There is a potential for false positives from anomalies that are not associated with unauthorized activity.\r
 * Attackers that move low and slow may not differentiate their data transfer behavior enough for an alert to trigger.""" ;
     :kb-reference :Reference-SystemAndMethodThereofForIdentifyingAndRespondingToSecurityIncidentsBasedOnPreemptiveForensics_PaloAltoNetworksInc,
         :Reference-SystemForImplementingThreatDetectionUsingThreatAndRiskAssessmentOfAsset-actorInteractions_VECTRANETWORKSInc ;
@@ -23142,15 +23144,15 @@ Unusual data transfer activity may indicate unauthorized activity. Data transfer
             owl:someValuesFrom :NetworkTraffic ] ;
     :d3fend-id "D3-UGLPA" ;
     :definition "Monitoring geolocation data of user logon attempts and comparing it to a baseline user behavior profile to identify anomalies in logon location." ;
-    :kb-article """## How it works
-Geolocation data for each user logon attempt is collected and used to create a baseline user behavior profile. Current geolocation logon data is then compared against the user behavior profile. Logon activity that deviates from normal patterns and can help in identifying situations that may be indicative of a remote attacker using stolen credentials. For example:
-
-* logons from locations that are different from where a user usually logs in
-* logons from a location in which an enterprise has no users located
-* logon that is not physically possible given the elapsed time since a logon from another location.
-
-## Considerations
-* Potential for false positives from logon anomalies that are not associated with malicious activity.
+    :kb-article """## How it works\r
+Geolocation data for each user logon attempt is collected and used to create a baseline user behavior profile. Current geolocation logon data is then compared against the user behavior profile. Logon activity that deviates from normal patterns and can help in identifying situations that may be indicative of a remote attacker using stolen credentials. For example:\r
+\r
+* logons from locations that are different from where a user usually logs in\r
+* logons from a location in which an enterprise has no users located\r
+* logon that is not physically possible given the elapsed time since a logon from another location.\r
+\r
+## Considerations\r
+* Potential for false positives from logon anomalies that are not associated with malicious activity.\r
 * Attackers may not differentiate their logon behavior enough to trigger an alert.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC .
@@ -23271,7 +23273,7 @@ Geolocation data for each user logon attempt is collected and used to create a b
     rdfs:subClassOf :DescriptiveStatistics ;
     :d3fend-id "D3A-VAR" ;
     :definition "Dispersion (also called variability, scatter, or spread) is the extent to which a distribution is stretched or squeezed. A measure of statistical dispersion is a nonnegative real number that is zero if all the data are the same and increases as the data become more diverse." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Statistical dispersion. [Link](https://en.wikipedia.org/wiki/Statistical_dispersion)""" ;
     :todo "Name should maybe be thought about as dispersion may be more descriptive or intuitive. Perhaps dispersion measure" .
 
@@ -23281,7 +23283,7 @@ Wikipedia. (n.d.). Statistical dispersion. [Link](https://en.wikipedia.org/wiki/
     rdfs:subClassOf :Variability ;
     :d3fend-id "D3A-VAR" ;
     :definition "Variance is a measure of dispersion, meaning it is a measure of how far a set of numbers is spread out from their average value." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Wikipedia. (n.d.). Variance. [Link](https://en.wikipedia.org/wiki/Variance)""" .
 
 :VarianceReduction a owl:Class,
@@ -23290,7 +23292,7 @@ Wikipedia. (n.d.). Variance. [Link](https://en.wikipedia.org/wiki/Variance)""" .
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-VR" ;
     :definition "Leverages a well-known result from statistical learning and decomposes the model error into a data noise term, a model bias term and a model variance term. As the noise term only depends on the data and the bias is induced by the choice of model, any reduction in the error can only come from the variance term." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
 :Vendor a owl:Class ;
@@ -23357,15 +23359,15 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :EnsembleLearning ;
     :d3fend-id "D3A-VOT" ;
     :definition "Voting is another form of ensembling." ;
-    :kb-article """## References
+    :kb-article """## References\r
 Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_learning).""" .
 
 :VPNServer a owl:Class ;
     rdfs:label "VPN Server" ;
     rdfs:subClassOf :Server ;
     rdfs:isDefinedBy <https://www.techopedia.com/definition/30750/vpn-server> ;
-    :definition """A VPN server is a type of server that enables hosting and delivery of VPN services.
-
+    :definition """A VPN server is a type of server that enables hosting and delivery of VPN services.\r
+\r
 It is a combination of VPN hardware and software technologies that provides VPN clients with connectivity to a secure and/or private network, or rather, the VPN.""" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Virtual_private_network> .
 
@@ -23450,11 +23452,11 @@ It is a combination of VPN hardware and software technologies that provides VPN 
             owl:someValuesFrom :WebResourceAccess ] ;
     :d3fend-id "D3-WSAA" ;
     :definition "Monitoring changes in user web session behavior by comparing current web session activity to a baseline behavior profile or a catalog of predetermined malicious behavior." ;
-    :kb-article """## How it works
-User web session data is collected over a period of time to create a user behavior profile. Data collected includes clicks made on a website, average time between clicks, filling out web forms, order in which pages are viewed, and downloading files. Current user web session behavior is then compared against the use behavior profile to identify anomalies and a likelihood that the current user web session is malicious. Current user web session behavior can also be compared to predetermined known malicious behavior profiles that are developed through analysis of malware in run time at a threat research facility.
-
-## Considerations
-* Potential for false positives from anomalies that are not associated with malicious activity.
+    :kb-article """## How it works\r
+User web session data is collected over a period of time to create a user behavior profile. Data collected includes clicks made on a website, average time between clicks, filling out web forms, order in which pages are viewed, and downloading files. Current user web session behavior is then compared against the use behavior profile to identify anomalies and a likelihood that the current user web session is malicious. Current user web session behavior can also be compared to predetermined known malicious behavior profiles that are developed through analysis of malware in run time at a threat research facility.\r
+\r
+## Considerations\r
+* Potential for false positives from anomalies that are not associated with malicious activity.\r
 * Attackers may not differentiate their web session activity enough to trigger an alert.""" ;
     :kb-reference :Reference-HostIntrusionPreventionSystemUsingSoftwareAndUserBehaviorAnalysis_SophosLtd,
         :Reference-SystemAndMethodForDetectionOfAChangeInBehaviorInTheUseOfAWebsiteThroughVectorVelocityAnalysis_SilverTailSystems,
@@ -23467,10 +23469,10 @@ User web session data is collected over a period of time to create a user behavi
     rdfs:subClassOf :CentralTendency ;
     :d3fend-id "D3A-WM" ;
     :definition "A mean that incorporates weighting to certain data elements." ;
-    :kb-article """## Considerations
-The arithmetic mean, geometric mean, and harmonic mean can all be weighted.
-
-## References
+    :kb-article """## Considerations\r
+The arithmetic mean, geometric mean, and harmonic mean can all be weighted.\r
+\r
+## References\r
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" .
 
 :WideAreaNetwork a owl:Class ;
@@ -23785,7 +23787,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         owl:NamedIndividual ;
     rdfs:label "Reference - Continuous authentication by analysis of keyboard typing characteristics - Bradford Univ., UK" ;
     :has-link "https://ieeexplore.ieee.org/document/491588?reload=true&arnumber=491588"^^xsd:anyURI ;
-    :kb-abstract """This paper describes a simple, software based keyboard monitoring system for the IBM PC for the continuous analysis of the typing characteristics of the user for the purpose of continuous authentication. By exploiting the electrical characteristics of the PC keyboard interface together with modifications to the internal system timer, very accurate measurements can be made of keystroke interval and duration, including measurements of rollover. Rollover patterns, particularly when typing common diphthongs, can be highly characteristic of individual users and provide quite an accurate indication of the users identity.
+    :kb-abstract """This paper describes a simple, software based keyboard monitoring system for the IBM PC for the continuous analysis of the typing characteristics of the user for the purpose of continuous authentication. By exploiting the electrical characteristics of the PC keyboard interface together with modifications to the internal system timer, very accurate measurements can be made of keystroke interval and duration, including measurements of rollover. Rollover patterns, particularly when typing common diphthongs, can be highly characteristic of individual users and provide quite an accurate indication of the users identity.\r
 Published in: European Convention on Security and Detection, 1995.""" ;
     :kb-author "S.J. Shepherd" ;
     :kb-mitre-analysis " " ;
@@ -23798,8 +23800,8 @@ Published in: European Convention on Security and Detection, 1995.""" ;
         :PatentReference ;
     rdfs:label "Reference - Decoy and deceptive data object technology - Cymmetria, Inc." ;
     :has-link "https://patents.google.com/patent/US20170134423A1"^^xsd:anyURI ;
-    :kb-abstract """A computer implemented method of detecting unauthorized access to a protected network by monitoring a dynamically updated deception environment, comprising launching, on one or more decoy endpoints, one or more decoy operating system (OS) managing one or more of a plurality of deception applications mapping a plurality of applications executed in a protected network, updating dynamically a usage indication for a plurality of deception data objects deployed in the protected network to emulate usage of the plurality of deception data objects for accessing the deception application(s) wherein the plurality of deception data objects are configured to trigger an interaction with the deception application(s) when used, detecting usage of data contained in the deception data object(s) by monitoring the interaction and identifying one or more potential unauthorized operations based on analysis of the detection.
-
+    :kb-abstract """A computer implemented method of detecting unauthorized access to a protected network by monitoring a dynamically updated deception environment, comprising launching, on one or more decoy endpoints, one or more decoy operating system (OS) managing one or more of a plurality of deception applications mapping a plurality of applications executed in a protected network, updating dynamically a usage indication for a plurality of deception data objects deployed in the protected network to emulate usage of the plurality of deception data objects for accessing the deception application(s) wherein the plurality of deception data objects are configured to trigger an interaction with the deception application(s) when used, detecting usage of data contained in the deception data object(s) by monitoring the interaction and identifying one or more potential unauthorized operations based on analysis of the detection.\r
+\r
 In order to convince the potential attacker that the deception environment is the real (valid) processing environment and/or part thereof, the campaign manager may construct the false identity according to the public information of the certain user that may typically be available to the potential attacker. By exposing the real (public) information of the certain user to the potential attacker, the false identity may seem consistent and legitimate to the potential attacker. For example, the campaign manager may create a false account, for example, a Facebook account of the certain user that includes the same public information that is publicly available to other Facebook users from the real (genuine) Facebook account of the certain user. The fake company account may include information specific to the role and/or job title of certain user within the company, for example, a programmer, an accountant, an IT person and/or the like.""" ;
     :kb-author "Dean Sysman, Gadi Evron, Imri Goldberg, Itamar Sher, Shmuel Ur" ;
     :kb-mitre-analysis " " ;
@@ -23839,23 +23841,23 @@ In order to convince the potential attacker that the deception environment is th
     :kb-reference-of :DecoyFile ;
     :kb-reference-title "Supply chain cyber-deception" ;
     :todo "MITRE Analysis was not found",
-        """Section header did not match either 'MITRE Analysis' or 'Document Abstract' (possible typo?):  Additional Information from Document
-The deception data objects 214 may include, for example, one or more of the following:
-
-Cookies and/or history log entries. In case the access client 255 is browsing, for example, to a supplier-facing website (an exemplary resource 222) of the protected network 235, typically, a cookie is added to the to be added to the access client 255 and the website's address added to the history log of the access client 255. In such a case, the campaign manager 216 may, for example, open an iframe to a deception website (an exemplary deception resource 210 corresponding to the exemplary resource 222) in which different cookie(s) and/or different history log entry(s) may be added to the access client 255. The different cookie(s) and/or history log entry(s) may point to the deception environment, for example, a false website, an identical system that is not used by real users (internal and/or external), a proxy that redirects to a real system within the protected network 235, a different service, such as, for example, email, SharePoint and/or the like.
-
-JavaScripts, pop-up windows, pop-under windows and/or any other browsing technique used to browse to another website(s). In case the access client 255 is browsing, for example, to the supplier-facing website, the campaign manager 216 may, for example, initiate a JavaScript, a pop-up window and/or a pop-under window to direct the access client 255 to the deception website in which the different cookie(s) and/or the different history log entry(s) may be added to the access client 255. The JavaScripts, the pop-up windows and/or the pop-under windows may maintain a visibility similarity with the supplier-facing website such that they do not significantly alter the browsing experience of the external user(s) using the access client(s) 255.
-
-Credential object. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install additional fake credentials on the external endpoint 251 from which the RDP is initiated.
-
-Configuration file. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install a fake remote access configuration file on the external endpoint 251 from which the RDP is initiated.
-
-Deception file, password and/or the like. In case the external user(s) use the VNC serving as the access client 255, the campaign manager 216 may install additional fake credentials, files, password(s) and/or the like on the external endpoint 251from which the VNC is initiated.
-
-In some cases, the access client 255 may be offered with automatic password completion when accessing a resource, a service and/or an application at the remote network. In such case(s), the campaign manager 216 may manipulate the automatic password completion and provide fake password(s) to the access client 255 accessing the protected network 235.
-
-Archive files, for example, zip, rar, tar.gz and/or the like. In case the external user(s) using the access client 255 performs a backup and/or retrieves data from the protected network 235, the campaign manager 216 may insert one or more deception data objects 214 into one or more of the created archive files.
-
+        """Section header did not match either 'MITRE Analysis' or 'Document Abstract' (possible typo?):  Additional Information from Document\r
+The deception data objects 214 may include, for example, one or more of the following:\r
+\r
+Cookies and/or history log entries. In case the access client 255 is browsing, for example, to a supplier-facing website (an exemplary resource 222) of the protected network 235, typically, a cookie is added to the to be added to the access client 255 and the website's address added to the history log of the access client 255. In such a case, the campaign manager 216 may, for example, open an iframe to a deception website (an exemplary deception resource 210 corresponding to the exemplary resource 222) in which different cookie(s) and/or different history log entry(s) may be added to the access client 255. The different cookie(s) and/or history log entry(s) may point to the deception environment, for example, a false website, an identical system that is not used by real users (internal and/or external), a proxy that redirects to a real system within the protected network 235, a different service, such as, for example, email, SharePoint and/or the like.\r
+\r
+JavaScripts, pop-up windows, pop-under windows and/or any other browsing technique used to browse to another website(s). In case the access client 255 is browsing, for example, to the supplier-facing website, the campaign manager 216 may, for example, initiate a JavaScript, a pop-up window and/or a pop-under window to direct the access client 255 to the deception website in which the different cookie(s) and/or the different history log entry(s) may be added to the access client 255. The JavaScripts, the pop-up windows and/or the pop-under windows may maintain a visibility similarity with the supplier-facing website such that they do not significantly alter the browsing experience of the external user(s) using the access client(s) 255.\r
+\r
+Credential object. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install additional fake credentials on the external endpoint 251 from which the RDP is initiated.\r
+\r
+Configuration file. In case the external user(s) use the RDP serving as the access client 255, upon login of the RDP, the campaign manager 216 may install a fake remote access configuration file on the external endpoint 251 from which the RDP is initiated.\r
+\r
+Deception file, password and/or the like. In case the external user(s) use the VNC serving as the access client 255, the campaign manager 216 may install additional fake credentials, files, password(s) and/or the like on the external endpoint 251from which the VNC is initiated.\r
+\r
+In some cases, the access client 255 may be offered with automatic password completion when accessing a resource, a service and/or an application at the remote network. In such case(s), the campaign manager 216 may manipulate the automatic password completion and provide fake password(s) to the access client 255 accessing the protected network 235.\r
+\r
+Archive files, for example, zip, rar, tar.gz and/or the like. In case the external user(s) using the access client 255 performs a backup and/or retrieves data from the protected network 235, the campaign manager 216 may insert one or more deception data objects 214 into one or more of the created archive files.\r
+\r
 An account. The campaign manager 216 may provide the external user(s) one or more false accounts for accessing one of more of the deception applications 212. The campaign manager 216 may configure each of the deception data objects 214 to interact with one or more of the deception resources 210. The campaign manager 216 may configure the deception data objects 214 and define their relationships according to a deception policy and/or methods defined for the deception campaign. Naturally, the campaign manager 216 creates and configures the deception data objects 214 according to the resource(s) 222 accessed by the access client(s) 255. The campaign manager 216 also defines the interaction with the deception resource(s) 210 which map the accessed resource(s) 222. For example, the deceptive data object 214 of type "browser cookie" may be created to interact with one or more deception resources 210, for example, a fake website and/or a deception application launched using, for example, a deception resource 210 of type "browser" created during the deception campaign. As another example, a deceptive data object 214 of type "compressed file" may be created for external user(s) using a certain one of the external endpoints 251. As another example, a deceptive data object 214 of type "credentials" may be created for users accessing a certain application 212 of type "ERP". Optionally, the campaign manager 216 periodically and/or dynamically updates one or more of the deception data objects 214 to impersonate an active real (valid) processing environment such that the deception data objects 214 appear to be valid data objects to lead the potential attacker to believe the emulated deception environment is a real one.""" .
 
 <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc> a owl:NamedIndividual,
@@ -23864,17 +23866,17 @@ An account. The campaign manager 216 may provide the external user(s) one or mor
     :has-link "https://patents.google.com/patent/US20190034641A1"^^xsd:anyURI ;
     :kb-abstract "The present disclosure is directed to a system, method, and computer program for detecting and assessing security risks in an enterprise's computer network. A behavior model is built for a user in the network based on the user's interactions with the network, wherein a behavior model for a user indicates client device(s), server(s), and resources used by the user. The user's behavior during a period of time is compared to the user's behavior model. A risk assessment is calculated for the period of time based at least in part on the comparison between the user's behavior and the user's behavior model, wherein any one of certain anomalies between the user's behavior and the user's behavior model increase the risk assessment." ;
     :kb-author "Sylvain Gil; Domingo Mihovilovic; Nir Polak; Magnus Stensmo; Sing Yip" ;
-    :kb-mitre-analysis """This patent describes calculating a risk score to detect anomalies in user activity based on comparing a user's current session with a user behavior model. The user behavior model is comprised of a number of histograms including:
-
-* client devices from which the user logs in
-* servers accessed
-* data accessed
-* applications accessed
-* session duration
-* logon time of day
-* logon day of week
-* geo - location of logon origination
-
+    :kb-mitre-analysis """This patent describes calculating a risk score to detect anomalies in user activity based on comparing a user's current session with a user behavior model. The user behavior model is comprised of a number of histograms including:\r
+\r
+* client devices from which the user logs in\r
+* servers accessed\r
+* data accessed\r
+* applications accessed\r
+* session duration\r
+* logon time of day\r
+* logon day of week\r
+* geo - location of logon origination\r
+\r
 The system has an initial training period with x number of days (e. g., 90 days) in which session data is recorded in behavior models before behavior analysis begins.The histograms are then used to determine anomalies between current session activity and a user's behavior model. Values for a histogram category are along one axis and the number of times the value is received for the category is along another axis. If a data point value associated with the current user session is over an anomaly threshold, an alert is generated.""" ;
     :kb-organization "Exabeam Inc" ;
     :kb-reference-of :AuthenticationEventThresholding,
@@ -23888,8 +23890,8 @@ The system has an initial training period with x number of days (e. g., 90 days)
         :SpecificationReference ;
     rdfs:label "Reference - TPM 2.0 Library Specification - Trusted Computing Group, Incorporated" ;
     :has-link "https://trustedcomputinggroup.org/resource/tpm-library-specification/"^^xsd:anyURI ;
-    :kb-abstract """This specification defines the Trusted Platform Module (TPM) a device that enables trust in computing
-platforms in general. It is broken into parts to make the role of each part clear. All parts are required in
+    :kb-abstract """This specification defines the Trusted Platform Module (TPM) a device that enables trust in computing\r
+platforms in general. It is broken into parts to make the role of each part clear. All parts are required in\r
 order to constitute a complete standard. For a complete definition of all requirements necessary to build a TPM, the designer will need to use the appropriate platform-specific specification to understand all of the requirements for a TPM in a specific application or make appropriate choices as an implementer. Those wishing to create a TPM need to be aware that this specification does not provide a complete picture of the options and commands necessary to implement a TPM. To implement a TPM the designer needs to refer to the relevant platform-specific specification to understand the options and settings required for a TPM in a specific type of platform or make appropriate choices as an implementer.""" ;
     :kb-author "Trusted Computing Group" ;
     :kb-mitre-analysis " " ;
@@ -24370,7 +24372,7 @@ order to constitute a complete standard. For a complete definition of all requir
         :PatentReference ;
     rdfs:label "Reference - Advanced device matching system" ;
     :has-link "https://patents.google.com/patent/US10892951B2/"^^xsd:anyURI ;
-    :kb-abstract """Disclosed is a device management system for discovery and management of components added to computer systems and sub-systems. The device management system provides for recognizing a newly added component, and determining if the newly added component is already a part of the system inventory. The newly added component is matched with a component currently on the system, based on at least one matching attribute. A point total is calculated for each match level and a final match score is provided. The match score is compared with an aggressiveness level to determine if a match does indeed exist.
+    :kb-abstract """Disclosed is a device management system for discovery and management of components added to computer systems and sub-systems. The device management system provides for recognizing a newly added component, and determining if the newly added component is already a part of the system inventory. The newly added component is matched with a component currently on the system, based on at least one matching attribute. A point total is calculated for each match level and a final match score is provided. The match score is compared with an aggressiveness level to determine if a match does indeed exist.\r
 """ ;
     :kb-author "Rajneesh Jalan, Joseph M. Schmitt, and Marco Simoes" ;
     :kb-organization "Device42 Inc" ;
@@ -24381,8 +24383,8 @@ order to constitute a complete standard. For a complete definition of all requir
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2015-07-001: All Logins Since Last Boot - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2015-07-001/"^^xsd:anyURI ;
-    :kb-abstract """Once a credential dumper like mimikatz runs, every user logged on since boot is potentially compromised, because the credentials were accessed via the memory of lsass.exe. When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.
-
+    :kb-abstract """Once a credential dumper like mimikatz runs, every user logged on since boot is potentially compromised, because the credentials were accessed via the memory of lsass.exe. When such an event occurs, this analytic will give the forensic context to identify compromised users. Those users could potentially be used in later events for additional logons.\r
+\r
 The time field indicates the first and last time a system reported a user logged into a given system. This means that activity could be intermittent between the times given and should not be considered a duration.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -24411,14 +24413,14 @@ The time field indicates the first and last time a system reported a user logged
     :has-link "https://patents.google.com/patent/US20160226901A1"^^xsd:anyURI ;
     :kb-abstract "The invention provides a system and method for automatic creation of adaptive behavioral profiles for observables associated with resource states and events in a computer network (IT) infrastructure of an enterprise and for detecting anomalies that represent potential malicious activity and threats as deviations from normal behavior. Separate profiles may be created for each behavioral indicator, as well as for each time series of measurements, and aggregated to create an overall behavioral profile. An anomaly probability is determined from the behavioral profile and used to evaluate the data values of observables. Outlier data values which deviate from normal behavior by more than a predetermined probability threshold are identified for risk analysis as possible threats while inliers within the range of normal behavior are used to update the behavioral profile. Behavioral profiles are created for behavioral indicators based upon observables measured over predetermined time periods using algorithms employing statistical analysis approaches that work for any type of data distribution, and profiles are adapted over time using data aging to more closely represent current behavior. Algorithm parameters for creating profiles are based on the type of data, i.e., its metadata." ;
     :kb-author "Igor A. Baikalov; Tanuj Gulati; Sachin Nayyar; Anjaneya Shenoy; Ganpatrao H. Patwardhan" ;
-    :kb-mitre-analysis """The patent describes a technique for detecting anomalous activity within an organization's IT infrastructure to identify threats. Behavioral profiles can be grouped by peer groups that identify functionally similar groups of actors (users or resources) based on their attributes and pre-defined grouping rules. For example, users can be grouped by their job title, organizational hierarchy, or location and can be observed for similarities in access patterns, based on granted access entitlements or actual logged resource access.
-
-Behavioral profiles are created from measurements of events over a time period for example:
-
-* Transaction counts
-* Concurrent users per hour
-* Daily volume of data
-
+    :kb-mitre-analysis """The patent describes a technique for detecting anomalous activity within an organization's IT infrastructure to identify threats. Behavioral profiles can be grouped by peer groups that identify functionally similar groups of actors (users or resources) based on their attributes and pre-defined grouping rules. For example, users can be grouped by their job title, organizational hierarchy, or location and can be observed for similarities in access patterns, based on granted access entitlements or actual logged resource access.\r
+\r
+Behavioral profiles are created from measurements of events over a time period for example:\r
+\r
+* Transaction counts\r
+* Concurrent users per hour\r
+* Daily volume of data\r
+\r
 Outlier data values which deviate from behavioral profile by more than a predetermined probability threshold are identified for risk analysis as possible threats.""" ;
     :kb-organization "Securonix Inc" ;
     :kb-reference-of :JobFunctionAccessPatternAnalysis ;
@@ -24508,8 +24510,8 @@ Outlier data values which deviate from behavioral profile by more than a predete
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-01-002: Autorun Differences - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-01-002/"^^xsd:anyURI ;
-    :kb-abstract """The Sysinternals tool Autoruns checks the registry and file system for known identify persistence mechanisms. It will output any tools identified, including built-in or added-on Microsoft functionality and third party software. Many of these locations are known by adversaries and used to obtain Persistence. Running Autoruns periodically in an environment makes it possible to collect and monitor its output for differences, which may include the removal or addition of persistent tools. Depending on the persistence mechanism and location, legitimate software may be more likely to make changes than an adversary tool. Thus, this analytic may result in significant noise in a highly dynamic environment. While Autoruns is a convenient method to scan for programs using persistence mechanisms its scanning nature does not conform well to streaming based analytics. This analytic could be replaced with one that draws from sensors that collect registry and file information if streaming analytics are desired.
-
+    :kb-abstract """The Sysinternals tool Autoruns checks the registry and file system for known identify persistence mechanisms. It will output any tools identified, including built-in or added-on Microsoft functionality and third party software. Many of these locations are known by adversaries and used to obtain Persistence. Running Autoruns periodically in an environment makes it possible to collect and monitor its output for differences, which may include the removal or addition of persistent tools. Depending on the persistence mechanism and location, legitimate software may be more likely to make changes than an adversary tool. Thus, this analytic may result in significant noise in a highly dynamic environment. While Autoruns is a convenient method to scan for programs using persistence mechanisms its scanning nature does not conform well to streaming based analytics. This analytic could be replaced with one that draws from sensors that collect registry and file information if streaming analytics are desired.\r
+\r
 Utilizes the Sysinternals autoruns tool (ignoring validated Microsoft entries). Primarily not a detection analytic by itself but through analysis of results by an analyst can be used for such. Building another analytic on top of this one identifying unusual entries would likely be a beneficial alternative.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -24522,8 +24524,8 @@ Utilizes the Sysinternals autoruns tool (ignoring validated Microsoft entries). 
         :PatentReference ;
     rdfs:label "Reference - Biometric Challenge-Response Authentication - Accenture" ;
     :has-link "https://www.patentguru.com/US2021110015A1"^^xsd:anyURI ;
-    :kb-abstract """Secret biometric responses to authentication challenges for MFA.
-
+    :kb-abstract """Secret biometric responses to authentication challenges for MFA.\r
+\r
 Methods, systems, and apparatus, including computer programs encoded on computer storage media, for authenticating users based on a sequence of biometric authentication challenges. In one aspect, a process includes receiving a first image of the face of the user and processing the first image according to a first authentication process to determine whether the face of the user shown in the first image matches the face of an authorized user. A second authentication process including a sequence of biometric authentication challenges is identified. The sequence includes at least one facial expression challenge. The user is authenticated in response to determining that the first authentication process is satisfied based on the face of the user shown in the first image matching the face of the authorized user and the second authentication process is satisfied based on the user providing a valid biometric response to each biometric authentication challenge.""" ;
     :kb-author "Ben McCarty, Ellie Daw" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -24547,10 +24549,10 @@ Methods, systems, and apparatus, including computer programs encoded on computer
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-05-001: RPC Activity - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-05-001/"^^xsd:anyURI ;
-    :kb-abstract """Microsoft Windows uses its implementation of Distributed Computing Environment/Remote Procedure Call (DCE/RPC), which it calls Microsoft RPC, to call certain APIs remotely.
-
-A Remote Procedure Call is initiated by communicating to the RPC Endpoint Mapper, which exists as the Windows service RpcEptMapper and listens on the port 135/tcp. The endpoint mapper resolves a requested endpoint/interface and responds to the client with the port that the service is listening on. Since the RPC endpoints are assigned ports when the services start, these ports are dynamically assigned from 49152 to 65535. The connection to the endpoint mapper then terminates and the client program can communicate directly with the requested service.
-
+    :kb-abstract """Microsoft Windows uses its implementation of Distributed Computing Environment/Remote Procedure Call (DCE/RPC), which it calls Microsoft RPC, to call certain APIs remotely.\r
+\r
+A Remote Procedure Call is initiated by communicating to the RPC Endpoint Mapper, which exists as the Windows service RpcEptMapper and listens on the port 135/tcp. The endpoint mapper resolves a requested endpoint/interface and responds to the client with the port that the service is listening on. Since the RPC endpoints are assigned ports when the services start, these ports are dynamically assigned from 49152 to 65535. The connection to the endpoint mapper then terminates and the client program can communicate directly with the requested service.\r
+\r
 RPC is a legitimate functionality of Windows that allows remote interaction with a variety of services. For a Windows environment to be properly configured, several programs use RPC to communicate legitimately with servers. The background and benign RPC activity may be enormous, but must be learned, especially peer-to-peer RPC between workstations, which is often indicative of Lateral Movement.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24562,8 +24564,8 @@ RPC is a legitimate functionality of Windows that allows remote interaction with
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-007: Remote Windows Management Instrumentation (WMI) over RPC - MITRE" ;
     :has-link ""^^xsd:anyURI ;
-    :kb-abstract """As described in ATT&CK, an adversary can use Windows Management Instrumentation (WMI) to view or manipulate objects on a remote host. It can be used to remotely edit configuration, start services, query files, and anything that can be done with a WMI class. When remote WMI requests are over RPC (CAR-2014-05-001), it connects to a DCOM interface within the RPC group netsvcs. To detect this activity, a sensor is needed at the network level that can decode RPC traffic or on the host where the communication can be detected more natively, such as Event Tracing for Windows. Using wireshark/tshark decoders, the WMI interfaces can be extracted so that WMI activity over RPC can be detected.
-
+    :kb-abstract """As described in ATT&CK, an adversary can use Windows Management Instrumentation (WMI) to view or manipulate objects on a remote host. It can be used to remotely edit configuration, start services, query files, and anything that can be done with a WMI class. When remote WMI requests are over RPC (CAR-2014-05-001), it connects to a DCOM interface within the RPC group netsvcs. To detect this activity, a sensor is needed at the network level that can decode RPC traffic or on the host where the communication can be detected more natively, such as Event Tracing for Windows. Using wireshark/tshark decoders, the WMI interfaces can be extracted so that WMI activity over RPC can be detected.\r
+\r
 Although the description details how to detect remote WMI precisely, a decent estimate has been to look for the string RPCSS within the initial RPC connection on 135/tcp. It returns a superset of this activity, and will trigger on all DCOM-related services running within RPC, which is likely to also be activity that should be detected between hosts. More about RPCSS at : rpcss_dcom_interfaces.html""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -24578,8 +24580,8 @@ Although the description details how to detect remote WMI precisely, a decent es
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2015-04-001: Remotely Scheduled Tasks via AT - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2015-04-001/"^^xsd:anyURI ;
-    :kb-abstract """When AT.exe is used to remotely schedule tasks, Windows uses named pipes over SMB to communicate with the API on the remote machine. After authentication over SMB, the Named Pipe “ATSVC” is opened, over which the JobAdd function is called. On the remote host, the job files are created by the Task Scheduler and follow the convention C:\\Windows\\System32\\AT<job\\_id>. Unlike CAR-2013-05-004, this analytic specifically focuses on uses of AT that can be detected between hosts, indicating remotely gained execution.
-
+    :kb-abstract """When AT.exe is used to remotely schedule tasks, Windows uses named pipes over SMB to communicate with the API on the remote machine. After authentication over SMB, the Named Pipe “ATSVC” is opened, over which the JobAdd function is called. On the remote host, the job files are created by the Task Scheduler and follow the convention C:\\Windows\\System32\\AT<job\\_id>. Unlike CAR-2013-05-004, this analytic specifically focuses on uses of AT that can be detected between hosts, indicating remotely gained execution.\r
+\r
 This pipe activity could be discovered with a network decoder, such as that in wireshark, that can inspect SMB traffic to identify the use of pipes. It could also be detected by looking for raw packet capture streams or from a custom sensor on the host that hooks the appropriate API functions. If no network or API level of visibility is possible, this traffic may inferred by looking at SMB connections over 445/tcp followed by the creation of files matching the pattern C:\\Windows\\System32\\AT\\<job_id\\>.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24598,8 +24600,8 @@ This pipe activity could be discovered with a network decoder, such as that in w
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2020-04-001: Shadow Copy Deletion - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2020-04-001/"^^xsd:anyURI ;
-    :kb-abstract """The Windows Volume Shadow Copy Service is a built-in OS feature that can be used to create backup copies of files and volumes.
-
+    :kb-abstract """The Windows Volume Shadow Copy Service is a built-in OS feature that can be used to create backup copies of files and volumes.\r
+\r
 Adversaries may delete these shadow copies, typically through the usage of system utilities such as vssadmin.exe or wmic.exe, in order prevent file and data recovery. This technique is commonly employed for this purpose by ransomware.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24611,10 +24613,10 @@ Adversaries may delete these shadow copies, typically through the usage of syste
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2020-05-001: MiniDump of LSASS - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2020-05-001/"^^xsd:anyURI ;
-    :kb-abstract """This analytic detects the minidump variant of credential dumping where a process opens lsass.exe in order to extract credentials using the Win32 API call MiniDumpWriteDump. Tools like SafetyKatz, SafetyDump, and Outflank-Dumpert default to this variant and may be detected by this analytic, though keep in mind that not all options for using those tools will result in this specific behavior.
-
-The analytic is based on a Sigma analytic contributed by Samir Bousseaden and written up in a blog on MENASEC. It looks for a call trace that includes either dbghelp.dll or dbgcore.dll, which export the relevant functions/permissions to perform the dump. It also detects using the Windows Task Manager (taskmgr.exe) to dump lsass, which is described in CAR-2019-08-001. In this iteration of the Sigma analytic, the GrantedAccess filter isn’t included because it didn’t seem to filter out any false positives and introduces the potential for evasion.
-
+    :kb-abstract """This analytic detects the minidump variant of credential dumping where a process opens lsass.exe in order to extract credentials using the Win32 API call MiniDumpWriteDump. Tools like SafetyKatz, SafetyDump, and Outflank-Dumpert default to this variant and may be detected by this analytic, though keep in mind that not all options for using those tools will result in this specific behavior.\r
+\r
+The analytic is based on a Sigma analytic contributed by Samir Bousseaden and written up in a blog on MENASEC. It looks for a call trace that includes either dbghelp.dll or dbgcore.dll, which export the relevant functions/permissions to perform the dump. It also detects using the Windows Task Manager (taskmgr.exe) to dump lsass, which is described in CAR-2019-08-001. In this iteration of the Sigma analytic, the GrantedAccess filter isn’t included because it didn’t seem to filter out any false positives and introduces the potential for evasion.\r
+\r
 This analytic was tested both in a lab and in a production environment with a very low false-positive rate. werfault.exe and tasklist.exe, both standard Windows processes, showed up multiple times as false positives.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24627,10 +24629,10 @@ This analytic was tested both in a lab and in a production environment with a ve
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2020-05-003: Rare LolBAS Command Lines - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2020-05-003/"^^xsd:anyURI ;
-    :kb-abstract """LoLBAS are binaries and scripts that are built in to Windows, frequently are signed by Microsoft, and may be used by an attacker. Some LoLBAS are used very rarely and it might be possible to alert every time they’re used (this would depend on your environment), but many others are very common and can’t be simply alerted on.
-
-This analytic takes all instances of LoLBAS execution and then looks for instances of command lines that are not normal in the environment. This can detect attackers (which will tend to need the binaries for something different than normal usage) but will also tend to have false positives.
-
+    :kb-abstract """LoLBAS are binaries and scripts that are built in to Windows, frequently are signed by Microsoft, and may be used by an attacker. Some LoLBAS are used very rarely and it might be possible to alert every time they’re used (this would depend on your environment), but many others are very common and can’t be simply alerted on.\r
+\r
+This analytic takes all instances of LoLBAS execution and then looks for instances of command lines that are not normal in the environment. This can detect attackers (which will tend to need the binaries for something different than normal usage) but will also tend to have false positives.\r
+\r
 The analytic needs to be tuned. The 1.5 in the query is the number of standard deviations away to look. It can be tuned up to filter out more noise and tuned down to get more results. This means it is probably best as a hunting analytic when you have analysts looking at the screen and able to tune the analytic up and down, because the threshold may not be stable for very long.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -24928,12 +24930,12 @@ The analytic needs to be tuned. The 1.5 in the query is the number of standard d
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2021-04-001: Common Windows Process Masquerading - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2021-04-001/"^^xsd:anyURI ;
-    :kb-abstract """Masquerading (T1036) is defined by ATT&CK as follows:
-
-“Masquerading occurs when the name or location of an object, legitimate or malicious, is manipulated or abused for the sake of evading defenses and observation. This may include manipulating file metadata, tricking users into misidentifying the file type, and giving legitimate task or service names.”
-
-Malware authors often use this technique to hide malicious executables behind legitimate Windows executable names (e.g. lsass.exe, svchost.exe, etc).
-
+    :kb-abstract """Masquerading (T1036) is defined by ATT&CK as follows:\r
+\r
+“Masquerading occurs when the name or location of an object, legitimate or malicious, is manipulated or abused for the sake of evading defenses and observation. This may include manipulating file metadata, tricking users into misidentifying the file type, and giving legitimate task or service names.”\r
+\r
+Malware authors often use this technique to hide malicious executables behind legitimate Windows executable names (e.g. lsass.exe, svchost.exe, etc).\r
+\r
 There are several sub-techniques, but this analytic focuses on Match Legitimate Name or Location only.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -25087,8 +25089,8 @@ There are several sub-techniques, but this analytic focuses on Match Legitimate 
         :TechniqueReference ;
     rdfs:label "Reference - Certificate Transparency" ;
     :has-link "https://www.certificate-transparency.org/"^^xsd:anyURI ;
-    :kb-abstract """Google's Certificate Transparency project fixes several structural flaws in the SSL certificate system, which is the main cryptographic system that underlies all HTTPS connections.
-
+    :kb-abstract """Google's Certificate Transparency project fixes several structural flaws in the SSL certificate system, which is the main cryptographic system that underlies all HTTPS connections.\r
+\r
 These flaws weaken the reliability and effectiveness of encrypted Internet connections and can compromise critical TLS/SSL mechanisms, including domain validation, end-to-end encryption, and the chains of trust set up by certificate authorities.""" ;
     :kb-author "Google" ;
     :kb-organization "Google" ;
@@ -25120,8 +25122,8 @@ These flaws weaken the reliability and effectiveness of encrypted Internet conne
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-07-005: Command Line Usage of Archiving Software - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-07-005/"^^xsd:anyURI ;
-    :kb-abstract """Before exfiltrating data that an adversary has collected, it is very likely that a compressed archive will be created, so that transfer times are minimized and fewer files are transmitted. There is variety between the tools used to compress data, but the command line usage and context of archiving tools, such as ZIP, RAR, and 7ZIP, should be monitored.
-
+    :kb-abstract """Before exfiltrating data that an adversary has collected, it is very likely that a compressed archive will be created, so that transfer times are minimized and fewer files are transmitted. There is variety between the tools used to compress data, but the command line usage and context of archiving tools, such as ZIP, RAR, and 7ZIP, should be monitored.\r
+\r
 In addition to looking for RAR or 7z program names, command line usage of 7Zip or RAR can be detected with the flag usage of "\\* a \\*". This is helpful, as adversaries may change program names.""" ;
     :kb-author "" ;
     :kb-mitre-analysis " " ;
@@ -25189,8 +25191,8 @@ In addition to looking for RAR or 7z program names, command line usage of 7Zip o
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2016-03-002: Create Remote Process via WMIC - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2016-03-002/"^^xsd:anyURI ;
-    :kb-abstract """Adversaries may use Windows Management Instrumentation (WMI) to move laterally, by launching executables remotely.The analytic CAR-2014-12-001 describes how to detect these processes with network traffic monitoring and process monitoring on the target host. However, if the command line utility wmic.exe is used on the source host, then it can additionally be detected on an analytic. The command line on the source host is constructed into something like wmic.exe /node:"\\<hostname\\>" process call create "\\<command line\\>". It is possible to also connect via IP address, in which case the string "\\<hostname\\>" would instead look like IP Address.
-
+    :kb-abstract """Adversaries may use Windows Management Instrumentation (WMI) to move laterally, by launching executables remotely.The analytic CAR-2014-12-001 describes how to detect these processes with network traffic monitoring and process monitoring on the target host. However, if the command line utility wmic.exe is used on the source host, then it can additionally be detected on an analytic. The command line on the source host is constructed into something like wmic.exe /node:"\\<hostname\\>" process call create "\\<command line\\>". It is possible to also connect via IP address, in which case the string "\\<hostname\\>" would instead look like IP Address.\r
+\r
 Although this analytic was created after CAR-2014-12-001, it is a much simpler (although more limited) approach. Processes can be created remotely via WMI in a few other ways, such as more direct API access or the built-in utility PowerShell.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25217,8 +25219,8 @@ Although this analytic was created after CAR-2014-12-001, it is a much simpler (
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2019-08-001: Credential Dumping via Windows Task Manager - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2019-08-001/"^^xsd:anyURI ;
-    :kb-abstract """The Windows Task Manager may be used to dump the memory space of lsass.exe to disk for processing with a credential access tool such as Mimikatz. This is performed by launching Task Manager as a privileged user, selecting lsass.exe, and clicking "Create dump file". This saves a dump file to disk with a deterministic name that includes the name of the process being dumped.
-
+    :kb-abstract """The Windows Task Manager may be used to dump the memory space of lsass.exe to disk for processing with a credential access tool such as Mimikatz. This is performed by launching Task Manager as a privileged user, selecting lsass.exe, and clicking "Create dump file". This saves a dump file to disk with a deterministic name that includes the name of the process being dumped.\r
+\r
 This requires filesystem data to determine whether files have been created.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25270,8 +25272,8 @@ This requires filesystem data to determine whether files have been created.""" ;
         :UserManualReference ;
     rdfs:label "Reference - Mitigate threats by using Windows 10 security features: Data Execution Prevention - Microsoft" ;
     :has-link "https://docs.microsoft.com/en-us/windows/security/threat-protection/overview-of-threat-mitigations-in-windows-10#data-execution-prevention"^^xsd:anyURI ;
-    :kb-abstract """Malware depends on its ability to insert a malicious payload into memory with the hope that it will be executed later. Wouldn't it be great if you could prevent malware from running if it wrote to an area that has been allocated solely for the storage of information?
-
+    :kb-abstract """Malware depends on its ability to insert a malicious payload into memory with the hope that it will be executed later. Wouldn't it be great if you could prevent malware from running if it wrote to an area that has been allocated solely for the storage of information?\r
+\r
 Data Execution Prevention (DEP) does exactly that, by substantially reducing the range of memory that malicious code can use for its benefit. DEP uses the No eXecute bit on modern CPUs to mark blocks of memory as read-only so that those blocks can't be used to execute malicious code that may be inserted by means of a vulnerability exploit.""" ;
     :kb-author "Nick Schonning, Daniel Simpson, Marty Hernandez Avedon, Trond B. Krokli, jreeds, jcaparas, Andres Mariano Gorzelany, Tina Burden, Thomas Raya, Justin Hall, justanotheranonymoususer, Liza Poggemeyer, Dani Halfin, imba-tjd (Authors for entire page)" ;
     :kb-mitre-analysis " " ;
@@ -25304,8 +25306,8 @@ Data Execution Prevention (DEP) does exactly that, by substantially reducing the
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-003: Debuggers for Accessibility Applications - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-11-006/"^^xsd:anyURI ;
-    :kb-abstract """The Windows Registry location HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options allows for parameters to be set for applications during execution. One feature used by malicious actors is the "Debugger" option. When a key has this value enabled, a Debugging command line can be specified. Windows will launch the Debugging command line, and pass the original command line in as an argument. Adversaries can set a Debugger for Accessibility Applications. The analytic looks for the original command line as an argument to the Debugger. When the strings "sethc.exe", "utilman.exe", "osk.exe", "narrator.exe", and "Magnify.exe" are detected in the arguments, but not as the main executable, it is very likely that a Debugger is set.
-
+    :kb-abstract """The Windows Registry location HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options allows for parameters to be set for applications during execution. One feature used by malicious actors is the "Debugger" option. When a key has this value enabled, a Debugging command line can be specified. Windows will launch the Debugging command line, and pass the original command line in as an argument. Adversaries can set a Debugger for Accessibility Applications. The analytic looks for the original command line as an argument to the Debugger. When the strings "sethc.exe", "utilman.exe", "osk.exe", "narrator.exe", and "Magnify.exe" are detected in the arguments, but not as the main executable, it is very likely that a Debugger is set.\r
+\r
 This analytic could depend on the possibility of the known strings used as arguments for other applications used in the day-to-day environment. Although the chance of the string "sethc.exe" being used as an argument for another application is unlikely, it still is a possibility.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25357,18 +25359,18 @@ This analytic could depend on the possibility of the known strings used as argum
         owl:NamedIndividual ;
     rdfs:label "Reference - Decoy Personas for Safeguarding Online Identity Using Deception - MITRE" ;
     :has-link "https://web.archive.org/web/20180407204216/https://isc.sans.edu/diary/Decoy+Personas+for+Safeguarding+Online+Identity+Using+Deception/16159"^^xsd:anyURI ;
-    :kb-abstract """What if online scammers weren't sure whether the user account they are targeting is really yours, or whether the information they compiled about you is real? It's worth considering whether decoy online personas might help in the quest to safeguard our digital identities and data.
-
-I believe deception tactics, such as selective and careful use of honeypots, holds promise for defending enterprise IT resources. Some forms of deception could also protect individuals against online scammers and other attackers. This approach might not be quite practical today for most people, but in the future we might find it both necessary and achievable.
-
-Human attackers and malicious software pursue user accounts and data on-line through harvesting, phishing, password-guessing, software vulnerabilities, and various other means. How might we use decoys to confuse, misdirect, slow down and detect adversaries engaged in such activities?
-
-...
-
-The wealth of personal details available on social networking sites allows attackers to target individuals using social engineering, secret question-guessing and other techniques. For some examples of such approaches, see The Use of Fake or Fraudulent LinkedIn Profiles and Data Mining Resumes for Computer Attack Reconnaissance.
-
-Setting up one or more fake social network profiles (e.g., on Facebook) that use the person's real name can help the individual deflect the attack or can act as an early warning of an impending attack. A decoy profile could purposefully expose some inaccurate information, while the person's real profile would be more carefully concealed using the site's privacy settings. Decoy profiles would be associated with spamtrap email addresses.
-
+    :kb-abstract """What if online scammers weren't sure whether the user account they are targeting is really yours, or whether the information they compiled about you is real? It's worth considering whether decoy online personas might help in the quest to safeguard our digital identities and data.\r
+\r
+I believe deception tactics, such as selective and careful use of honeypots, holds promise for defending enterprise IT resources. Some forms of deception could also protect individuals against online scammers and other attackers. This approach might not be quite practical today for most people, but in the future we might find it both necessary and achievable.\r
+\r
+Human attackers and malicious software pursue user accounts and data on-line through harvesting, phishing, password-guessing, software vulnerabilities, and various other means. How might we use decoys to confuse, misdirect, slow down and detect adversaries engaged in such activities?\r
+\r
+...\r
+\r
+The wealth of personal details available on social networking sites allows attackers to target individuals using social engineering, secret question-guessing and other techniques. For some examples of such approaches, see The Use of Fake or Fraudulent LinkedIn Profiles and Data Mining Resumes for Computer Attack Reconnaissance.\r
+\r
+Setting up one or more fake social network profiles (e.g., on Facebook) that use the person's real name can help the individual deflect the attack or can act as an early warning of an impending attack. A decoy profile could purposefully expose some inaccurate information, while the person's real profile would be more carefully concealed using the site's privacy settings. Decoy profiles would be associated with spamtrap email addresses.\r
+\r
 Similarly, the person could expose decoy profiles on other sites, for instance those reveal shopping habits (e.g., Amazon), musings (e.g., Twitter), skills (e.g., GitHub), travel (e.g., TripIt), affections (e.g., Pinterest), music taste (e.g., Pandora) and so on. The person's decoy identities could also have fake resumes available on sites such as Indeed and Monster.com.""" ;
     :kb-author "Lenny Zeltser" ;
     :kb-mitre-analysis " " ;
@@ -25406,12 +25408,12 @@ Similarly, the person could expose decoy profiles on other sites, for instance t
     :has-link "https://patents.google.com/patent/US20190188384A1"^^xsd:anyURI ;
     :kb-abstract "Described herein are systems, techniques, and computer program products for preventing execution, by a scripting engine, of harmful commands that may be introduced by computer malware or other mechanisms. The system identifies certain host processes that may attempt to utilize a hosted scripting engine. An unmanaged interface module is injected into an identified host process. The unmanaged interface module is configured to detect certain conditions indicating the likelihood that a scripting engine will be instantiated, and in response to inject a managed interface module into the host process. The managed interface module hooks into certain methods of the scripting engine to intercept commands before they are executed by the scripting engine. The managed and unmanaged interface components then communicate with a kernel-mode threat detection component to determine whether any commands should be blocked." ;
     :kb-author "Ion-Alexandru IONESCU; Satoshi Tanda" ;
-    :kb-mitre-analysis """The patent describes techniques that can be implemented to detect and block malicious commands and command scripts from being executed by scripting engines.
-
-### Script Execution Monitoring explanation
-This patent describes software installed on the host system that hooks into methods of a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. For example regular expression checking may be used to identify commands having malicious patterns. Expression checking may be used for script files as well as interactively - typed commands.
-
-### File Content Signatures explanation
+    :kb-mitre-analysis """The patent describes techniques that can be implemented to detect and block malicious commands and command scripts from being executed by scripting engines.\r
+\r
+### Script Execution Monitoring explanation\r
+This patent describes software installed on the host system that hooks into methods of a scripting engine to intercept commands before they are executed and block commands if they are determined to be harmful. For example regular expression checking may be used to identify commands having malicious patterns. Expression checking may be used for script files as well as interactively - typed commands.\r
+\r
+### File Content Signatures explanation\r
 This patent includes File Content Signatures because in the case of a script file, a hash of the file is compared against hashes of known malicious script files to determine whether the script file is malicious.""" ;
     :kb-organization "Crowdstrike Inc" ;
     :kb-reference-of :FileContentRules,
@@ -25454,11 +25456,11 @@ This patent includes File Content Signatures because in the case of a script fil
     :has-link "https://patents.google.com/patent/US20070028302A1/en?oq=US-2007028302-A1"^^xsd:anyURI ;
     :kb-abstract "A security system provides a defense from known and unknown viruses, worms, spyware, hackers, and social engineering attacks. The system can implement centralized policies that allow an administrator to approve, block, quarantine, and log file activities. A server associated with a number of hosts can provide a query for host computers to access security-related meta-information in local host stores. The query is pulled from the server by the hosts. The results of the distributed host query are stored and merged on the server, and exported for display, reports, or security response." ;
     :kb-author "Todd Brennan; John Hanratty" ;
-    :kb-mitre-analysis """Provides a mechanism to detect, monitor, locate, and control files installed on host computers. Each host has a host agent that analyzes file system activity and takes action based on policies configured on a server. The policies identify whether to block, log, allow, or quarantine actions such as file accesses and execution of executables. Examples of policies include:
-
-* Block/log execution of new executables and detached scripts (e.g., .exe or .bat)
-* Block/log reading/execution of new embedded content (e.g., macros in .doc)
-* Block/log installation/modification of Web content (alteration of content in .html or .cgi files)
+    :kb-mitre-analysis """Provides a mechanism to detect, monitor, locate, and control files installed on host computers. Each host has a host agent that analyzes file system activity and takes action based on policies configured on a server. The policies identify whether to block, log, allow, or quarantine actions such as file accesses and execution of executables. Examples of policies include:\r
+\r
+* Block/log execution of new executables and detached scripts (e.g., .exe or .bat)\r
+* Block/log reading/execution of new embedded content (e.g., macros in .doc)\r
+* Block/log installation/modification of Web content (alteration of content in .html or .cgi files)\r
 * Block/log execution of new files in an administratively defined 'class'; e.g., an administrator might want to block screen savers .scr, but not the entire class of executables .exe, .dll, .sys, etc . . .""" ;
     :kb-organization "Bit 9 Inc" ;
     :kb-reference-of :FileContentRules ;
@@ -25468,11 +25470,11 @@ This patent includes File Content Signatures because in the case of a script fil
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-10-002: DLL Injection via Load Library - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-10-002/"^^xsd:anyURI ;
-    :kb-abstract """Microsoft Windows allows for processes to remotely create threads within other processes of the same privilege level. This functionality is provided via the Windows API CreateRemoteThread. Both Windows and third-party software use this ability for legitimate purposes. For example, the Windows process csrss.exe creates threads in programs to send signals to registered callback routines. Both adversaries and host-based security software use this functionality to inject DLLs, but for very different purposes. An adversary is likely to inject into a program to evade defenses or bypass User Account Control, but a security program might do this to gain increased monitoring of API calls. One of the most common methods of DLL Injection is through the Windows API LoadLibrary.
-
-Allocate memory in the target program with VirtualAllocEx
-Write the name of the DLL to inject into this program with WriteProcessMemory
-Create a new thread and set its entry point to LoadLibrary using the API CreateRemoteThread.
+    :kb-abstract """Microsoft Windows allows for processes to remotely create threads within other processes of the same privilege level. This functionality is provided via the Windows API CreateRemoteThread. Both Windows and third-party software use this ability for legitimate purposes. For example, the Windows process csrss.exe creates threads in programs to send signals to registered callback routines. Both adversaries and host-based security software use this functionality to inject DLLs, but for very different purposes. An adversary is likely to inject into a program to evade defenses or bypass User Account Control, but a security program might do this to gain increased monitoring of API calls. One of the most common methods of DLL Injection is through the Windows API LoadLibrary.\r
+\r
+Allocate memory in the target program with VirtualAllocEx\r
+Write the name of the DLL to inject into this program with WriteProcessMemory\r
+Create a new thread and set its entry point to LoadLibrary using the API CreateRemoteThread.\r
 This behavior can be detected by looking for thread creations across processes, and resolving the entry point to determine the function name. If the function is LoadLibraryA or LoadLibraryW, then the intent of the remote thread is clearly to inject a DLL. When this is the case, the source process must be examined so that it can be ignored when it is both expected and a trusted process.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25504,8 +25506,8 @@ This behavior can be detected by looking for thread creations across processes, 
         :SpecificationReference ;
     rdfs:label "Reference - RFC 6376: DomainKeys Identified Mail (DKIM) Signatures - IETF" ;
     :has-link "https://tools.ietf.org/html/rfc6376"^^xsd:anyURI ;
-    :kb-abstract """DomainKeys Identified Mail (DKIM) permits a person, role, or organization that owns the signing domain to claim some responsibility for a message by associating the domain with the message.  This can be an author's organization, an operational relay, or one of their agents.  DKIM separates the question of the identity of the Signer of the message from the purported author of the message.  Assertion of responsibility is validated through a
-cryptographic signature and by querying the Signer's domain directly
+    :kb-abstract """DomainKeys Identified Mail (DKIM) permits a person, role, or organization that owns the signing domain to claim some responsibility for a message by associating the domain with the message.  This can be an author's organization, an operational relay, or one of their agents.  DKIM separates the question of the identity of the Signer of the message from the purported author of the message.  Assertion of responsibility is validated through a\r
+cryptographic signature and by querying the Signer's domain directly\r
 to retrieve the appropriate public key.  Message transit from author to recipient is through relays that typically make no substantive change to the message content and thus preserve the DKIM signature.""" ;
     :kb-author "D. Crocker, T. Hansen, M. Kucherawy" ;
     :kb-organization "Internet Engineering Task Force (IETF)" ;
@@ -25542,8 +25544,8 @@ to retrieve the appropriate public key.  Message transit from author to recipien
         :PatentReference ;
     rdfs:label "Reference - Embedding contexts for on-line threats into response policy zones - Verisign Inc" ;
     :has-link "https://patents.google.com/patent/US10440059B1"^^xsd:anyURI ;
-    :kb-abstract """Hierarchical threat intelligence embedded in subdomain CNAMEs of a DNS denylist.
-
+    :kb-abstract """Hierarchical threat intelligence embedded in subdomain CNAMEs of a DNS denylist.\r
+\r
 In one embodiment, a response policy zone (RPZ) application generates an RPZ that includes contexts for the on-line threats that are associated with domain names. For a domain name that is associated with an on-line threat, the RPZ application determines a threat specification that describes a characteristic of the on-line threat. The RPZ application then generates an alias based on the domain name and the threat specification. Subsequently, the RPZ application generates a domain name system (DNS) resource record that maps the domain name to the alias, includes the resource record in the RPZ, and transmits the RPZ to a DNS name server that implements the RPZ. Upon receiving a DNS query associated with the domain name, the DNS name server generates a DNS response based on the alias. Because the domain name and the threat specification is reflected in the alias, the DNS response automatically provides a relevant context.""" ;
     :kb-author "Ben McCarty" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -25606,17 +25608,17 @@ In one embodiment, a response policy zone (RPZ) application generates an RPZ tha
     :has-link "https://patents.google.com/patent/US20180121650A1/en?oq=US-2018121650-A1"^^xsd:anyURI ;
     :kb-abstract "A security agent implemented on a computing device is described herein. The security agent is configured to detect file-modifying malware by detecting that a process is traversing a directory of the memory of the computing device and detecting that the process is accessing files in the memory according to specified file access patterns. The security agent can also be configured to correlate actions of multiple processes that correspond to a specified file access pattern and detect that one or more of the multiple processes are malware by correlating their behavior." ;
     :kb-author "Daniel W. Brown" ;
-    :kb-mitre-analysis """This patent describes a technique for detecting file modifying malware such as wipers and ransomware that overwrite portions of files and encrypt portions of a computer's memory, respectively. Processes that are traversing a directory are identified along with file access patterns. Processes executing on a computing device that are traversing a directory include:
-
-* changing a directory of a process (e.g., iteratively, systematically, repeatedly)
-* detecting that a process is conducting an "open directory" operation repeatedly
-* the same process traversing through a directory and recording the locations of data files encountered in each sub - directory
-
-In addition to identifying processes traversing a directory, particular file access patterns are also detected that may be indicative of malicious behavior including:
-* multiple file types being accessed
-* accessing a large number of files
-* files located in multiple locations in the directory being accessed
-
+    :kb-mitre-analysis """This patent describes a technique for detecting file modifying malware such as wipers and ransomware that overwrite portions of files and encrypt portions of a computer's memory, respectively. Processes that are traversing a directory are identified along with file access patterns. Processes executing on a computing device that are traversing a directory include:\r
+\r
+* changing a directory of a process (e.g., iteratively, systematically, repeatedly)\r
+* detecting that a process is conducting an "open directory" operation repeatedly\r
+* the same process traversing through a directory and recording the locations of data files encountered in each sub - directory\r
+\r
+In addition to identifying processes traversing a directory, particular file access patterns are also detected that may be indicative of malicious behavior including:\r
+* multiple file types being accessed\r
+* accessing a large number of files\r
+* files located in multiple locations in the directory being accessed\r
+\r
 If a process is conducting a traversal of the directory and accessing files according to a defined access pattern associated with malicious behavior, a preventative action is performed.""" ;
     :kb-organization "Crowdstrike Inc" ;
     :kb-reference-of :FileAccessPatternAnalysis ;
@@ -25704,18 +25706,18 @@ If a process is conducting a traversal of the directory and accessing files acco
         owl:NamedIndividual ;
     rdfs:label "Reference - Firmware Behavior Analysis ConFirm" ;
     :has-link "http://sites.nyuad.nyu.edu/moma/pdfs/pubs/C22.pdf"^^xsd:anyURI ;
-    :kb-abstract """The modernization of various critical infrastructure components has dictated the use of microprocessor-based
-embedded control systems in critical applications. It is often
-infeasible, however, to employ the same level of security measures used in general purpose computing systems, due to the stringent
-performance and resource constraints of embedded devices. Furthermore, as software relies on the firmware for proper operation,
-no software-level technique can detect malicious behavior of
-the firmware. In this work, we propose ConFirm, a low-cost
-technique to detect malicious modifications in the firmware
+    :kb-abstract """The modernization of various critical infrastructure components has dictated the use of microprocessor-based\r
+embedded control systems in critical applications. It is often\r
+infeasible, however, to employ the same level of security measures used in general purpose computing systems, due to the stringent\r
+performance and resource constraints of embedded devices. Furthermore, as software relies on the firmware for proper operation,\r
+no software-level technique can detect malicious behavior of\r
+the firmware. In this work, we propose ConFirm, a low-cost\r
+technique to detect malicious modifications in the firmware\r
 of embedded systems by measuring the number of low-level hardware events that occur during the execution of the firmware.""" ;
     :kb-author "Xueyang Wang, Charalambos Konstantinou, Michail Maniatakos, Ramesh Karri" ;
     :kb-organization "Department of Electrical and Computer Engineering, Polytechnic School of Engineering, New York University and Department of Electrical and Computer Engineering, New York University Abu Dhabi" ;
     :kb-reference-of :FirmwareBehaviorAnalysis ;
-    :kb-reference-title """ConFirm: Detecting Firmware Modifications in Embedded Systems
+    :kb-reference-title """ConFirm: Detecting Firmware Modifications in Embedded Systems\r
 using Hardware Performance Counters""" .
 
 :Reference-FirmwareBehaviorAnalysisVIPER a :AcademicPaperReference,
@@ -25742,8 +25744,8 @@ using Hardware Performance Counters""" .
         owl:NamedIndividual ;
     rdfs:label "Reference - Firmware Embedded Monitoring Code Symbiotes" ;
     :has-link "http://nsl.cs.columbia.edu/projects/minestrone/papers/Symbiotes.pdf"^^xsd:anyURI ;
-    :kb-abstract """A large number of embedded devices on the internet, such as
-routers and VOIP phones, are typically ripe for exploitation. Little to no defensive technology, such as AV scanners or IDS's, are available to protect these devices. We propose a host-based defense mechanism, which we call Symbiotic Embedded Machines (SEM), that is specifically designed
+    :kb-abstract """A large number of embedded devices on the internet, such as\r
+routers and VOIP phones, are typically ripe for exploitation. Little to no defensive technology, such as AV scanners or IDS's, are available to protect these devices. We propose a host-based defense mechanism, which we call Symbiotic Embedded Machines (SEM), that is specifically designed\r
 to inject intrusion detection functionality into the firmware of the device.""" ;
     :kb-author "Ang Cui, Salvatore J. Stolfo" ;
     :kb-organization "Department of Computer Science Columbia University" ;
@@ -25801,10 +25803,10 @@ to inject intrusion detection functionality into the firmware of the device.""" 
         :TechniqueReference ;
     rdfs:label "Reference - FWTK Documentation - fwtk.org" ;
     :has-link "https://web.archive.org/web/20070510153306/http://www.fwtk.org/fwtk/docs/documentation.html#1.1"^^xsd:anyURI ;
-    :kb-abstract """In case you don't already know, FWTK stands for the FireW all Tool Kit. It is used as a base to create a secure firewall system. If you need good documentation, please read the source code. If you are not familiar with C or do not feel comfortable with performing the configuration and security verification yourself, then I would suggest that you purchase a commercial firewall from a vendor (such as TIS, Checkpoint, Raptor, etc.).
-
-A machine needs other tools to secure it, including, but hardly limited to, tools to check files (tripwire), audit tools (tiger/cops), secure access methods (kerberos/ssh), something to watch logs and machine states (swatch/watcher some to mind) and filtering and routing tools such as screend/ipfilterd/ipacl.
-
+    :kb-abstract """In case you don't already know, FWTK stands for the FireW all Tool Kit. It is used as a base to create a secure firewall system. If you need good documentation, please read the source code. If you are not familiar with C or do not feel comfortable with performing the configuration and security verification yourself, then I would suggest that you purchase a commercial firewall from a vendor (such as TIS, Checkpoint, Raptor, etc.).\r
+\r
+A machine needs other tools to secure it, including, but hardly limited to, tools to check files (tripwire), audit tools (tiger/cops), secure access methods (kerberos/ssh), something to watch logs and machine states (swatch/watcher some to mind) and filtering and routing tools such as screend/ipfilterd/ipacl.\r
+\r
 Again, I would recommend that you do not proceed to build a production FWTK firewall unless you are familiar with UNIX security.""" ;
     :kb-author "fwtk.org" ;
     :kb-organization "fwtk.org" ;
@@ -25859,16 +25861,16 @@ Again, I would recommend that you do not proceed to build a production FWTK fire
     :has-link "https://patents.google.com/patent/US20180032728A1/en?oq=US20180032728-A1"^^xsd:anyURI ;
     :kb-abstract "The present disclosure relates to a system and method for monitoring system calls to an operating system kernel. A performance monitoring unit is used to monitor system calls and to gather information about each system call. The information is gathered upon interrupting the system call and can include system call type, parameters, and information about the calling thread/process, in order to determine whether the system call was generated by malicious software code. Potentially malicious software code is nullified by a malicious code counter-attack module." ;
     :kb-author "Matthew D. Spisak" ;
-    :kb-mitre-analysis """This patent describes a technique for monitoring system calls to detect malicious software code. A system call monitoring module operates at the kernel level and traps system calls.
-Monitoring data includes:
-
-* information about the path to the file to be accessed by a system call.
-* the memory address or range of addresses to be accessed by a system call.
-* the context for the thread within operating system that will be interrupted by a system call.
-* the type of system call information about the socket that is being used by system call in order to send or receive data.
-* the history of system calls in order to monitor for specific sequences of system calls.
-* the frequency or periodicity of a particular system call or set of systems calls.
-
+    :kb-mitre-analysis """This patent describes a technique for monitoring system calls to detect malicious software code. A system call monitoring module operates at the kernel level and traps system calls.\r
+Monitoring data includes:\r
+\r
+* information about the path to the file to be accessed by a system call.\r
+* the memory address or range of addresses to be accessed by a system call.\r
+* the context for the thread within operating system that will be interrupted by a system call.\r
+* the type of system call information about the socket that is being used by system call in order to send or receive data.\r
+* the history of system calls in order to monitor for specific sequences of system calls.\r
+* the frequency or periodicity of a particular system call or set of systems calls.\r
+\r
 Captured system call data is analyzed using data analysis algorithms such as machine learning algorithms, artificial intelligence algorithms, pattern recognition algorithms, or other known data analysis techniques. An alert is generated if it is likely that the system call was generated by malicious software code.""" ;
     :kb-organization "Endgame Inc" ;
     :kb-reference-of :SystemCallAnalysis ;
@@ -25880,12 +25882,12 @@ Captured system call data is analyzed using data analysis algorithms such as mac
     :has-link "https://patents.google.com/patent/US20160156644A1"^^xsd:anyURI ;
     :kb-abstract "In some embodiments, heuristic botnet detection is provided. In some embodiments, heuristic botnet detection includes monitoring network traffic to identify suspicious network traffic; and detecting a bot based on a heuristic analysis of the suspicious network traffic behavior using a processor, in which the suspicious network traffic behavior includes command and control traffic associated with a bot master. In some embodiments, heuristic botnet detection further includes assigning a score to the monitored network traffic, in which the score corresponds to a botnet risk characterization of the monitored network traffic (e.g., based on one or more heuristic botnet detection techniques); increasing the score based on a correlation of additional suspicious behaviors associated with the monitored network traffic (e.g., based on one or more heuristic botnet detection techniques); and determining the suspicious behavior is associated with a botnet based on the score." ;
     :kb-author "Xinran Wang; Huagang Xie" ;
-    :kb-mitre-analysis """This patent describes detecting botnets using heuristic analysis techniques on collected network flows. The heuristic techniques include:
-
-* Identifying suspicious traffic patterns to detect command and control traffic ex. periodically visiting a known malware URL, a host visiting a malware domain twice every 5 hour and 14 minutes (this is a specific pattern for a variant of Swizzor botnets).
-* Identifying non-standard behaviors such as connecting to a non-standard HTTP port for HTTP traffic, visiting a non-existent domain, downloading executable files with non-standard executable file extensions, communicating using HTTP header with a shorter than common length
-* Analyzing visited domain information to identify the following: visiting a domain with a domain name that is longer than a common domain name length, visiting a dynamic DNS domain, visiting a fast-flux domain, and visiting a recently created domain.
-
+    :kb-mitre-analysis """This patent describes detecting botnets using heuristic analysis techniques on collected network flows. The heuristic techniques include:\r
+\r
+* Identifying suspicious traffic patterns to detect command and control traffic ex. periodically visiting a known malware URL, a host visiting a malware domain twice every 5 hour and 14 minutes (this is a specific pattern for a variant of Swizzor botnets).\r
+* Identifying non-standard behaviors such as connecting to a non-standard HTTP port for HTTP traffic, visiting a non-existent domain, downloading executable files with non-standard executable file extensions, communicating using HTTP header with a shorter than common length\r
+* Analyzing visited domain information to identify the following: visiting a domain with a domain name that is longer than a common domain name length, visiting a dynamic DNS domain, visiting a fast-flux domain, and visiting a recently created domain.\r
+\r
 A score is determined based on these factors and if the score is over a threshold, a responsive action is performed.""" ;
     :kb-organization "Palo Alto Networks Inc" ;
     :kb-reference-of :DNSTrafficAnalysis ;
@@ -25895,8 +25897,8 @@ A score is determined based on these factors and if the score is over a threshol
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2016-03-001: Host Discovery Commands - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2016-03-001/"^^xsd:anyURI ;
-    :kb-abstract """When entering on a host for the first time, an adversary may try to discover information about the host. There are several built-in Windows commands that can be used to learn about the software configurations, active users, administrators, and networking configuration. These commands should be monitored to identify when an adversary is learning information about the system and environment. The information returned may impact choices an adversary can make when establishing persistence, escalating privileges, or moving laterally.
-
+    :kb-abstract """When entering on a host for the first time, an adversary may try to discover information about the host. There are several built-in Windows commands that can be used to learn about the software configurations, active users, administrators, and networking configuration. These commands should be monitored to identify when an adversary is learning information about the system and environment. The information returned may impact choices an adversary can make when establishing persistence, escalating privileges, or moving laterally.\r
+\r
 Because these commands are built in, they may be run frequently by power users or even by normal users. Thus, an analytic looking at this information should have well-defined white- or blacklists, and should consider looking at an anomaly detection approach, so that this information can be learned dynamically.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -25912,25 +25914,25 @@ Because these commands are built in, they may be run frequently by power users o
     :has-link "https://patents.google.com/patent/US20110023115A1"^^xsd:anyURI ;
     :kb-abstract "In embodiments of the present invention improved capabilities are described for threat detection using a behavioral-based host-intrusion prevention method and system for monitoring a user interaction with a computer, software application, operating system, graphic user interface, or some other component or client of a computer network, and performing an action to protect the computer network based at least in part on the user interaction and a computer code process executing during or in association with a computer usage session." ;
     :kb-author "Clifford C. Wright" ;
-    :kb-mitre-analysis """The patent describes a technique for performing behavior based threat detection. User and code behavior data is collected and stored to create baseline user and code behavior profiles. User behavior data collected over a user session or over multiple sessions can include a user:
-
-* clicking on a link
-* scrolling down a page
-* opening or closing a window
-* downloading a file
-* saving a file
-* running a file
-* typing a keyword
-
-Code behavior monitored includes code:
-
-* copying itself to a system folder
-* setting a run key to itself in the registry
-* setting a second runkey to itself in the registry in
-a different location
-* disabling OS tools in the registry
-* opening a hidden file
-
+    :kb-mitre-analysis """The patent describes a technique for performing behavior based threat detection. User and code behavior data is collected and stored to create baseline user and code behavior profiles. User behavior data collected over a user session or over multiple sessions can include a user:\r
+\r
+* clicking on a link\r
+* scrolling down a page\r
+* opening or closing a window\r
+* downloading a file\r
+* saving a file\r
+* running a file\r
+* typing a keyword\r
+\r
+Code behavior monitored includes code:\r
+\r
+* copying itself to a system folder\r
+* setting a run key to itself in the registry\r
+* setting a second runkey to itself in the registry in\r
+a different location\r
+* disabling OS tools in the registry\r
+* opening a hidden file\r
+\r
 The user interaction and the code process executed during the user session are monitored and compared with predetermined malicious behavior profiles that are typically present in a malicious user session.  The predetermined collection of malicious behaviors are created based on analysis of families of malware in run time in a threat research facility. If a match is made an action is taken that can include isolating the computer on which the user interaction occurs and limiting network access to or from the computer.""" ;
     :kb-organization "Sophos Ltd" ;
     :kb-reference-of :ResourceAccessPatternAnalysis,
@@ -25963,9 +25965,9 @@ The user interaction and the code process executed during the user session are m
         owl:NamedIndividual ;
     rdfs:label "Reference - How to change registry values or permissions from a command line or a script" ;
     :has-link "https://docs.microsoft.com/en-us/troubleshoot/windows-client/application-management/change-registry-values-permissions"^^xsd:anyURI ;
-    :kb-abstract """This article describes how to change registry values or permissions from a command line or a script.
-
-Applies to:   Windows 10 - all editions, Windows Server 2012 R2
+    :kb-abstract """This article describes how to change registry values or permissions from a command line or a script.\r
+\r
+Applies to:   Windows 10 - all editions, Windows Server 2012 R2\r
 Original KB number:   264584""" ;
     :kb-organization "Microsoft" ;
     :kb-reference-title "How to change registry values or permissions from a command line or a script" .
@@ -26000,8 +26002,8 @@ Original KB number:   264584""" ;
         :PatentReference ;
     rdfs:label "Reference - Identification of visual international domain name collisions - Verisign Inc" ;
     :has-link "https://patents.google.com/patent/US10599836B2/en"^^xsd:anyURI ;
-    :kb-abstract """Fuzzy OCR to detect domain name homoglyph attacks.
-
+    :kb-abstract """Fuzzy OCR to detect domain name homoglyph attacks.\r
+\r
 Various embodiments of the invention disclosed herein provide techniques for detecting a homograph attack. An IDN collision detection server retrieves a first domain name that includes a punycode element. The IDN collision detection server converts the first domain into a second domain name that includes a Unicode character corresponding to the punycode element. The IDN collision detection server converts the second domain name into an image. The IDN collision detection server performs one or more optical character recognition operations on the image to generate a textual string associated with the image. The IDN collision detection server determines that the textual string matches at least a portion of a third domain name.""" ;
     :kb-author "Ben McCarty, Preston Zeh" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -26031,24 +26033,24 @@ Various embodiments of the invention disclosed herein provide techniques for det
         owl:NamedIndividual ;
     rdfs:label "Reference - Indirect Branching Calls" ;
     :has-link "https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.1048.1241&rep=rep1&type=pdf"^^xsd:anyURI ;
-    :kb-abstract """Return-oriented programming (ROP) has become the
-primary exploitation technique for system compromise
-in the presence of non-executable page protections. ROP
-exploits are facilitated mainly by the lack of complete
-address space randomization coverage or the presence
-of memory disclosure vulnerabilities, necessitating additional ROP-specific mitigations.
-In this paper we present a practical runtime ROP exploit prevention technique for the protection of thirdparty applications. Our approach is based on the detection of abnormal control transfers that take place during
-ROP code execution. This is achieved using hardware
-features of commodity processors, which incur negligible runtime overhead and allow for completely transparent operation without requiring any modifications to
-the protected applications. Our implementation for Windows 7, named kBouncer, can be selectively enabled for
-installed programs in the same fashion as user-friendly
-mitigation toolkits like Microsoft's EMET. The results of
-our evaluation demonstrate that kBouncer has low runtime overhead of up to 4%, when stressed with specially
-crafted workloads that continuously trigger its core detection component, while it has negligible overhead for
-actual user applications. In our experiments with in-thewild ROP exploits, kBouncer successfully protected all
-tested applications, including Internet Explorer, Adobe
+    :kb-abstract """Return-oriented programming (ROP) has become the\r
+primary exploitation technique for system compromise\r
+in the presence of non-executable page protections. ROP\r
+exploits are facilitated mainly by the lack of complete\r
+address space randomization coverage or the presence\r
+of memory disclosure vulnerabilities, necessitating additional ROP-specific mitigations.\r
+In this paper we present a practical runtime ROP exploit prevention technique for the protection of thirdparty applications. Our approach is based on the detection of abnormal control transfers that take place during\r
+ROP code execution. This is achieved using hardware\r
+features of commodity processors, which incur negligible runtime overhead and allow for completely transparent operation without requiring any modifications to\r
+the protected applications. Our implementation for Windows 7, named kBouncer, can be selectively enabled for\r
+installed programs in the same fashion as user-friendly\r
+mitigation toolkits like Microsoft's EMET. The results of\r
+our evaluation demonstrate that kBouncer has low runtime overhead of up to 4%, when stressed with specially\r
+crafted workloads that continuously trigger its core detection component, while it has negligible overhead for\r
+actual user applications. In our experiments with in-thewild ROP exploits, kBouncer successfully protected all\r
+tested applications, including Internet Explorer, Adobe\r
 Flash Player, and Adobe Reader.""" ;
-    :kb-author """Vasilis Pappas, Michalis Polychronakis, Angelos D. Keromytis
+    :kb-author """Vasilis Pappas, Michalis Polychronakis, Angelos D. Keromytis\r
 Columbia University""" ;
     :kb-organization "Columbia University" ;
     :kb-reference-of :IndirectBranchCallAnalysis ;
@@ -26058,10 +26060,10 @@ Columbia University""" ;
         :PatentReference ;
     rdfs:label "Reference - Inferential exploit attempt detection - Crowdstrike Inc" ;
     :has-link "https://patents.google.com/patent/US10216934B2/en?oq=US-10216934-B2"^^xsd:anyURI ;
-    :kb-abstract """A security agent implemented on a monitored computing device is described herein. The security agent is configured to detect an action of interest (AoI) that may be probative of a security exploit and to determine a context in which that AoI occurred. Based on that context, the security agent is further configured to decide whether the AoI is a security exploit and can take preventative action to prevent the exploit from being completed.
-
-Determining that the AoI includes the security exploit is based at least in part on one or more of: determining that the return address is outside memory previously allocated for an object; determining that the object identifier is associated with a vulnerable object; determining that permissions of the memory region include two or more of read, write, and execute; or determining that the memory region is one page in length.
-
+    :kb-abstract """A security agent implemented on a monitored computing device is described herein. The security agent is configured to detect an action of interest (AoI) that may be probative of a security exploit and to determine a context in which that AoI occurred. Based on that context, the security agent is further configured to decide whether the AoI is a security exploit and can take preventative action to prevent the exploit from being completed.\r
+\r
+Determining that the AoI includes the security exploit is based at least in part on one or more of: determining that the return address is outside memory previously allocated for an object; determining that the object identifier is associated with a vulnerable object; determining that permissions of the memory region include two or more of read, write, and execute; or determining that the memory region is one page in length.\r
+\r
 Determining that the return address is outside memory previously allocated for an object and the method further including treating code that the return address points to as malicious code.""" ;
     :kb-author "Daniel W. Brown; Ion-Alexandru Ionescu; Loren C. Robinson" ;
     :kb-mitre-analysis " " ;
@@ -26088,8 +26090,8 @@ Determining that the return address is outside memory previously allocated for a
     :has-link "https://patents.google.com/patent/US20170061127A1"^^xsd:anyURI ;
     :kb-abstract "Techniques utilizing library and pre-boot components to ensure that a driver associated with a kernel-mode component is initialized before other drivers during a boot phase are described herein. The library component is processed during a boot phase; the pre-boot component, which may be an alternative to the library component, is processed during a pre-boot phase. By ensuring that the driver is the first driver initialized, the components enable the driver to launch the kernel-mode component before other drivers are initialized. The library component may also determine whether another driver is to be initialized before the kernel-mode component driver, may ensure that kernel-mode component driver is initialized first, and may alert the kernel-mode component. Also, the library component may retrieve information that is to be deleted by the operating system before initialization of drivers and may provide that information to the kernel-mode component." ;
     :kb-author "Ion-Alexandru Ionescu" ;
-    :kb-mitre-analysis """To compromise software or to gain control of a host device, a security exploit can modify driver initialization order used by an operating system and place a driver associated with the security exploit first in a list of drivers initialized by the operating system.
-
+    :kb-mitre-analysis """To compromise software or to gain control of a host device, a security exploit can modify driver initialization order used by an operating system and place a driver associated with the security exploit first in a list of drivers initialized by the operating system.\r
+\r
 This patent describes ensuring that a driver associated with the agent is initialized first. To ensure the driver is initialized first, a dependent DLL associated with the driver is configured to be processed before other dependent DLLs. The dependent DLL can be configured to be processed first by various methods, for example if processing is done in alphabetical order, changing its name to be processed first. The dependent DLL, once processed, executes a number of operations to ensure the driver associated with the agent is initialized first. Furthermore, if the initialization order is modified, an alert is provided to the kernel-mode component that notifies the kernel-mode component it was not first and the order had to be altered. It can then take additional actions such as additional monitoring or remediation.""" ;
     :kb-organization "Crowdstrike Inc" ;
     :kb-reference-of :DriverLoadIntegrityChecking ;
@@ -26101,13 +26103,13 @@ This patent describes ensuring that a driver associated with the agent is initia
     :has-link "https://patents.google.com/patent/US20180191752A1"^^xsd:anyURI ;
     :kb-abstract "A variety of techniques are disclosed for detection of advanced persistent threats and similar malware. In one aspect, the detection of certain network traffic at a gateway is used to trigger a query of an originating endpoint, which can use internal logs to identify a local process that is sourcing the network traffic. In another aspect, an endpoint is configured to periodically generate and transmit a secure heartbeat, so that an interruption of the heartbeat can be used to signal the possible presence of malware. In another aspect, other information such as local and global reputation information is used to provide context for more accurate malware detection." ;
     :kb-author "Kenneth D. Ray" ;
-    :kb-mitre-analysis """This patent describes a health monitor deployed on an endpoint that uses a heartbeat to periodically communicate status to a gateway's remote health monitor. The endpoint health monitor issues a heartbeat for satisfactory status of the endpoint using factors such as:
-
-* checking the status of individual software items executing on the endpoint
-* checking that antivirus and other security software is up to date (e. g., with current virus definition files) and running correctly
-* checking the integrity of cryptographic key stores
-* checking other hardware or software components of the endpoint as necessary or helpful for health monitoring
-
+    :kb-mitre-analysis """This patent describes a health monitor deployed on an endpoint that uses a heartbeat to periodically communicate status to a gateway's remote health monitor. The endpoint health monitor issues a heartbeat for satisfactory status of the endpoint using factors such as:\r
+\r
+* checking the status of individual software items executing on the endpoint\r
+* checking that antivirus and other security software is up to date (e. g., with current virus definition files) and running correctly\r
+* checking the integrity of cryptographic key stores\r
+* checking other hardware or software components of the endpoint as necessary or helpful for health monitoring\r
+\r
 A disappearance of the heartbeat from the endpoint may indicate that the endpoint has been compromised.""" ;
     :kb-organization "Sophos Ltd" ;
     :kb-reference-of :EndpointHealthBeacon ;
@@ -26117,8 +26119,8 @@ A disappearance of the heartbeat from the endpoint may indicate that the endpoin
         :UserManualReference ;
     rdfs:label "Reference - Libre NMS - Network Map Extension" ;
     :has-link "https://docs.librenms.org/Extensions/Network-Map/"^^xsd:anyURI ;
-    :kb-abstract """LibreNMS has the ability to show you a network map based on:
-* xDP Discovery
+    :kb-abstract """LibreNMS has the ability to show you a network map based on:\r
+* xDP Discovery\r
 * MAC addresses""" ;
     :kb-organization "LibreNMS.org" ;
     :kb-reference-of :NetworkMapping ;
@@ -26128,10 +26130,10 @@ A disappearance of the heartbeat from the endpoint may indicate that the endpoin
         :UserManualReference ;
     rdfs:label "Reference - Libre NMS - Oxidized Extension" ;
     :has-link "https://docs.librenms.org/Extensions/Oxidized/"^^xsd:anyURI ;
-    :kb-abstract """Integrating LibreNMS with Oxidized brings the following benefits:
-
-* Config viewing: Current, History, and Diffs all under the Configs tab of each device
-* Automatic addition of devices to Oxidized: Including filtering and grouping to ease credential management
+    :kb-abstract """Integrating LibreNMS with Oxidized brings the following benefits:\r
+\r
+* Config viewing: Current, History, and Diffs all under the Configs tab of each device\r
+* Automatic addition of devices to Oxidized: Including filtering and grouping to ease credential management\r
 * Configuration searching""" ;
     :kb-organization "LibreNMS.org" ;
     :kb-reference-of :DiskEncryption ;
@@ -26141,8 +26143,8 @@ A disappearance of the heartbeat from the endpoint may indicate that the endpoin
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2019-07-002: Lsass Process Dump via Procdump - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2019-07-002/"^^xsd:anyURI ;
-    :kb-abstract """ProcDump is a sysinternal command-line utility whose primary purpose is monitoring an application for CPU spikes and generating crash dumps during a spike that an administrator or developer can use to determine the cause of the spike.
-
+    :kb-abstract """ProcDump is a sysinternal command-line utility whose primary purpose is monitoring an application for CPU spikes and generating crash dumps during a spike that an administrator or developer can use to determine the cause of the spike.\r
+\r
 ProcDump may be used to dump the memory space of lsass.exe to disk for processing with a credential access tool such as Mimikatz. This is performed by launching procdump.exe as a privileged user with command line options indicating that lsass.exe should be dumped to a file with an arbitrary name.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26213,14 +26215,14 @@ ProcDump may be used to dump the memory space of lsass.exe to disk for processin
     :has-link "https://patents.google.com/patent/US20140331319A1"^^xsd:anyURI ;
     :kb-abstract "A method and apparatus for detecting malicious websites is disclosed." ;
     :kb-author "John Burnet MUNRO, IV; Jason Aaron Trost; Zachary Daniel HANIF" ;
-    :kb-mitre-analysis """This patent describes a domain classification engine on the host computer that analyzes URLs clicked by a user or entered into a web browser to visit a website. URL analysis is done by using a combination of techniques:
-
-* Feature extraction: A URL is analyzed against features associated with suspicious URLs such as % of longest consecutive digits in a subdomain, % of longest repeated characters in a subdomain, % of vowels in a high level domain.
-
-* Markov analysis: The probability of a digit occurring in normal language given the preceding two digits is determined. For example, if the received URL is google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an "o' occurring after a 'g' and "o, and so forth will be determined. The probability of each digit is then multiplied to get a probability for the whole domain name. Probabilities are determined based on a database of existing usage, such as a dictionary, or a list of known good domain names
-
-* Domain names are compared against an existing dataset of known unauthorized domain names.
-
+    :kb-mitre-analysis """This patent describes a domain classification engine on the host computer that analyzes URLs clicked by a user or entered into a web browser to visit a website. URL analysis is done by using a combination of techniques:\r
+\r
+* Feature extraction: A URL is analyzed against features associated with suspicious URLs such as % of longest consecutive digits in a subdomain, % of longest repeated characters in a subdomain, % of vowels in a high level domain.\r
+\r
+* Markov analysis: The probability of a digit occurring in normal language given the preceding two digits is determined. For example, if the received URL is google.com, the probability of a 'g' occurring at the beginning of a word, the probability of an 'o' occurring after a "g, the probability of an "o' occurring after a 'g' and "o, and so forth will be determined. The probability of each digit is then multiplied to get a probability for the whole domain name. Probabilities are determined based on a database of existing usage, such as a dictionary, or a list of known good domain names\r
+\r
+* Domain names are compared against an existing dataset of known unauthorized domain names.\r
+\r
 A rating is developed based on the results of these techniques, and if the rating is over a set threshold, an action is taken such as blocking access or generating an alert.""" ;
     :kb-organization "Endgame Inc" ;
     :kb-reference-of :URLAnalysis ;
@@ -26244,14 +26246,14 @@ A rating is developed based on the results of these techniques, and if the ratin
     :has-link "https://patents.google.com/patent/US20190081968A1/en"^^xsd:anyURI ;
     :kb-abstract "A system and method for assessing the identity fraud risk of an entity's (a user's, computer process's, or device's) behavior within a computer network and then to take appropriate action. The system uses real-time machine learning for its assessment. It records the entity's log-in behavior (conditions at log-in) and behavior once logged in to create an entity profile that helps identify behavior patterns. The system compares new entity behavior with the entity profile to determine a risk score and a confidence level for the behavior. If the risk score and confidence level indicate a credible identity fraud risk at log-in, the system can require more factors of authentication before log-in succeeds. If the system detects risky behavior after log-in, it can take remedial action such as ending the entity's session, curtailing the entity's privileges, or notifying a human administrator." ;
     :kb-author "Yanlin Wang; Weizhi Li" ;
-    :kb-mitre-analysis """This patent describes determining a confidence score to detect anomalies in user activity based on comparing a user's behavior profile with current user activity events.  The following types of events are used to develop a user entity profile:
-
-* logon and logoff times and locations
-* starting or ending applications
-* reading or writing files
-* changing an entity 's authorization
-* monitoring network traffic
-
+    :kb-mitre-analysis """This patent describes determining a confidence score to detect anomalies in user activity based on comparing a user's behavior profile with current user activity events.  The following types of events are used to develop a user entity profile:\r
+\r
+* logon and logoff times and locations\r
+* starting or ending applications\r
+* reading or writing files\r
+* changing an entity 's authorization\r
+* monitoring network traffic\r
+\r
 User events that deviate from the entity profile over a certain threshold trigger a remedial action.""" ;
     :kb-organization "Idaptive LLC" ;
     :kb-reference-of :AuthenticationEventThresholding,
@@ -26289,12 +26291,12 @@ User events that deviate from the entity profile over a certain threshold trigge
     :has-link "https://patents.google.com/patent/US20150264070A1"^^xsd:anyURI ;
     :kb-abstract "A method and system for detecting algorithm-generated domains (AGDs) is disclosed wherein domain names requested by an internal host are categorized or classified using curated data sets, active services (e.g. Internet services), and certainty scores to match domain names to domain names or IP addresses used by command and control servers." ;
     :kb-author "James Patrick HARLACHER; Aditya Sood; Oskar Ibatullin" ;
-    :kb-mitre-analysis """This patent describes detecting algorithm generated domains (AGD). DNS requests and responses are analyzed by first checking whether the domain matches existing data sets that specify different types of AGDs with known characteristics, such as Evil Twin Domains, Sinkholed domains, sleeper cells, ghost domains, parked domains, and/or bulk-registered domains. In addition to comparing domains against known data sets, the following information is collected to perform analysis:
-
-* IP Information: checks for information known about the IP addresses returned in the DNS response, including the number of IP addresses returned, the registered owners of the IP addresses, or different IP addresses returned for the same domain (IP fluxing)
-* Domain Registration: examines the domain registration date, domain update date, domain expiration date, registrant identity, and authorized name servers associated with a specific domain name.
-* Domain Popularity: provides information on the popularity of a domain name.
-
+    :kb-mitre-analysis """This patent describes detecting algorithm generated domains (AGD). DNS requests and responses are analyzed by first checking whether the domain matches existing data sets that specify different types of AGDs with known characteristics, such as Evil Twin Domains, Sinkholed domains, sleeper cells, ghost domains, parked domains, and/or bulk-registered domains. In addition to comparing domains against known data sets, the following information is collected to perform analysis:\r
+\r
+* IP Information: checks for information known about the IP addresses returned in the DNS response, including the number of IP addresses returned, the registered owners of the IP addresses, or different IP addresses returned for the same domain (IP fluxing)\r
+* Domain Registration: examines the domain registration date, domain update date, domain expiration date, registrant identity, and authorized name servers associated with a specific domain name.\r
+* Domain Popularity: provides information on the popularity of a domain name.\r
+\r
 Based on analysis of these factors a score is developed; if the score is above a certain threshold, an alert is generated.""" ;
     :kb-organization "VECTRA NETWORKS Inc" ;
     :kb-reference-of :DNSTrafficAnalysis ;
@@ -26315,13 +26317,13 @@ Based on analysis of these factors a score is developed; if the score is above a
         :PatentReference ;
     rdfs:label "Reference - Method and system for detecting malicious payloads - Vectra Networks Inc" ;
     :has-link "https://patents.google.com/patent/EP3293937A1/en?oq=EP-3293937-A1"^^xsd:anyURI ;
-    :kb-abstract """Disclosed is an improved method, system, and computer program product for identifying malicious payloads. The disclosed approach identifies potentially malicious payload exchanges which may be associated with payload injection or root-kit magic key usage.
-
-Some examples of data inputs:
-    Information for clients and servers, such as IP address and host information
-    Payloads for both clients and servers
-    Amount of data being transferred
-    Duration of communications
+    :kb-abstract """Disclosed is an improved method, system, and computer program product for identifying malicious payloads. The disclosed approach identifies potentially malicious payload exchanges which may be associated with payload injection or root-kit magic key usage.\r
+\r
+Some examples of data inputs:\r
+    Information for clients and servers, such as IP address and host information\r
+    Payloads for both clients and servers\r
+    Amount of data being transferred\r
+    Duration of communications\r
     Length of time delay between client request and server response""" ;
     :kb-author "Nicolas Beauchesne; John Steven Mancini" ;
     :kb-mitre-analysis "Extraction of network flow data and using unsupervised machine learning to create a standard baseline. During the monitoring phase, abnormal network metadata will result in an alert." ;
@@ -26491,17 +26493,17 @@ Some examples of data inputs:
         owl:NamedIndividual ;
     rdfs:label "Reference - Network-Based Buffer Overflow Detection by Exploit Code Analysis - Information Security Research Centre" ;
     :has-link "https://eprints.qut.edu.au/21172/1/21172.pdf"^^xsd:anyURI ;
-    :kb-abstract """Buffer overflow attacks continue to be a major security problem and detecting attacks of this nature
-is therefore crucial to network security. Signature based network based intrusion detection systems (NIDS)
-compare network traffic to signatures modelling suspicious or attack traffic to detect network attacks. Since
-detection is based on pattern matching, a signature modelling the attack must exist for the NIDS to detect it, and
-it is therefore only capable of detecting known attacks. This paper proposes a method to detect buffer overflow
-attacks by parsing the payload of network packets in search of shellcode which is the remotely executable
-component of a buffer overflow attack. By analysing the shellcode it is possible to determine which system
-calls the exploit uses, and hence the operation of the exploit. Current NIDS-based buffer overflow detection
-techniques mainly rely upon specific signatures for each new attack. Our approach is able to detect previously
-unseen buffer overflow attacks, in addition to existing ones, without the need for specific signatures for each
-new attack. The method has been implemented and tested for buffer overflow attacks on Linux on the Intel x86
+    :kb-abstract """Buffer overflow attacks continue to be a major security problem and detecting attacks of this nature\r
+is therefore crucial to network security. Signature based network based intrusion detection systems (NIDS)\r
+compare network traffic to signatures modelling suspicious or attack traffic to detect network attacks. Since\r
+detection is based on pattern matching, a signature modelling the attack must exist for the NIDS to detect it, and\r
+it is therefore only capable of detecting known attacks. This paper proposes a method to detect buffer overflow\r
+attacks by parsing the payload of network packets in search of shellcode which is the remotely executable\r
+component of a buffer overflow attack. By analysing the shellcode it is possible to determine which system\r
+calls the exploit uses, and hence the operation of the exploit. Current NIDS-based buffer overflow detection\r
+techniques mainly rely upon specific signatures for each new attack. Our approach is able to detect previously\r
+unseen buffer overflow attacks, in addition to existing ones, without the need for specific signatures for each\r
+new attack. The method has been implemented and tested for buffer overflow attacks on Linux on the Intel x86\r
 architecture using the Snort NIDS.""" ;
     :kb-author "Stig Andersson, Andrew Clark, and George Mohay" ;
     :kb-mitre-analysis " " ;
@@ -26608,8 +26610,8 @@ architecture using the Snort NIDS.""" ;
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-002: Outlier Parents of Cmd - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-11-002/"^^xsd:anyURI ;
-    :kb-abstract """Many programs create command prompts as part of their normal operation including malware used by attackers. This analytic attempts to identify suspicious programs spawning cmd.exe by looking for programs that do not normally create cmd.exe.
-
+    :kb-abstract """Many programs create command prompts as part of their normal operation including malware used by attackers. This analytic attempts to identify suspicious programs spawning cmd.exe by looking for programs that do not normally create cmd.exe.\r
+\r
 While this analytic does not take the user into account, doing so could generate further interesting results. It is very common for some programs to spawn cmd.exe as a subprocess, for example to run batch files or windows commands. However many process don't routinely launch a command prompt - for example Microsoft Outlook. A command prompt being launched from a process that normally doesn't launch command prompts could be the result of malicious code being injected into that process, or of an attacker replacing a legitimate program with a malicious one.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26672,8 +26674,8 @@ While this analytic does not take the user into account, doing so could generate
     :has-link "https://patents.google.com/patent/US20190138715A1/"^^xsd:anyURI ;
     :kb-abstract "In one aspect, a method useful for monitoring and validating execution of executable binary code, includes the step of disassembling an executable binary code of an application. The method includes the step of detecting and obtaining location and type of an application programming interface (API) call, system call, and privileged instruction that is executed by the executable binary code. The method includes the step of detecting and obtaining return address from an Al call and system call. The method includes the step of validating location of the API call system call, and privileged instruction. The method includes the step of validating return from the API call and system call." ;
     :kb-author "Jayant Shukla" ;
-    :kb-mitre-analysis """The patent describes a technique for monitoring API calls. Executable binary code of an application is first disassembled and scanned for API calls. Based on the recorded API calls, a rule list is generated. Software hooks are placed in the code for monitoring API calls during program execution and then each API call is validated using the generated rule list to permit or deny execution of API calls.
-
+    :kb-mitre-analysis """The patent describes a technique for monitoring API calls. Executable binary code of an application is first disassembled and scanned for API calls. Based on the recorded API calls, a rule list is generated. Software hooks are placed in the code for monitoring API calls during program execution and then each API call is validated using the generated rule list to permit or deny execution of API calls.\r
+\r
 Rules are created that specify the type and location of the API call. For example, data collected for an application can show an API call to libc at address 0x43e0 and an API call by libc at address 0xlfb47. Accordingly, two rules are generated. The first rule specifies the location type and target of the API call at address 0x43e0, as well as the return address. The second rule is for the API call to the kernel and states the target address, return address, instruction, and target type.""" ;
     :kb-organization "K2 Cyber Security Inc" ;
     :kb-reference-of :SystemCallAnalysis ;
@@ -26683,11 +26685,11 @@ Rules are created that specify the type and location of the API call. For exampl
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-04-003: Powershell Execution - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-04-003/"^^xsd:anyURI ;
-    :kb-abstract """PowerShell is a scripting environment included with Windows that is used by both attackers and administrators. Execution of PowerShell scripts in most Windows versions is opaque and not typically secured by antivirus which makes using PowerShell an easy way to circumvent security measures. This analytic detects execution of PowerShell scripts.
-
-Powershell can be used to hide monitored command line execution such as:
-
-* net use
+    :kb-abstract """PowerShell is a scripting environment included with Windows that is used by both attackers and administrators. Execution of PowerShell scripts in most Windows versions is opaque and not typically secured by antivirus which makes using PowerShell an easy way to circumvent security measures. This analytic detects execution of PowerShell scripts.\r
+\r
+Powershell can be used to hide monitored command line execution such as:\r
+\r
+* net use\r
 * sc start""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26879,10 +26881,10 @@ Powershell can be used to hide monitored command line execution such as:
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-03-005: Remotely Launched Executables via Services - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-03-005/"^^xsd:anyURI ;
-    :kb-abstract """There are several ways to cause code to execute on a remote host. One of the most common methods is via the Windows Service Control Manager (SCM), which allows authorized users to remotely create and modify services. Several tools, such as PsExec, use this functionality.
-
-When a client remotely communicates with the Service Control Manager, there are two observable behaviors. First, the client connects to the RPC Endpoint Mapper over 135/tcp. This handles authentication, and tells the client what port the endpoint--in this case the SCM--is listening on. Then, the client connects directly to the listening port on services.exe. If the request is to start an existing service with a known command line, the the SCM process will run the corresponding command.
-
+    :kb-abstract """There are several ways to cause code to execute on a remote host. One of the most common methods is via the Windows Service Control Manager (SCM), which allows authorized users to remotely create and modify services. Several tools, such as PsExec, use this functionality.\r
+\r
+When a client remotely communicates with the Service Control Manager, there are two observable behaviors. First, the client connects to the RPC Endpoint Mapper over 135/tcp. This handles authentication, and tells the client what port the endpoint--in this case the SCM--is listening on. Then, the client connects directly to the listening port on services.exe. If the request is to start an existing service with a known command line, the the SCM process will run the corresponding command.\r
+\r
 This compound behavior can be detected by looking for services.exe receiving a network connection and immediately spawning a child process.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26895,12 +26897,12 @@ This compound behavior can be detected by looking for services.exe receiving a n
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-12-001: Remotely Launched Executables via WMI - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-12-001/"^^xsd:anyURI ;
-    :kb-abstract """Adversaries can use Windows Management Instrumentation (WMI) to move laterally by launching executables remotely. For adversaries to achieve this, they must open a WMI connection to a remote host. This RPC activity is currently detected by CAR-2014-11-007. After the WMI connection has been initialized, a process can be remotely launched using the command: wmic /node:"<hostname>" process call create "<command line>", which is detected via CAR-2016-03-002.
-
-This leaves artifacts at both a network (RPC) and process (command line) level. When wmic.exe (or the schtasks API) is used to remotely create processes, Windows uses RPC (135/tcp) to communicate with the the remote machine.
-
-After RPC authenticates, the RPC endpoint mapper opens a high port connection, through which the schtasks Remote Procedure Call is actually implemented. With the right packet decoders, or by looking for certain byte streams in raw data, these functions can be identified.
-
+    :kb-abstract """Adversaries can use Windows Management Instrumentation (WMI) to move laterally by launching executables remotely. For adversaries to achieve this, they must open a WMI connection to a remote host. This RPC activity is currently detected by CAR-2014-11-007. After the WMI connection has been initialized, a process can be remotely launched using the command: wmic /node:"<hostname>" process call create "<command line>", which is detected via CAR-2016-03-002.\r
+\r
+This leaves artifacts at both a network (RPC) and process (command line) level. When wmic.exe (or the schtasks API) is used to remotely create processes, Windows uses RPC (135/tcp) to communicate with the the remote machine.\r
+\r
+After RPC authenticates, the RPC endpoint mapper opens a high port connection, through which the schtasks Remote Procedure Call is actually implemented. With the right packet decoders, or by looking for certain byte streams in raw data, these functions can be identified.\r
+\r
 When the command line is executed, it has the parent process of C:\\windows\\system32\\wbem\\WmiPrvSE.exe. This analytic looks for these two events happening in sequence, so that the network connection and target process are output.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26914,14 +26916,14 @@ When the command line is executed, it has the parent process of C:\\windows\\sys
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2015-04-002: Remotely Scheduled Tasks via Schtasks - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2015-04-002/"^^xsd:anyURI ;
-    :kb-abstract """An adversary can move laterally using the schtasks command to remotely schedule tasks. Although these events can be detected with command line analytics CAR-2013-08-001, it is possible for an adversary to use the API directly, via the Task Scheduler GUI or with a scripting language such as PowerShell. In this cases, an additional source of data becomes necessary to detect adversarial behavior. When scheduled tasks are created remotely, Windows uses RPC (135/tcp) to communicate with the Task Scheduler on the remote machine. Once an RPC connection is established (CAR-2014-05-001), the client communicates with the Scheduled Tasks endpoint, which runs within the service group netsvcs. With packet capture and the right packet decoders or byte-stream based signatures, remote invocations of these functions can be identified.
-
-Certain strings can be identifiers of the schtasks, by looking up the interface UUID of ITaskSchedulerService in different formats
-
-* UUID 86d35949-83c9-4044-b424-db363231fd0c (decoded)
-* Hex 49 59 d3 86 c9 83 44 40 b4 24 db 36 32 31 fd 0c (raw)
-* ASCII IYD@$621 (printable bytes only)
-
+    :kb-abstract """An adversary can move laterally using the schtasks command to remotely schedule tasks. Although these events can be detected with command line analytics CAR-2013-08-001, it is possible for an adversary to use the API directly, via the Task Scheduler GUI or with a scripting language such as PowerShell. In this cases, an additional source of data becomes necessary to detect adversarial behavior. When scheduled tasks are created remotely, Windows uses RPC (135/tcp) to communicate with the Task Scheduler on the remote machine. Once an RPC connection is established (CAR-2014-05-001), the client communicates with the Scheduled Tasks endpoint, which runs within the service group netsvcs. With packet capture and the right packet decoders or byte-stream based signatures, remote invocations of these functions can be identified.\r
+\r
+Certain strings can be identifiers of the schtasks, by looking up the interface UUID of ITaskSchedulerService in different formats\r
+\r
+* UUID 86d35949-83c9-4044-b424-db363231fd0c (decoded)\r
+* Hex 49 59 d3 86 c9 83 44 40 b4 24 db 36 32 31 fd 0c (raw)\r
+* ASCII IYD@$621 (printable bytes only)\r
+\r
 This identifier is present three times during the RPC request phase. Any sensor that has access to the byte code as raw, decoded, or ASCII could implement this analytic.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -26934,14 +26936,14 @@ This identifier is present three times during the RPC request phase. Any sensor 
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-005: Remote Registry - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-11-005/"^^xsd:anyURI ;
-    :kb-abstract """An adversary can remotely manipulate the registry of another machine if the RemoteRegistry service is enabled and valid credentials are obtained. While the registry is remotely accessed, it can be used to prepare a Lateral Movement technique, discover the configuration of a host, achieve Persistence, or anything that aids an adversary in achieving the mission. Like most ATT&CK techniques, this behavior can be used legitimately, and the reliability of an analytic depends on the proper identification of the pre-existing legitimate behaviors. Although this behavior is disabled in many Windows configurations, it is possible to remotely enable the RemoteRegistry service, which can be detected with CAR-2014-03-005.
-
-Remote access to the registry can be achieved via
-
-* Windows API function RegConnectRegistry
-* command line via reg.exe
-* graphically via regedit.exe
-
+    :kb-abstract """An adversary can remotely manipulate the registry of another machine if the RemoteRegistry service is enabled and valid credentials are obtained. While the registry is remotely accessed, it can be used to prepare a Lateral Movement technique, discover the configuration of a host, achieve Persistence, or anything that aids an adversary in achieving the mission. Like most ATT&CK techniques, this behavior can be used legitimately, and the reliability of an analytic depends on the proper identification of the pre-existing legitimate behaviors. Although this behavior is disabled in many Windows configurations, it is possible to remotely enable the RemoteRegistry service, which can be detected with CAR-2014-03-005.\r
+\r
+Remote access to the registry can be achieved via\r
+\r
+* Windows API function RegConnectRegistry\r
+* command line via reg.exe\r
+* graphically via regedit.exe\r
+\r
 All of these behaviors call into the Windows API, which uses the NamedPipe WINREG over SMB to handle the protocol information. This network can be decoded with wireshark or a similar sensor, and can also be detected by hooking the API function.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27008,11 +27010,11 @@ All of these behaviors call into the Windows API, which uses the NamedPipe WINRE
         :SpecificationReference ;
     rdfs:label "Reference - RFC 7489: Domain-based Message Authentication, Reporting, and Conformance (DMARC) - IETF" ;
     :has-link "https://tools.ietf.org/html/rfc7489"^^xsd:anyURI ;
-    :kb-abstract """Domain-based Message Authentication, Reporting, and Conformance(DMARC) is a scalable mechanism by which a mail-originating organization can express domain-level policies and preferences for message validation, disposition, and reporting, that a mail-receiving organization can use to improve mail handling.
-
-Originators of Internet Mail need to be able to associate reliable and authenticated domain identifiers with messages, communicate policies about messages that use those identifiers, and report about mail using those identifiers.  These abilities have several benefits: Receivers can provide feedback to Domain Owners about the use of their domains; this feedback can provide valuable insight about the management of internal operations and the presence of external domain name abuse.
-
-DMARC does not produce or encourage elevated delivery privilege of authenticated email. DMARC is a mechanism for policy distribution that enables increasingly strict handling of messages that fail authentication checks, ranging from no action, through altered
+    :kb-abstract """Domain-based Message Authentication, Reporting, and Conformance(DMARC) is a scalable mechanism by which a mail-originating organization can express domain-level policies and preferences for message validation, disposition, and reporting, that a mail-receiving organization can use to improve mail handling.\r
+\r
+Originators of Internet Mail need to be able to associate reliable and authenticated domain identifiers with messages, communicate policies about messages that use those identifiers, and report about mail using those identifiers.  These abilities have several benefits: Receivers can provide feedback to Domain Owners about the use of their domains; this feedback can provide valuable insight about the management of internal operations and the presence of external domain name abuse.\r
+\r
+DMARC does not produce or encourage elevated delivery privilege of authenticated email. DMARC is a mechanism for policy distribution that enables increasingly strict handling of messages that fail authentication checks, ranging from no action, through altered\r
 delivery, up to message rejection.""" ;
     :kb-author "M. Kucherawy, E. Zwicky" ;
     :kb-organization "Internet Engineering Task Force (IETF)" ;
@@ -27100,11 +27102,11 @@ delivery, up to message rejection.""" ;
         owl:NamedIndividual ;
     rdfs:label "Reference - Securing Web Transactions" ;
     :has-link "https://www.nccoe.nist.gov/sites/default/files/library/sp1800/tls-serv-cert-mgt-nist-sp1800-16b-final.pdf"^^xsd:anyURI ;
-    :kb-abstract """Organizations risk losing revenue, customers, and reputation, and exposing internal or customer data to
-attackers if they do not properly manage Transport Layer Security (TLS) server certificates. TLS is the
-most widely used security protocol to secure web transactions and other communications on the
-internet and internal networks. TLS server certificates are central to the security and operation of
-internet-facing and internal web services. Improper TLS server certificate management results in
+    :kb-abstract """Organizations risk losing revenue, customers, and reputation, and exposing internal or customer data to\r
+attackers if they do not properly manage Transport Layer Security (TLS) server certificates. TLS is the\r
+most widely used security protocol to secure web transactions and other communications on the\r
+internet and internal networks. TLS server certificates are central to the security and operation of\r
+internet-facing and internal web services. Improper TLS server certificate management results in\r
 significant outages to web applications and services-such as government services, online banking, flight operations, and mission-critical services within an organization-and increased risk of security breaches.""" ;
     :kb-author "William Haag, Murugiah Souppaya, Paul Turner, William C. Barker, Brett Pleasant, Susan Symington" ;
     :kb-organization "NIST" ;
@@ -27115,12 +27117,12 @@ significant outages to web applications and services-such as government services
         :SpecificationReference ;
     rdfs:label "Reference - Security Architecture for the Internet Protocol" ;
     :has-link "https://datatracker.ietf.org/doc/html/rfc1825"^^xsd:anyURI ;
-    :kb-abstract """This memo describes the security mechanisms for IP version 4 (IPv4)
-   and IP version 6 (IPv6) and the services that they provide.  Each
-   security mechanism is specified in a separate document.  This
-   document also describes key management requirements for systems
-   implementing those security mechanisms.  This document is not an
-   overall Security Architecture for the Internet and is instead focused
+    :kb-abstract """This memo describes the security mechanisms for IP version 4 (IPv4)\r
+   and IP version 6 (IPv6) and the services that they provide.  Each\r
+   security mechanism is specified in a separate document.  This\r
+   document also describes key management requirements for systems\r
+   implementing those security mechanisms.  This document is not an\r
+   overall Security Architecture for the Internet and is instead focused\r
    on IP-layer security.""" ;
     :kb-author "Randall Atkinson" ;
     :kb-reference-of :EncryptedTunnels ;
@@ -27191,8 +27193,8 @@ significant outages to web applications and services-such as government services
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-05-002: Services launching Cmd - MITRE" ;
     :has-link ""^^xsd:anyURI ;
-    :kb-abstract """Windows runs the Service Control Manager (SCM) within the process services.exe. Windows launches services as independent processes or DLL loads within a svchost.exe group. To be a legitimate service, a process (or DLL) must have the appropriate service entry point SvcMain. If an application does not have the entry point, then it will timeout (default is 30 seconds) and the process will be killed.
-
+    :kb-abstract """Windows runs the Service Control Manager (SCM) within the process services.exe. Windows launches services as independent processes or DLL loads within a svchost.exe group. To be a legitimate service, a process (or DLL) must have the appropriate service entry point SvcMain. If an application does not have the entry point, then it will timeout (default is 30 seconds) and the process will be killed.\r
+\r
 To survive the timeout, adversaries and red teams can create services that direct to cmd.exe with the flag /c, followed by the desired command. The /c flag causes the command shell to run a command and immediately exit. As a result, the desired program will remain running and it will report an error starting the service. This analytic will catch that command prompt instance that is used to launch the actual malicious executable. Additionally, the children and descendants of services.exe will run as a SYSTEM user by default. Thus, services are a convenient way for an adversary to gain Persistence and Privilege Escalation.""" ;
     :kb-author "" ;
     :kb-mitre-analysis " " ;
@@ -27210,8 +27212,8 @@ To survive the timeout, adversaries and red teams can create services that direc
     rdfs:label "Reference - CAR-2013-02-008: Simultaneous Logins on a Host - MITRE" ;
     :comment "The reference only lists pre-Vista event IDs; current (2020) ones are found at: https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-audit-logon-events" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-02-008/"^^xsd:anyURI ;
-    :kb-abstract """Multiple users logged into a single machine at the same time, or even within the same hour, do not typically occur in networks we have observed.
-
+    :kb-abstract """Multiple users logged into a single machine at the same time, or even within the same hour, do not typically occur in networks we have observed.\r
+\r
 Logon events are Windows Event Code 4624 for Windows Vista and above, 518 for pre-Vista. Logoff events are 4634 for Windows Vista and above, 538 for pre-Vista. Logon types 2, 3, 9 and 10 are of interest. For more details see the Logon Types table on Microsoft's Audit Logon Events page.""" ;
     :kb-author "MITRE" ;
     :kb-reference-of :AuthenticationEventThresholding ;
@@ -27232,8 +27234,8 @@ Logon events are Windows Event Code 4624 for Windows Vista and above, 518 for pr
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-05-005: SMB Copy and Execution - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-05-005/"^^xsd:anyURI ;
-    :kb-abstract """An adversary needs to gain access to other hosts to move throughout an environment. In many cases, this is a twofold process. First, a file is remotely written to a host via an SMB share (detected by CAR-2013-05-003). Then, a variety of Execution techniques can be used to remotely establish execution of the file or script. To detect this behavior, look for files that are written to a host over SMB and then later run directly as a process or in the command line arguments. SMB File Writes and Remote Execution may happen normally in an environment, but the combination of the two behaviors is less frequent and more likely to indicate adversarial activity.
-
+    :kb-abstract """An adversary needs to gain access to other hosts to move throughout an environment. In many cases, this is a twofold process. First, a file is remotely written to a host via an SMB share (detected by CAR-2013-05-003). Then, a variety of Execution techniques can be used to remotely establish execution of the file or script. To detect this behavior, look for files that are written to a host over SMB and then later run directly as a process or in the command line arguments. SMB File Writes and Remote Execution may happen normally in an environment, but the combination of the two behaviors is less frequent and more likely to indicate adversarial activity.\r
+\r
 This can possibly extend to more copy protocols in order to widen its reach, or it could be tuned more finely to focus on specific program run locations (e.g. %SYSTEMROOT%\\system32) to gain a higher detection rate.""" ;
     :kb-author "" ;
     :kb-mitre-analysis " " ;
@@ -27249,9 +27251,9 @@ This can possibly extend to more copy protocols in order to widen its reach, or 
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-01-003: SMB Events Monitoring - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-01-003/"^^xsd:anyURI ;
-    :kb-abstract """Server Message Block (SMB) is used by Windows to allow for file, pipe, and printer sharing over port 445/tcp. It allows for enumerating, and reading from and writing to file shares for a remote computer. Although it is heavily used by Windows servers for legitimate purposes and by users for file and printer sharing, many adversaries also use SMB to achieve Lateral Movement. Looking at this activity more closely to obtain an adequate sense of situational awareness may make it possible to detect adversaries moving between hosts in a way that deviates from normal activity. Because SMB traffic is heavy in many environments, this analytic may be difficult to turn into something that can be used to quickly detect an APT. In some cases, it may make more sense to run this analytic in a forensic fashion. Looking through and filtering its output after an intrusion has been discovered may be helpful in identifying the scope of compromise.
-
-Output Description:
+    :kb-abstract """Server Message Block (SMB) is used by Windows to allow for file, pipe, and printer sharing over port 445/tcp. It allows for enumerating, and reading from and writing to file shares for a remote computer. Although it is heavily used by Windows servers for legitimate purposes and by users for file and printer sharing, many adversaries also use SMB to achieve Lateral Movement. Looking at this activity more closely to obtain an adequate sense of situational awareness may make it possible to detect adversaries moving between hosts in a way that deviates from normal activity. Because SMB traffic is heavy in many environments, this analytic may be difficult to turn into something that can be used to quickly detect an APT. In some cases, it may make more sense to run this analytic in a forensic fashion. Looking through and filtering its output after an intrusion has been discovered may be helpful in identifying the scope of compromise.\r
+\r
+Output Description:\r
 The source, destination, content, and time of each event.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27264,8 +27266,8 @@ The source, destination, content, and time of each event.""" ;
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-09-003: SMB Session Setups - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-09-003/"^^xsd:anyURI ;
-    :kb-abstract """Account usage within SMB can be used to identify compromised credentials, and the hosts accessed with them.
-
+    :kb-abstract """Account usage within SMB can be used to identify compromised credentials, and the hosts accessed with them.\r
+\r
 This analytic monitors SMB activity that deals with user activity rather than file activity.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27280,8 +27282,8 @@ This analytic monitors SMB activity that deals with user activity rather than fi
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-03-001: SMB Write Request - NamedPipes - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2014-03-001/"^^xsd:anyURI ;
-    :kb-abstract """An SMB write can be an indicator of lateral movement, especially when combined with other information such as execution of that written file. Named pipes are a subset of SMB write requests. Named pipes such as msftewds may not be alarming; however others, such as lsarpc, may.
-
+    :kb-abstract """An SMB write can be an indicator of lateral movement, especially when combined with other information such as execution of that written file. Named pipes are a subset of SMB write requests. Named pipes such as msftewds may not be alarming; however others, such as lsarpc, may.\r
+\r
 Monitoring SMB write requests still creates some noise, particularly with named pipes. As a result, SMB is now split between writing named pipes and writing other files.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27456,7 +27458,7 @@ Monitoring SMB write requests still creates some noise, particularly with named 
     :has-link "https://patents.google.com/patent/US9807114B2/en?oq=US-9807114-B2"^^xsd:anyURI ;
     :kb-abstract "A system for identifying the presence of advanced persistent threats on a network including a plurality of resources, interconnected to form a network, at least one decoy resource, at least one mini-trap installed on at least one of the plurality of resources and functionally associated with at one of the at least one decoy resource, the at least one mini-trap comprising deceptive information directing malware accessing the at least one mini-trap to the decoy resource associated therewith, and a manager node forming part of the network, locally or remotely, and configured to manage placement of the at least one mini-trap on the at least one of the plurality of resources and association between the at least one mini-trap and the decoy resource associated therewith." ;
     :kb-author "Doron Kolton; Rami Mizrahi; Omer Zohar; Benny Ben-Rabi; Alex Barbalat; Shlomi Gabai" ;
-    :kb-mitre-analysis """Questionable or all files (as determined by the enterprise) are forwarded to the decoy network. Using a manager node user interface, you can setup fake information (ex. IP address of a decoy FTP server)
+    :kb-mitre-analysis """Questionable or all files (as determined by the enterprise) are forwarded to the decoy network. Using a manager node user interface, you can setup fake information (ex. IP address of a decoy FTP server)\r
 and deploy decoy physical or virtual endpoints.""" ;
     :kb-organization "Fidelis Cybersecurity Solutions Inc" ;
     :kb-reference-of :DecoyNetworkResource,
@@ -27622,13 +27624,13 @@ and deploy decoy physical or virtual endpoints.""" ;
     :has-link "https://patents.google.com/patent/US20160142424A1"^^xsd:anyURI ;
     :kb-abstract "A system is connected to a plurality of user devices coupled to an enterprise's network. The system continuously collects, stores, and analyzes forensic data related to the enterprise's network. Based on the analysis, the system is able to determine normal behavior of the network and portions thereof and thereby identify abnormal behaviors within the network. Upon identification of an abnormal behavior, the system determines whether the abnormal behavior relates to a security incident. Upon determining a security incident in any portion of the enterprise's network, the system extracts forensic data respective of the security incident and enables further assessment of the security incident as well as identification of the source of the security incident. The system provides real-time damage assessment respective of the security incident as well as the security incident's attributions." ;
     :kb-author "Gil BARAK; Shai MORAG" ;
-    :kb-mitre-analysis """This patent describes detecting abnormal behavior related to a security incident by collecting and analyzing forensic data in real time. Forensic data may include:
-
-* URLs visited
-* data downloaded or streamed
-* messages received and sent
-* amount of memory used for processing
-
+    :kb-mitre-analysis """This patent describes detecting abnormal behavior related to a security incident by collecting and analyzing forensic data in real time. Forensic data may include:\r
+\r
+* URLs visited\r
+* data downloaded or streamed\r
+* messages received and sent\r
+* amount of memory used for processing\r
+\r
 The data is then analyzed according to a set of dynamically created rules to determine normal behavior patterns associated with the network or user devices. Anomalies between current behavior and normal behavior patterns trigger an alert.""" ;
     :kb-organization "Palo Alto Networks Inc" ;
     :kb-reference-of :ResourceAccessPatternAnalysis,
@@ -27642,10 +27644,10 @@ The data is then analyzed according to a set of dynamically created rules to det
     :has-link "https://patents.google.com/patent/US20160191563A1"^^xsd:anyURI ;
     :kb-abstract "Disclosed is an improved approach to implement a system and method for detecting insider threats, where models are constructed that is capable of defining what constitutes the normal behavior for any given hosts and quickly find anomalous behaviors that could constitute a potential threat to an organization. The disclosed approach provides a way to identify abnormal data transfers within and external to an organization without the need for individual monitoring software on each host, by leveraging metadata that describe the data exchange patterns observed in the network." ;
     :kb-author "Nicolas BEAUCHESNE; David Lopes Pegna" ;
-    :kb-mitre-analysis """Determination of anomalous data transfers is performed over a given time period. For example, a check of a pull vs. push data ratio can be established over a specific time period, e.g., over a three-hour period, over a one day period, over a one week period, etc.
-
-The system can also establish a baseline behavior for data exchange for each host in terms of pull vs. push data ratio for each resource contacted by the host.
-
+    :kb-mitre-analysis """Determination of anomalous data transfers is performed over a given time period. For example, a check of a pull vs. push data ratio can be established over a specific time period, e.g., over a three-hour period, over a one day period, over a one week period, etc.\r
+\r
+The system can also establish a baseline behavior for data exchange for each host in terms of pull vs. push data ratio for each resource contacted by the host.\r
+\r
 Network packet capture data is collected and metadata is extracted. Aggregate data push/pull information from the metadata is then analyzed for a given host versus specific client to server relationships. This technique can potentially catch lateral data transfers, and may have filtering on alerting logic to only raise alarms when external hosts receive large data transfers.""" ;
     :kb-organization "VECTRA NETWORKS Inc" ;
     :kb-reference-of :PerHostDownload-UploadRatioAnalysis ;
@@ -27680,34 +27682,34 @@ Network packet capture data is collected and metadata is extracted. Aggregate da
     :has-link "https://patents.google.com/patent/US20170324767A1"^^xsd:anyURI ;
     :kb-abstract "Techniques for detecting and/or handling target attacks in an enterprise's email channel are provided. The techniques include receiving aspects of an incoming email message addressed to a first email account holder, selecting a recipient interaction profile and/or a sender profile from a plurality of predetermined profiles stored in a memory based upon the received properties, determining a message trust rating associated with the incoming email message based upon the incoming email message and the selected recipient interaction profile and/or the sender profile; and generating an alert identifying the incoming email message as including a security risk based upon the determined message trust rating. The recipient interaction profile includes information associating the first email account holder and a plurality of email senders from whom email messages have previously been received for the first email account holder, and the sender profile includes information associating a sender of the incoming email message with characteristics determined from a plurality of email messages previously received from the sender." ;
     :kb-author "Manoj Kumar Srivastava" ;
-    :kb-mitre-analysis """The patent describes using sender trust rating and sender MTA trust rating as an indicator of level of email security risk.
-
-### Sender Reputation explanation
-This patent includes Sender Reputation because it describes sender trust rating being used as an indicator of the level of security risk and/or trust level associated with an email sender. The sender trust rating may be determined based on one or more of:
-
-* length of time sender has known the enterprise
-* number of recipients in the enterprise the sender interacts with
-* sender vs. enterprise originated message ratio
-* sender messages open vs. not-open ratio
-* number of emails received from this sender
-* number of emails replied for this sender
-* number of emails from this sender not opened
-* number of emails from this sender not opened that contain an attachment
-* number of emails from this sender not opened that contain a URL
-* number of emails sent to this sender
-* number of email replies received from this sender
-
-Based on the trust rating an alert is generated identifying the incoming email message as a security risk.
-
-### Sender MTA Reputation explanation
-This patent includes Sender MTA Reputation because it describes sender MTA trust rating as an indicator of the level of security risk and/or trust level associated with a sender MTA. The trust rating may be determined based on one or more of:
-
-* length of time MTA has interacted with the enterprise
-* number of sender domains sending emails from the MTA
-* number of recipients in the enterprise the MTA sends emails to
-* number of emails received from this MTA
-* number of email replies received from this MTA
-
+    :kb-mitre-analysis """The patent describes using sender trust rating and sender MTA trust rating as an indicator of level of email security risk.\r
+\r
+### Sender Reputation explanation\r
+This patent includes Sender Reputation because it describes sender trust rating being used as an indicator of the level of security risk and/or trust level associated with an email sender. The sender trust rating may be determined based on one or more of:\r
+\r
+* length of time sender has known the enterprise\r
+* number of recipients in the enterprise the sender interacts with\r
+* sender vs. enterprise originated message ratio\r
+* sender messages open vs. not-open ratio\r
+* number of emails received from this sender\r
+* number of emails replied for this sender\r
+* number of emails from this sender not opened\r
+* number of emails from this sender not opened that contain an attachment\r
+* number of emails from this sender not opened that contain a URL\r
+* number of emails sent to this sender\r
+* number of email replies received from this sender\r
+\r
+Based on the trust rating an alert is generated identifying the incoming email message as a security risk.\r
+\r
+### Sender MTA Reputation explanation\r
+This patent includes Sender MTA Reputation because it describes sender MTA trust rating as an indicator of the level of security risk and/or trust level associated with a sender MTA. The trust rating may be determined based on one or more of:\r
+\r
+* length of time MTA has interacted with the enterprise\r
+* number of sender domains sending emails from the MTA\r
+* number of recipients in the enterprise the MTA sends emails to\r
+* number of emails received from this MTA\r
+* number of email replies received from this MTA\r
+\r
 Based on the trust rating an alert is generated identifying the incoming email message as a security risk.""" ;
     :kb-organization "Graphus Inc" ;
     :kb-reference-of :SenderMTAReputationAnalysis,
@@ -27756,8 +27758,8 @@ Based on the trust rating an alert is generated identifying the incoming email m
         :PatentReference ;
     rdfs:label "Reference - Techniques for impeding and detecting network threats - Verisign Inc" ;
     :has-link "https://patents.google.com/patent/US10904273B1/"^^xsd:anyURI ;
-    :kb-abstract """Infinite DNS decoy trap resource to catch threats scanning for network resources to attack.
-
+    :kb-abstract """Infinite DNS decoy trap resource to catch threats scanning for network resources to attack.\r
+\r
 In various embodiments, a name server transmits a canonical name as resolution to another canonical name. In operation, when a resource name is requested for resolution, a determination is made that the resource name corresponds to a trap resource name. A first canonical name is transmitted as resolution to the trap resource name. The first canonical name is requested for resolution, and a second canonical name is transmitted as resolution. By providing trap canonical names as resolutions to trap canonical names, unauthorized software making the resolution requests is kept occupied with requesting resolution of canonical name after canonical name, impeding the ability of the unauthorized software from traversing a network.""" ;
     :kb-author "Ben McCarty, James Graham" ;
     :kb-mitre-analysis "MITRE Analysis was not found." ;
@@ -27845,7 +27847,7 @@ In various embodiments, a name server transmits a canonical name as resolution t
         :SpecificationReference ;
     rdfs:label "Reference - Trusted Attestation Protocol Use Cases" ;
     :has-link "https://trustedcomputinggroup.org/wp-content/uploads/TCG_TNC_TAP_Use_Cases_v1r0p35_published.pdf"^^xsd:anyURI ;
-    :kb-article """## Document Abstract
+    :kb-article """## Document Abstract\r
 This specification defines the Trusted Platform Module (TPM) a device that enables trust in computing platforms in general. It is broken into parts to make the role of each part clear. All parts are required in order to constitute a complete standard. For a complete definition of all requirements necessary to build a TPM, the designer will need to use the appropriate platform-specific specification to understand all of the requirements for a TPM in a specific application or make appropriate choices as an implementer. Those wishing to create a TPM need to be aware that this specification does not provide a complete picture of the options and commands necessary to implement a TPM. To implement a TPM the designer needs to refer to the relevant platform-specific specification to understand the options and settings required for a TPM in a specific type of platform or make appropriate choices as an implementer.""" ;
     :kb-reference-title "Trusted Attestation Protocol Use Cases" .
 
@@ -27959,8 +27961,8 @@ This specification defines the Trusted Platform Module (TPM) a device that enabl
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-02-012: User Logged in to Multiple Hosts - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-02-012/"^^xsd:anyURI ;
-    :kb-abstract """Most users use only one or two machines during the normal course of business. User accounts that log in to multiple machines, especially over a short period of time, may be compromised. Remote logins among multiple machines may be an indicator of Lateral Movement.
-
+    :kb-abstract """Most users use only one or two machines during the normal course of business. User accounts that log in to multiple machines, especially over a short period of time, may be compromised. Remote logins among multiple machines may be an indicator of Lateral Movement.\r
+\r
 Certain users will likely appear as being logged into several machines and may need to be "whitelisted." Such users would include network admins or user names that are common to many hosts.""" ;
     :kb-author "MITRE" ;
     :kb-mitre-analysis " " ;
@@ -27975,8 +27977,8 @@ Certain users will likely appear as being logged into several machines and may n
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2013-10-001: User Login Activity Monitoring - MITRE" ;
     :has-link "https://car.mitre.org/analytics/CAR-2013-10-001/"^^xsd:anyURI ;
-    :kb-abstract """Monitoring logon and logoff events for hosts on the network is very important for situational awareness. This information can be used as an indicator of unusual activity as well as to corroborate activity seen elsewhere.
-
+    :kb-abstract """Monitoring logon and logoff events for hosts on the network is very important for situational awareness. This information can be used as an indicator of unusual activity as well as to corroborate activity seen elsewhere.\r
+\r
 Could be applied to a number of different types of monitoring depending on what information is desired. Some use cases include monitoring for all remote connections and building login timelines for users. Logon events are Windows Event Code 4624 for Windows Vista and above, 518 for pre-Vista. Logoff events are 4634 for Windows Vista and above, 538 for pre-Vista.""" ;
     :kb-author "MITRE" ;
     :kb-organization "MITRE" ;
@@ -28020,24 +28022,24 @@ Could be applied to a number of different types of monitoring depending on what 
 
 :Reference-WebAuthentication_AnAPIForAccessingPublicKeyCredentials%0ALevel2 a owl:NamedIndividual,
         :SpecificationReference ;
-    rdfs:label """Reference - Web Authentication: An API for accessing Public Key Credentials
+    rdfs:label """Reference - Web Authentication: An API for accessing Public Key Credentials\r
 Level 2""" ;
     :has-link "https://www.w3.org/TR/webauthn-2/"^^xsd:anyURI ;
     :kb-abstract "This specification defines an API enabling the creation and use of strong, attested, scoped, public key-based credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more public key credentials, each scoped to a given WebAuthn Relying Party, are created by and bound to authenticators as requested by the web application. The user agent mediates access to authenticators and their public key credentials in order to preserve user privacy. Authenticators are responsible for ensuring that no operation is performed without user consent. Authenticators provide cryptographic proof of their properties to Relying Parties via attestation. This specification also describes the functional model for WebAuthn conformant authenticators, including their signature and attestation functionality." ;
     :kb-author "W3C" ;
     :kb-reference-of :CredentialTransmissionScoping ;
-    :kb-reference-title """Web Authentication: An API for accessing Public Key Credentials
+    :kb-reference-title """Web Authentication: An API for accessing Public Key Credentials\r
 Level 2""" .
 
 :Reference-WhatIsNX_XDFeature_RedHat a :InternetArticleReference,
         owl:NamedIndividual ;
     rdfs:label "Reference - What is NX/XD feature?" ;
     :has-link "https://access.redhat.com/solutions/2936741"^^xsd:anyURI ;
-    :kb-abstract """What is NX/XD feature ?
-How to check whether NX/XD is enabled ?
-How to enable or disable NX/XD?
-
-NX/XD is a hardware cpu feature which is provided in almost all the hardware. Some BIOS has advanced option of enabling or disabling it.
+    :kb-abstract """What is NX/XD feature ?\r
+How to check whether NX/XD is enabled ?\r
+How to enable or disable NX/XD?\r
+\r
+NX/XD is a hardware cpu feature which is provided in almost all the hardware. Some BIOS has advanced option of enabling or disabling it.\r
 NX stands for No eXecute and XD stands for eXecute Disable. Both are same and is a technology used in processors to prevent execution of certain types of code.""" ;
     :kb-author "Red Hat" ;
     :kb-mitre-analysis " " ;
@@ -28096,10 +28098,10 @@ NX stands for No eXecute and XD stands for eXecute Disable. Both are same and is
         owl:NamedIndividual ;
     rdfs:label "Reference - http://www.biometric-solutions.com/keystroke-dynamics.html - biometric-solutions.com" ;
     :has-link "http://www.biometric-solutions.com/keystroke-dynamics.html"^^xsd:anyURI ;
-    :kb-abstract """Keystroke dynamics or typing dynamics refers to the automated method of identifying or confirming the identity of an individual based on the manner and the rhythm of typing on a keyboard. Keystroke dynamics is a behavioral biometric, this means that the biometric factor is 'something you do'.
-
-Already during the second world war a technique known as The Fist of the Sender was used by military intelligence to distinguish based on the rhythm whether a morse code message was send by ally or enemy. These days each household has at least one computer keyboard, making keystroke dynamics the easiest biometric solution to implement in terms of hardware.
-
+    :kb-abstract """Keystroke dynamics or typing dynamics refers to the automated method of identifying or confirming the identity of an individual based on the manner and the rhythm of typing on a keyboard. Keystroke dynamics is a behavioral biometric, this means that the biometric factor is 'something you do'.\r
+\r
+Already during the second world war a technique known as The Fist of the Sender was used by military intelligence to distinguish based on the rhythm whether a morse code message was send by ally or enemy. These days each household has at least one computer keyboard, making keystroke dynamics the easiest biometric solution to implement in terms of hardware.\r
+\r
 With keystroke dynamics the biometric template used to identify an individual is based on the typing pattern, the rhythm and the speed of typing on a keyboard. The raw measurements used for keystroke dynamics are dwell time and flight time.""" ;
     :kb-author "Biometric Solutions" ;
     :kb-organization "Biometric Solutions" ;


### PR DESCRIPTION
Resolves #203

Changes:

- fixed a restriction for the `Resource Development Techniques` class. 
- fixed the display order of tactics (*to minimize the number of edits, I simply decreased the display order of Reconnaissance*). 
- added label property to `Reconnaissance` tactic.