### PR TITLE
Corrected typo in definition of :OSAPISystemFunction (Issue #235)

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -14934,7 +14934,7 @@ Operating System Monitoring Techniques have varied implementations including bui
 :OSAPISystemFunction a owl:Class ;
     rdfs:label "OS API System Function" ;
     rdfs:subClassOf :OSAPIFunction ;
-    :definition "Indirect System calls are made through OS-specific libraries (like glibc in Linux) that provides a higher-level API for the system calls." ;
+    :definition "Indirect System calls are made through an OS-specific library (like glibc in Linux) that provides a higher-level API for the system calls." ;
     :synonym "Indirect System Call" .
 
 :OSAPITerminateProcess a owl:Class ;


### PR DESCRIPTION
Typo corrected on branch `235-definition-typo`. Request you review and merge into branch `develop`.