### PR TITLE
Using package URLs to identify some SoftwarePackage

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -1014,6 +1014,18 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "publishes" ;
     rdfs:subPropertyOf :d3fend-catalog-object-property .
 
+:purl a owl:InverseFunctionalProperty,
+        owl:ObjectProperty ;
+    rdfs:label "has package URL" ;
+    skos:altLabel "purl" ;
+    rdfs:subPropertyOf :identified-by ;
+    rdfs:domain :SoftwarePackage ;
+    rdfs:range :URL ;
+    rdfs:comment "A purl is a URL string used to identify and locate a software package in a mostly universal and uniform way across programming languages, package managers, packaging conventions, tools, APIs and databases." ;
+    rdfs:isDefinedBy <https://schema.ocsf.io/objects/package> ;
+    :definition "x has package URL y: The subject software package x is identified by the package URL y." ;
+    rdfs:seeAlso <https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst> .
+
 :queries a owl:ObjectProperty ;
     rdfs:label "queries" ;
     rdfs:subPropertyOf :associated-with,


### PR DESCRIPTION
Addresses #227 

* [rdfs:seeAlso](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst).
* The d3f:definition is sourced from OCSF "package" object dictionary property "purl" via [rdfs:isDefinedBy](https://schema.ocsf.io/objects/package).