### PR TITLE
GetRunningProcesses enumerates Process

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -11319,7 +11319,10 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
 
 :GetRunningProcesses a owl:Class ;
     rdfs:label "Get Running Processes" ;
-    rdfs:subClassOf :SystemCall .
+    rdfs:subClassOf :SystemCall,
+        [ a owl:Restriction ;
+            owl:onProperty :enumerates ;
+            owl:someValuesFrom :Process ] .
 
 :GetScreenCapture a owl:Class ;
     rdfs:label "Get Screen Capture" ;


### PR DESCRIPTION
I propose that this system call has the restriction d3f:enumerates d3f:Process, similar to how d3f:GetOpenSockets d3f:enumerates d3f:Pipe.

Addresses #231 