### PR TITLE
Fix issue #201 - typo in URL

### DIFF
--- a/src/ontology/mappings/d3fend-ontology-mappings.ttl
+++ b/src/ontology/mappings/d3fend-ontology-mappings.ttl
@@ -13,7 +13,7 @@
 #does not appear to be necessary:
 @base <http://d3fend.mitre.org/ontologies/d3fend.owl#> .
 
-<http://d3fend.mitre.org/ontologies/d3fend.owll#> rdf:type owl:Ontology ;
+<http://d3fend.mitre.org/ontologies/d3fend.owl#> rdf:type owl:Ontology ;
     owl:imports <http://www.w3.org/2002/07/owl> ;
     owl:imports <https://www.w3.org/2009/08/skos-reference/skos.rdf> ;
     owl:imports <https://www.dublincore.org/specifications/bibo/bibo/bibo.rdf.xml> ;


### PR DESCRIPTION
Fixed URL typo in d3fend-ontology-mappings.ttl

