### PR TITLE
Integrate CAPEC patterns into D3FEND

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ D3FEND_RELEASE_DATE :="2024-04-26T00:00:00.000Z"
 
 ATTACK_VERSION := 15.0
 
+CAPEC_VERSION := 3.9
+
 JENA_VERSION := 4.5.0
 
 JENA_PATH := "bin/jena/apache-jena-${JENA_VERSION}/bin"
@@ -132,6 +134,17 @@ download-attack:
 
 update-attack:
 	bash src/util/update_attack.sh $(ATTACK_VERSION)
+	$(END)
+
+download-capec:
+	mkdir -p data
+	echo "Version: $(CAPEC_VERSION)"
+	cd data; wget https://capec.mitre.org/data/archive/capec_v$(CAPEC_VERSION).zip
+	unzip data/capec_v$(CAPEC_VERSION).zip -d data
+	$(END)
+
+update-capec:
+	bash src/util/update_capec.sh $(CAPEC_VERSION)
 	$(END)
 
 update-puns:

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ pandas = "*"
 owlready2 = "*"
 openpyxl = "*"
 stix2 = "*"
+defusedxml = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f337fc6fc82ec3fc4b3206949c51e9152e97f802884a61c8f24d0eecd41a8842"
+            "sha256": "66251e5b84d8c580e91f8222f503996f8310eda23e3112d6c4f93f2e512fb2ec"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -24,92 +24,116 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
-                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
+                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
+                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.5.7"
+            "version": "==2024.2.2"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
-                "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
-                "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
-                "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
-                "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
-                "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
-                "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
-                "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
-                "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0",
-                "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448",
-                "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
-                "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
-                "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
-                "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
-                "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
-                "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
-                "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59",
-                "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23",
-                "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5",
-                "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
-                "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
-                "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
-                "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
-                "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
-                "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
-                "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
-                "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974",
-                "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
-                "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
-                "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
-                "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
-                "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8",
-                "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
-                "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
-                "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
-                "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
-                "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
-                "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
-                "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
-                "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
-                "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
-                "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
-                "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
-                "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b",
-                "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
-                "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
-                "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
-                "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1",
-                "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
-                "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
-                "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
-                "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
-                "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
-                "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
-                "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
-                "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
-                "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909",
-                "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
-                "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
-                "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
-                "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755",
-                "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
-                "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
-                "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
-                "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
-                "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
-                "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
-                "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
-                "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
-                "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
-                "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
-                "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
-                "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
-                "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
-                "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
+                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
+                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
+                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
+                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
+                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
+                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
+                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
+                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
+                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
+                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
+                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
+                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
+                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
+                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
+                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
+                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
+                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
+                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
+                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
+                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
+                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
+                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
+                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
+                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
+                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
+                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
+                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
+                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
+                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
+                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
+                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
+                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
+                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
+                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
+                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
+                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
+                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
+                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
+                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
+                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
+                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
+                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
+                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
+                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
+                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
+                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
+                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
+                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
+                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
+                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
+                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
+                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
+                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
+                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
+                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
+                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
+                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
+                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
+                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
+                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
+                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
+                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
+                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
+                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
+                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
+                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
+                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
+                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
+                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
+                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
+                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
+                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
+                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
+                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
+                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
+                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
+                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
+                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
+                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
+                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
+                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
+                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
+                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
+                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
+                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
+                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
+                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
+                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
+                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.1.0"
+            "version": "==3.3.2"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
+                "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.7.1"
         },
         "docopt": {
             "hashes": [
@@ -127,11 +151,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.4"
+            "version": "==3.7"
         },
         "isodate": {
             "hashes": [
@@ -142,44 +166,53 @@
         },
         "joblib": {
             "hashes": [
-                "sha256:091138ed78f800342968c523bdde947e7a305b8594b910a0fea2ab83c3c6d385",
-                "sha256:e1cee4a79e4af22881164f218d4311f60074197fb707e082e803b61f6d137018"
+                "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6",
+                "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"
             ],
-            "version": "==1.2.0"
+            "version": "==1.4.2"
         },
         "numpy": {
             "hashes": [
-                "sha256:0ec87a7084caa559c36e0a2309e4ecb1baa03b687201d0a847c8b0ed476a7187",
-                "sha256:1a7d6acc2e7524c9955e5c903160aa4ea083736fde7e91276b0e5d98e6332812",
-                "sha256:202de8f38fc4a45a3eea4b63e2f376e5f2dc64ef0fa692838e31a808520efaf7",
-                "sha256:210461d87fb02a84ef243cac5e814aad2b7f4be953b32cb53327bb49fd77fbb4",
-                "sha256:2d926b52ba1367f9acb76b0df6ed21f0b16a1ad87c6720a1121674e5cf63e2b6",
-                "sha256:352ee00c7f8387b44d19f4cada524586f07379c0d49270f87233983bc5087ca0",
-                "sha256:35400e6a8d102fd07c71ed7dcadd9eb62ee9a6e84ec159bd48c28235bbb0f8e4",
-                "sha256:3c1104d3c036fb81ab923f507536daedc718d0ad5a8707c6061cdfd6d184e570",
-                "sha256:4719d5aefb5189f50887773699eaf94e7d1e02bf36c1a9d353d9f46703758ca4",
-                "sha256:4749e053a29364d3452c034827102ee100986903263e89884922ef01a0a6fd2f",
-                "sha256:5342cf6aad47943286afa6f1609cad9b4266a05e7f2ec408e2cf7aea7ff69d80",
-                "sha256:56e48aec79ae238f6e4395886b5eaed058abb7231fb3361ddd7bfdf4eed54289",
-                "sha256:76e3f4e85fc5d4fd311f6e9b794d0c00e7002ec122be271f2019d63376f1d385",
-                "sha256:7776ea65423ca6a15255ba1872d82d207bd1e09f6d0894ee4a64678dd2204078",
-                "sha256:784c6da1a07818491b0ffd63c6bbe5a33deaa0e25a20e1b3ea20cf0e43f8046c",
-                "sha256:8535303847b89aa6b0f00aa1dc62867b5a32923e4d1681a35b5eef2d9591a463",
-                "sha256:9a7721ec204d3a237225db3e194c25268faf92e19338a35f3a224469cb6039a3",
-                "sha256:a1d3c026f57ceaad42f8231305d4653d5f05dc6332a730ae5c0bea3513de0950",
-                "sha256:ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155",
-                "sha256:ab5f23af8c16022663a652d3b25dcdc272ac3f83c3af4c02eb8b824e6b3ab9d7",
-                "sha256:ae8d0be48d1b6ed82588934aaaa179875e7dc4f3d84da18d7eae6eb3f06c242c",
-                "sha256:c91c4afd8abc3908e00a44b2672718905b8611503f7ff87390cc0ac3423fb096",
-                "sha256:d5036197ecae68d7f491fcdb4df90082b0d4960ca6599ba2659957aafced7c17",
-                "sha256:d6cc757de514c00b24ae8cf5c876af2a7c3df189028d68c0cb4eaa9cd5afc2bf",
-                "sha256:d933fabd8f6a319e8530d0de4fcc2e6a61917e0b0c271fded460032db42a0fe4",
-                "sha256:ea8282b9bcfe2b5e7d491d0bf7f3e2da29700cec05b49e64d6246923329f2b02",
-                "sha256:ecde0f8adef7dfdec993fd54b0f78183051b6580f606111a6d789cd14c61ea0c",
-                "sha256:f21c442fdd2805e91799fbe044a7b999b8571bb0ab0f7850d0cb9641a687092b"
+                "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b",
+                "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818",
+                "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20",
+                "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0",
+                "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010",
+                "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a",
+                "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea",
+                "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c",
+                "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71",
+                "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110",
+                "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be",
+                "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a",
+                "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a",
+                "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5",
+                "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed",
+                "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd",
+                "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c",
+                "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e",
+                "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0",
+                "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c",
+                "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a",
+                "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b",
+                "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0",
+                "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6",
+                "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2",
+                "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a",
+                "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30",
+                "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218",
+                "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5",
+                "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07",
+                "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2",
+                "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4",
+                "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764",
+                "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef",
+                "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3",
+                "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"
             ],
             "index": "pypi",
-            "version": "==1.24.3"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.26.4"
         },
         "openpyxl": {
             "hashes": [
@@ -187,183 +220,204 @@
                 "sha256:f91456ead12ab3c6c2e9491cf33ba6d08357d802192379bb482f1033ade496f5"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==3.1.2"
         },
         "owlready2": {
             "hashes": [
-                "sha256:04fcf4cce810e7b1e78a76ec7c13e44133df316f85081a05f082887e2dd39e03"
+                "sha256:3c1b06dbe85df77dfa2de5a13ba1d11b4b8543c1c0ccdc5be252a81e3c0de55a"
             ],
             "index": "pypi",
-            "version": "==0.43"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.46"
         },
         "pandas": {
             "hashes": [
-                "sha256:02755de164da6827764ceb3bbc5f64b35cb12394b1024fdf88704d0fa06e0e2f",
-                "sha256:0a1e0576611641acde15c2322228d138258f236d14b749ad9af498ab69089e2d",
-                "sha256:1eb09a242184092f424b2edd06eb2b99d06dc07eeddff9929e8667d4ed44e181",
-                "sha256:30a89d0fec4263ccbf96f68592fd668939481854d2ff9da709d32a047689393b",
-                "sha256:50e451932b3011b61d2961b4185382c92cc8c6ee4658dcd4f320687bb2d000ee",
-                "sha256:51a93d422fbb1bd04b67639ba4b5368dffc26923f3ea32a275d2cc450f1d1c86",
-                "sha256:598e9020d85a8cdbaa1815eb325a91cfff2bb2b23c1442549b8a3668e36f0f77",
-                "sha256:66d00300f188fa5de73f92d5725ced162488f6dc6ad4cecfe4144ca29debe3b8",
-                "sha256:69167693cb8f9b3fc060956a5d0a0a8dbfed5f980d9fd2c306fb5b9c855c814c",
-                "sha256:6d6d10c2142d11d40d6e6c0a190b1f89f525bcf85564707e31b0a39e3b398e08",
-                "sha256:713f2f70abcdade1ddd68fc91577cb090b3544b07ceba78a12f799355a13ee44",
-                "sha256:7376e13d28eb16752c398ca1d36ccfe52bf7e887067af9a0474de6331dd948d2",
-                "sha256:77550c8909ebc23e56a89f91b40ad01b50c42cfbfab49b3393694a50549295ea",
-                "sha256:7b21cb72958fc49ad757685db1919021d99650d7aaba676576c9e88d3889d456",
-                "sha256:9ebb9f1c22ddb828e7fd017ea265a59d80461d5a79154b49a4207bd17514d122",
-                "sha256:a18e5c72b989ff0f7197707ceddc99828320d0ca22ab50dd1b9e37db45b010c0",
-                "sha256:a6b5f14cd24a2ed06e14255ff40fe2ea0cfaef79a8dd68069b7ace74bd6acbba",
-                "sha256:b42b120458636a981077cfcfa8568c031b3e8709701315e2bfa866324a83efa8",
-                "sha256:c4af689352c4fe3d75b2834933ee9d0ccdbf5d7a8a7264f0ce9524e877820c08",
-                "sha256:c7319b6e68de14e6209460f72a8d1ef13c09fb3d3ef6c37c1e65b35d50b5c145",
-                "sha256:cf3f0c361a4270185baa89ec7ab92ecaa355fe783791457077473f974f654df5",
-                "sha256:dd46bde7309088481b1cf9c58e3f0e204b9ff9e3244f441accd220dd3365ce7c",
-                "sha256:dd5476b6c3fe410ee95926873f377b856dbc4e81a9c605a0dc05aaccc6a7c6c6",
-                "sha256:e69140bc2d29a8556f55445c15f5794490852af3de0f609a24003ef174528b79",
-                "sha256:f908a77cbeef9bbd646bd4b81214cbef9ac3dda4181d5092a4aa9797d1bc7774"
+                "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863",
+                "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2",
+                "sha256:0cace394b6ea70c01ca1595f839cf193df35d1575986e484ad35c4aeae7266c1",
+                "sha256:1cb51fe389360f3b5a4d57dbd2848a5f033350336ca3b340d1c53a1fad33bcad",
+                "sha256:2925720037f06e89af896c70bca73459d7e6a4be96f9de79e2d440bd499fe0db",
+                "sha256:3e374f59e440d4ab45ca2fffde54b81ac3834cf5ae2cdfa69c90bc03bde04d76",
+                "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51",
+                "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32",
+                "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08",
+                "sha256:58b84b91b0b9f4bafac2a0ac55002280c094dfc6402402332c0913a59654ab2b",
+                "sha256:640cef9aa381b60e296db324337a554aeeb883ead99dc8f6c18e81a93942f5f4",
+                "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921",
+                "sha256:696039430f7a562b74fa45f540aca068ea85fa34c244d0deee539cb6d70aa288",
+                "sha256:6d2123dc9ad6a814bcdea0f099885276b31b24f7edf40f6cdbc0912672e22eee",
+                "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0",
+                "sha256:873d13d177501a28b2756375d59816c365e42ed8417b41665f346289adc68d24",
+                "sha256:8e5a0b00e1e56a842f922e7fae8ae4077aee4af0acb5ae3622bd4b4c30aedf99",
+                "sha256:8e90497254aacacbc4ea6ae5e7a8cd75629d6ad2b30025a4a8b09aa4faf55151",
+                "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd",
+                "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce",
+                "sha256:92fd6b027924a7e178ac202cfbe25e53368db90d56872d20ffae94b96c7acc57",
+                "sha256:9dfde2a0ddef507a631dc9dc4af6a9489d5e2e740e226ad426a05cabfbd7c8ef",
+                "sha256:9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54",
+                "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a",
+                "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238",
+                "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23",
+                "sha256:ddf818e4e6c7c6f4f7c8a12709696d193976b591cc7dc50588d3d1a6b5dc8772",
+                "sha256:e9b79011ff7a0f4b1d6da6a61aa1aa604fb312d6647de5bad20013682d1429ce",
+                "sha256:eee3a87076c0756de40b05c5e9a6069c035ba43e8dd71c379e68cab2c20f16ad"
             ],
             "index": "pypi",
-            "version": "==2.0.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.2.2"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+                "sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad",
+                "sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742"
             ],
             "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
+            "version": "==3.1.2"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "version": "==2.9.0.post0"
         },
         "pytz": {
             "hashes": [
-                "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588",
-                "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
+                "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812",
+                "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"
             ],
-            "version": "==2023.3"
+            "version": "==2024.1"
         },
         "rdflib": {
             "hashes": [
-                "sha256:36b4e74a32aa1e4fa7b8719876fb192f19ecd45ff932ea5ebbd2e417a0247e63",
-                "sha256:72af591ff704f4caacea7ecc0c5a9056b8553e0489dd4f35a9bc52dbd41522e0"
+                "sha256:6136ae056001474ee2aff5fc5b956e62a11c3a9c66bb0f3d9c0aaa5fbb56854e",
+                "sha256:b7642daac8cdad1ba157fecb236f5d1b2aa1de64e714dcee80d65e2b794d88a6"
             ],
             "index": "pypi",
-            "version": "==6.3.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0.2"
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5",
+                "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.0"
         },
         "setuptools": {
             "hashes": [
-                "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b",
-                "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"
+                "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987",
+                "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==66.1.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==69.5.1"
         },
         "simplejson": {
             "hashes": [
-                "sha256:081ea6305b3b5e84ae7417e7f45956db5ea3872ec497a584ec86c3260cda049e",
-                "sha256:08be5a241fdf67a8e05ac7edbd49b07b638ebe4846b560673e196b2a25c94b92",
-                "sha256:0c16ec6a67a5f66ab004190829eeede01c633936375edcad7cbf06d3241e5865",
-                "sha256:0ccb2c1877bc9b25bc4f4687169caa925ffda605d7569c40e8e95186e9a5e58b",
-                "sha256:17a963e8dd4d81061cc05b627677c1f6a12e81345111fbdc5708c9f088d752c9",
-                "sha256:199a0bcd792811c252d71e3eabb3d4a132b3e85e43ebd93bfd053d5b59a7e78b",
-                "sha256:1cb19eacb77adc5a9720244d8d0b5507421d117c7ed4f2f9461424a1829e0ceb",
-                "sha256:203412745fed916fc04566ecef3f2b6c872b52f1e7fb3a6a84451b800fb508c1",
-                "sha256:2098811cd241429c08b7fc5c9e41fcc3f59f27c2e8d1da2ccdcf6c8e340ab507",
-                "sha256:22b867205cd258050c2625325fdd9a65f917a5aff22a23387e245ecae4098e78",
-                "sha256:23fbb7b46d44ed7cbcda689295862851105c7594ae5875dce2a70eeaa498ff86",
-                "sha256:2541fdb7467ef9bfad1f55b6c52e8ea52b3ce4a0027d37aff094190a955daa9d",
-                "sha256:3231100edee292da78948fa0a77dee4e5a94a0a60bcba9ed7a9dc77f4d4bb11e",
-                "sha256:344a5093b71c1b370968d0fbd14d55c9413cb6f0355fdefeb4a322d602d21776",
-                "sha256:37724c634f93e5caaca04458f267836eb9505d897ab3947b52f33b191bf344f3",
-                "sha256:3844305bc33d52c4975da07f75b480e17af3558c0d13085eaa6cc2f32882ccf7",
-                "sha256:390f4a8ca61d90bcf806c3ad644e05fa5890f5b9a72abdd4ca8430cdc1e386fa",
-                "sha256:3a4480e348000d89cf501b5606415f4d328484bbb431146c2971123d49fd8430",
-                "sha256:3b652579c21af73879d99c8072c31476788c8c26b5565687fd9db154070d852a",
-                "sha256:3e0902c278243d6f7223ba3e6c5738614c971fd9a887fff8feaa8dcf7249c8d4",
-                "sha256:412e58997a30c5deb8cab5858b8e2e5b40ca007079f7010ee74565cc13d19665",
-                "sha256:44cdb4e544134f305b033ad79ae5c6b9a32e7c58b46d9f55a64e2a883fbbba01",
-                "sha256:46133bc7dd45c9953e6ee4852e3de3d5a9a4a03b068bd238935a5c72f0a1ce34",
-                "sha256:46e89f58e4bed107626edce1cf098da3664a336d01fc78fddcfb1f397f553d44",
-                "sha256:4710806eb75e87919b858af0cba4ffedc01b463edc3982ded7b55143f39e41e1",
-                "sha256:476c8033abed7b1fd8db62a7600bf18501ce701c1a71179e4ce04ac92c1c5c3c",
-                "sha256:48600a6e0032bed17c20319d91775f1797d39953ccfd68c27f83c8d7fc3b32cb",
-                "sha256:4d3025e7e9ddb48813aec2974e1a7e68e63eac911dd5e0a9568775de107ac79a",
-                "sha256:547ea86ca408a6735335c881a2e6208851027f5bfd678d8f2c92a0f02c7e7330",
-                "sha256:54fca2b26bcd1c403146fd9461d1da76199442297160721b1d63def2a1b17799",
-                "sha256:5673d27806085d2a413b3be5f85fad6fca4b7ffd31cfe510bbe65eea52fff571",
-                "sha256:58ee5e24d6863b22194020eb62673cf8cc69945fcad6b283919490f6e359f7c5",
-                "sha256:5ca922c61d87b4c38f37aa706520328ffe22d7ac1553ef1cadc73f053a673553",
-                "sha256:5db86bb82034e055257c8e45228ca3dbce85e38d7bfa84fa7b2838e032a3219c",
-                "sha256:6277f60848a7d8319d27d2be767a7546bc965535b28070e310b3a9af90604a4c",
-                "sha256:6424d8229ba62e5dbbc377908cfee9b2edf25abd63b855c21f12ac596cd18e41",
-                "sha256:65dafe413b15e8895ad42e49210b74a955c9ae65564952b0243a18fb35b986cc",
-                "sha256:66389b6b6ee46a94a493a933a26008a1bae0cfadeca176933e7ff6556c0ce998",
-                "sha256:66d780047c31ff316ee305c3f7550f352d87257c756413632303fc59fef19eac",
-                "sha256:69a8b10a4f81548bc1e06ded0c4a6c9042c0be0d947c53c1ed89703f7e613950",
-                "sha256:6a561320485017ddfc21bd2ed5de2d70184f754f1c9b1947c55f8e2b0163a268",
-                "sha256:6aa7ca03f25b23b01629b1c7f78e1cd826a66bfb8809f8977a3635be2ec48f1a",
-                "sha256:6b79642a599740603ca86cf9df54f57a2013c47e1dd4dd2ae4769af0a6816900",
-                "sha256:6e7c70f19405e5f99168077b785fe15fcb5f9b3c0b70b0b5c2757ce294922c8c",
-                "sha256:70128fb92932524c89f373e17221cf9535d7d0c63794955cc3cd5868e19f5d38",
-                "sha256:73d0904c2471f317386d4ae5c665b16b5c50ab4f3ee7fd3d3b7651e564ad74b1",
-                "sha256:74bf802debe68627227ddb665c067eb8c73aa68b2476369237adf55c1161b728",
-                "sha256:79c748aa61fd8098d0472e776743de20fae2686edb80a24f0f6593a77f74fe86",
-                "sha256:79d46e7e33c3a4ef853a1307b2032cfb7220e1a079d0c65488fbd7118f44935a",
-                "sha256:7e78d79b10aa92f40f54178ada2b635c960d24fc6141856b926d82f67e56d169",
-                "sha256:8090e75653ea7db75bc21fa5f7bcf5f7bdf64ea258cbbac45c7065f6324f1b50",
-                "sha256:87b190e6ceec286219bd6b6f13547ca433f977d4600b4e81739e9ac23b5b9ba9",
-                "sha256:889328873c35cb0b2b4c83cbb83ec52efee5a05e75002e2c0c46c4e42790e83c",
-                "sha256:8f8d179393e6f0cf6c7c950576892ea6acbcea0a320838c61968ac7046f59228",
-                "sha256:919bc5aa4d8094cf8f1371ea9119e5d952f741dc4162810ab714aec948a23fe5",
-                "sha256:926957b278de22797bfc2f004b15297013843b595b3cd7ecd9e37ccb5fad0b72",
-                "sha256:93f5ac30607157a0b2579af59a065bcfaa7fadeb4875bf927a8f8b6739c8d910",
-                "sha256:96ade243fb6f3b57e7bd3b71e90c190cd0f93ec5dce6bf38734a73a2e5fa274f",
-                "sha256:9f14ecca970d825df0d29d5c6736ff27999ee7bdf5510e807f7ad8845f7760ce",
-                "sha256:a755f7bfc8adcb94887710dc70cc12a69a454120c6adcc6f251c3f7b46ee6aac",
-                "sha256:a79b439a6a77649bb8e2f2644e6c9cc0adb720fc55bed63546edea86e1d5c6c8",
-                "sha256:aa9d614a612ad02492f704fbac636f666fa89295a5d22b4facf2d665fc3b5ea9",
-                "sha256:ad071cd84a636195f35fa71de2186d717db775f94f985232775794d09f8d9061",
-                "sha256:b0e9a5e66969f7a47dc500e3dba8edc3b45d4eb31efb855c8647700a3493dd8a",
-                "sha256:b438e5eaa474365f4faaeeef1ec3e8d5b4e7030706e3e3d6b5bee6049732e0e6",
-                "sha256:b46aaf0332a8a9c965310058cf3487d705bf672641d2c43a835625b326689cf4",
-                "sha256:c39fa911e4302eb79c804b221ddec775c3da08833c0a9120041dd322789824de",
-                "sha256:ca56a6c8c8236d6fe19abb67ef08d76f3c3f46712c49a3b6a5352b6e43e8855f",
-                "sha256:cb502cde018e93e75dc8fc7bb2d93477ce4f3ac10369f48866c61b5e031db1fd",
-                "sha256:cd4d50a27b065447c9c399f0bf0a993bd0e6308db8bbbfbc3ea03b41c145775a",
-                "sha256:d125e754d26c0298715bdc3f8a03a0658ecbe72330be247f4b328d229d8cf67f",
-                "sha256:d300773b93eed82f6da138fd1d081dc96fbe53d96000a85e41460fe07c8d8b33",
-                "sha256:d396b610e77b0c438846607cd56418bfc194973b9886550a98fd6724e8c6cfec",
-                "sha256:d61482b5d18181e6bb4810b4a6a24c63a490c3a20e9fbd7876639653e2b30a1a",
-                "sha256:d9f2c27f18a0b94107d57294aab3d06d6046ea843ed4a45cae8bd45756749f3a",
-                "sha256:dc2b3f06430cbd4fac0dae5b2974d2bf14f71b415fb6de017f498950da8159b1",
-                "sha256:dc935d8322ba9bc7b84f99f40f111809b0473df167bf5b93b89fb719d2c4892b",
-                "sha256:e333c5b62e93949f5ac27e6758ba53ef6ee4f93e36cc977fe2e3df85c02f6dc4",
-                "sha256:e765b1f47293dedf77946f0427e03ee45def2862edacd8868c6cf9ab97c8afbd",
-                "sha256:ed18728b90758d171f0c66c475c24a443ede815cf3f1a91e907b0db0ebc6e508",
-                "sha256:eff87c68058374e45225089e4538c26329a13499bc0104b52b77f8428eed36b2",
-                "sha256:f05d05d99fce5537d8f7a0af6417a9afa9af3a6c4bb1ba7359c53b6257625fcb",
-                "sha256:f253edf694ce836631b350d758d00a8c4011243d58318fbfbe0dd54a6a839ab4",
-                "sha256:f41915a4e1f059dfad614b187bc06021fefb5fc5255bfe63abf8247d2f7a646a",
-                "sha256:f96def94576f857abf58e031ce881b5a3fc25cbec64b2bc4824824a8a4367af9"
+                "sha256:0405984f3ec1d3f8777c4adc33eac7ab7a3e629f3b1c05fdded63acc7cf01137",
+                "sha256:0436a70d8eb42bea4fe1a1c32d371d9bb3b62c637969cb33970ad624d5a3336a",
+                "sha256:061e81ea2d62671fa9dea2c2bfbc1eec2617ae7651e366c7b4a2baf0a8c72cae",
+                "sha256:064300a4ea17d1cd9ea1706aa0590dcb3be81112aac30233823ee494f02cb78a",
+                "sha256:08889f2f597ae965284d7b52a5c3928653a9406d88c93e3161180f0abc2433ba",
+                "sha256:0a48679310e1dd5c9f03481799311a65d343748fe86850b7fb41df4e2c00c087",
+                "sha256:0b0a3eb6dd39cce23801a50c01a0976971498da49bc8a0590ce311492b82c44b",
+                "sha256:0d2d5119b1d7a1ed286b8af37357116072fc96700bce3bec5bb81b2e7057ab41",
+                "sha256:0d551dc931638e2102b8549836a1632e6e7cf620af3d093a7456aa642bff601d",
+                "sha256:1018bd0d70ce85f165185d2227c71e3b1e446186f9fa9f971b69eee223e1e3cd",
+                "sha256:11c39fbc4280d7420684494373b7c5904fa72a2b48ef543a56c2d412999c9e5d",
+                "sha256:11cc3afd8160d44582543838b7e4f9aa5e97865322844b75d51bf4e0e413bb3e",
+                "sha256:1537b3dd62d8aae644f3518c407aa8469e3fd0f179cdf86c5992792713ed717a",
+                "sha256:16ca9c90da4b1f50f089e14485db8c20cbfff2d55424062791a7392b5a9b3ff9",
+                "sha256:176a1b524a3bd3314ed47029a86d02d5a95cc0bee15bd3063a1e1ec62b947de6",
+                "sha256:18955c1da6fc39d957adfa346f75226246b6569e096ac9e40f67d102278c3bcb",
+                "sha256:1bb5b50dc6dd671eb46a605a3e2eb98deb4a9af787a08fcdddabe5d824bb9664",
+                "sha256:1c768e7584c45094dca4b334af361e43b0aaa4844c04945ac7d43379eeda9bc2",
+                "sha256:1dd4f692304854352c3e396e9b5f0a9c9e666868dd0bdc784e2ac4c93092d87b",
+                "sha256:25785d038281cd106c0d91a68b9930049b6464288cea59ba95b35ee37c2d23a5",
+                "sha256:287e39ba24e141b046812c880f4619d0ca9e617235d74abc27267194fc0c7835",
+                "sha256:2c1467d939932901a97ba4f979e8f2642415fcf02ea12f53a4e3206c9c03bc17",
+                "sha256:2c433a412e96afb9a3ce36fa96c8e61a757af53e9c9192c97392f72871e18e69",
+                "sha256:2d022b14d7758bfb98405672953fe5c202ea8a9ccf9f6713c5bd0718eba286fd",
+                "sha256:2f98d918f7f3aaf4b91f2b08c0c92b1774aea113334f7cde4fe40e777114dbe6",
+                "sha256:2fc697be37585eded0c8581c4788fcfac0e3f84ca635b73a5bf360e28c8ea1a2",
+                "sha256:3194cd0d2c959062b94094c0a9f8780ffd38417a5322450a0db0ca1a23e7fbd2",
+                "sha256:332c848f02d71a649272b3f1feccacb7e4f7e6de4a2e6dc70a32645326f3d428",
+                "sha256:346820ae96aa90c7d52653539a57766f10f33dd4be609206c001432b59ddf89f",
+                "sha256:3471e95110dcaf901db16063b2e40fb394f8a9e99b3fe9ee3acc6f6ef72183a2",
+                "sha256:3848427b65e31bea2c11f521b6fc7a3145d6e501a1038529da2391aff5970f2f",
+                "sha256:39b6d79f5cbfa3eb63a869639cfacf7c41d753c64f7801efc72692c1b2637ac7",
+                "sha256:3e74355cb47e0cd399ead3477e29e2f50e1540952c22fb3504dda0184fc9819f",
+                "sha256:3f39bb1f6e620f3e158c8b2eaf1b3e3e54408baca96a02fe891794705e788637",
+                "sha256:40847f617287a38623507d08cbcb75d51cf9d4f9551dd6321df40215128325a3",
+                "sha256:4280e460e51f86ad76dc456acdbfa9513bdf329556ffc8c49e0200878ca57816",
+                "sha256:445a96543948c011a3a47c8e0f9d61e9785df2544ea5be5ab3bc2be4bd8a2565",
+                "sha256:4969d974d9db826a2c07671273e6b27bc48e940738d768fa8f33b577f0978378",
+                "sha256:49aaf4546f6023c44d7e7136be84a03a4237f0b2b5fb2b17c3e3770a758fc1a0",
+                "sha256:49e0e3faf3070abdf71a5c80a97c1afc059b4f45a5aa62de0c2ca0444b51669b",
+                "sha256:49f9da0d6cd17b600a178439d7d2d57c5ef01f816b1e0e875e8e8b3b42db2693",
+                "sha256:4a8c3cc4f9dfc33220246760358c8265dad6e1104f25f0077bbca692d616d358",
+                "sha256:4d36081c0b1c12ea0ed62c202046dca11438bee48dd5240b7c8de8da62c620e9",
+                "sha256:4edcd0bf70087b244ba77038db23cd98a1ace2f91b4a3ecef22036314d77ac23",
+                "sha256:554313db34d63eac3b3f42986aa9efddd1a481169c12b7be1e7512edebff8eaf",
+                "sha256:5675e9d8eeef0aa06093c1ff898413ade042d73dc920a03e8cea2fb68f62445a",
+                "sha256:60848ab779195b72382841fc3fa4f71698a98d9589b0a081a9399904487b5832",
+                "sha256:66e5dc13bfb17cd6ee764fc96ccafd6e405daa846a42baab81f4c60e15650414",
+                "sha256:6779105d2fcb7fcf794a6a2a233787f6bbd4731227333a072d8513b252ed374f",
+                "sha256:6ad331349b0b9ca6da86064a3599c425c7a21cd41616e175ddba0866da32df48",
+                "sha256:6f0a0b41dd05eefab547576bed0cf066595f3b20b083956b1405a6f17d1be6ad",
+                "sha256:73a8a4653f2e809049999d63530180d7b5a344b23a793502413ad1ecea9a0290",
+                "sha256:778331444917108fa8441f59af45886270d33ce8a23bfc4f9b192c0b2ecef1b3",
+                "sha256:7cb98be113911cb0ad09e5523d0e2a926c09a465c9abb0784c9269efe4f95917",
+                "sha256:7d74beca677623481810c7052926365d5f07393c72cbf62d6cce29991b676402",
+                "sha256:7f2398361508c560d0bf1773af19e9fe644e218f2a814a02210ac2c97ad70db0",
+                "sha256:8434dcdd347459f9fd9c526117c01fe7ca7b016b6008dddc3c13471098f4f0dc",
+                "sha256:8a390e56a7963e3946ff2049ee1eb218380e87c8a0e7608f7f8790ba19390867",
+                "sha256:92c4a4a2b1f4846cd4364855cbac83efc48ff5a7d7c06ba014c792dd96483f6f",
+                "sha256:9300aee2a8b5992d0f4293d88deb59c218989833e3396c824b69ba330d04a589",
+                "sha256:9453419ea2ab9b21d925d0fd7e3a132a178a191881fab4169b6f96e118cc25bb",
+                "sha256:9652e59c022e62a5b58a6f9948b104e5bb96d3b06940c6482588176f40f4914b",
+                "sha256:972a7833d4a1fcf7a711c939e315721a88b988553fc770a5b6a5a64bd6ebeba3",
+                "sha256:9c1a4393242e321e344213a90a1e3bf35d2f624aa8b8f6174d43e3c6b0e8f6eb",
+                "sha256:9e038c615b3906df4c3be8db16b3e24821d26c55177638ea47b3f8f73615111c",
+                "sha256:9e4c166f743bb42c5fcc60760fb1c3623e8fda94f6619534217b083e08644b46",
+                "sha256:9eb117db8d7ed733a7317c4215c35993b815bf6aeab67523f1f11e108c040672",
+                "sha256:9eb442a2442ce417801c912df68e1f6ccfcd41577ae7274953ab3ad24ef7d82c",
+                "sha256:a3cd18e03b0ee54ea4319cdcce48357719ea487b53f92a469ba8ca8e39df285e",
+                "sha256:a8617625369d2d03766413bff9e64310feafc9fc4f0ad2b902136f1a5cd8c6b0",
+                "sha256:a970a2e6d5281d56cacf3dc82081c95c1f4da5a559e52469287457811db6a79b",
+                "sha256:aad7405c033d32c751d98d3a65801e2797ae77fac284a539f6c3a3e13005edc4",
+                "sha256:adcb3332979cbc941b8fff07181f06d2b608625edc0a4d8bc3ffc0be414ad0c4",
+                "sha256:af9c7e6669c4d0ad7362f79cb2ab6784d71147503e62b57e3d95c4a0f222c01c",
+                "sha256:b01fda3e95d07a6148702a641e5e293b6da7863f8bc9b967f62db9461330562c",
+                "sha256:b8d940fd28eb34a7084877747a60873956893e377f15a32ad445fe66c972c3b8",
+                "sha256:bccb3e88ec26ffa90f72229f983d3a5d1155e41a1171190fa723d4135523585b",
+                "sha256:bcedf4cae0d47839fee7de344f96b5694ca53c786f28b5f773d4f0b265a159eb",
+                "sha256:be893258d5b68dd3a8cba8deb35dc6411db844a9d35268a8d3793b9d9a256f80",
+                "sha256:c0521e0f07cb56415fdb3aae0bbd8701eb31a9dfef47bb57206075a0584ab2a2",
+                "sha256:c594642d6b13d225e10df5c16ee15b3398e21a35ecd6aee824f107a625690374",
+                "sha256:c87c22bd6a987aca976e3d3e23806d17f65426191db36d40da4ae16a6a494cbc",
+                "sha256:c9ac1c2678abf9270e7228133e5b77c6c3c930ad33a3c1dfbdd76ff2c33b7b50",
+                "sha256:d0e5ffc763678d48ecc8da836f2ae2dd1b6eb2d27a48671066f91694e575173c",
+                "sha256:d0f402e787e6e7ee7876c8b05e2fe6464820d9f35ba3f172e95b5f8b699f6c7f",
+                "sha256:d222a9ed082cd9f38b58923775152003765016342a12f08f8c123bf893461f28",
+                "sha256:d94245caa3c61f760c4ce4953cfa76e7739b6f2cbfc94cc46fff6c050c2390c5",
+                "sha256:de9a2792612ec6def556d1dc621fd6b2073aff015d64fba9f3e53349ad292734",
+                "sha256:e2f5a398b5e77bb01b23d92872255e1bcb3c0c719a3be40b8df146570fe7781a",
+                "sha256:e8dd53a8706b15bc0e34f00e6150fbefb35d2fd9235d095b4f83b3c5ed4fa11d",
+                "sha256:e9eb3cff1b7d71aa50c89a0536f469cb8d6dcdd585d8f14fb8500d822f3bdee4",
+                "sha256:ed628c1431100b0b65387419551e822987396bee3c088a15d68446d92f554e0c",
+                "sha256:ef7938a78447174e2616be223f496ddccdbf7854f7bf2ce716dbccd958cc7d13",
+                "sha256:f1c70249b15e4ce1a7d5340c97670a95f305ca79f376887759b43bb33288c973",
+                "sha256:f3c7363a8cb8c5238878ec96c5eb0fc5ca2cb11fc0c7d2379863d342c6ee367a",
+                "sha256:fbbcc6b0639aa09b9649f36f1bcb347b19403fe44109948392fbb5ea69e48c3e",
+                "sha256:febffa5b1eda6622d44b245b0685aff6fb555ce0ed734e2d7b1c3acd018a2cff",
+                "sha256:ff836cd4041e16003549449cc0a5e372f6b6f871eb89007ab0ee18fb2800fded"
             ],
             "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==3.19.1"
+            "version": "==3.19.2"
         },
         "six": {
             "hashes": [
@@ -379,6 +433,7 @@
                 "sha256:827acf0b5b319c1b857c9db0d54907bb438b2b32312d236c891a305ad49b0ba2"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==3.0.1"
         },
         "stix2-patterns": {
@@ -397,56 +452,41 @@
                 "sha256:24900bdd8212813c3bdddebf5cad2213401ba8881d6fe258fb8c1a7b51ffb760",
                 "sha256:d832e7c51c5a01407e50b0e8cb9bbec55642bfee2cbe593d234929deddcf01d9"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.5'",
             "version": "==1.1.5"
         },
         "tzdata": {
             "hashes": [
-                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
-                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
+                "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd",
+                "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"
             ],
             "markers": "python_version >= '2'",
-            "version": "==2023.3"
+            "version": "==2024.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1",
-                "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"
+                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
+                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.1"
         }
     },
     "develop": {
-        "appnope": {
-            "hashes": [
-                "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
-                "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.3"
-        },
         "astroid": {
             "hashes": [
-                "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324",
-                "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"
+                "sha256:8ead48e31b92b2e217b6c9733a21afafe479d52d6e164dd25fb1a770c7c3cf94",
+                "sha256:e8a0083b4bb28fcffb6207a3bfc9e5d0a68be951dd7e336d5dcf639c682388c0"
             ],
-            "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.15.5"
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==3.2.2"
         },
         "asttokens": {
             "hashes": [
-                "sha256:4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3",
-                "sha256:6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c"
+                "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24",
+                "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0"
             ],
-            "version": "==2.2.1"
-        },
-        "backcall": {
-            "hashes": [
-                "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
-                "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
-            ],
-            "version": "==0.2.0"
+            "version": "==2.4.1"
         },
         "decorator": {
             "hashes": [
@@ -458,18 +498,27 @@
         },
         "dill": {
             "hashes": [
-                "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
-                "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
+                "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca",
+                "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==0.3.6"
+            "version": "==0.3.8"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
+                "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.1"
         },
         "executing": {
             "hashes": [
-                "sha256:0314a69e37426e3608aada02473b4161d4caf5a4b244d1d0c48072b8fee7bacc",
-                "sha256:19da64c18d2d851112f09c287f8d3dbbdf725ab0e569077efb6cdcbd3497c107"
+                "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147",
+                "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"
             ],
-            "version": "==1.2.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.1"
         },
         "ipdb": {
             "hashes": [
@@ -477,81 +526,41 @@
                 "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.13"
         },
         "ipython": {
             "hashes": [
-                "sha256:1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1",
-                "sha256:248aca623f5c99a6635bc3857677b7320b9b8039f99f070ee0d20a5ca5a8e6bf"
+                "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27",
+                "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397"
             ],
             "index": "pypi",
-            "version": "==8.14.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==8.18.1"
         },
         "isort": {
             "hashes": [
-                "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504",
-                "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
+                "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
+                "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==5.12.0"
+            "version": "==5.13.2"
         },
         "jedi": {
             "hashes": [
-                "sha256:203c1fd9d969ab8f2119ec0a3342e0b49910045abe6af0a3ae83a5764d54639e",
-                "sha256:bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612"
+                "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd",
+                "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.18.2"
-        },
-        "lazy-object-proxy": {
-            "hashes": [
-                "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382",
-                "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82",
-                "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9",
-                "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494",
-                "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46",
-                "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30",
-                "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63",
-                "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4",
-                "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae",
-                "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be",
-                "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701",
-                "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd",
-                "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006",
-                "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a",
-                "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586",
-                "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8",
-                "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821",
-                "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07",
-                "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b",
-                "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171",
-                "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b",
-                "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2",
-                "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7",
-                "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4",
-                "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8",
-                "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e",
-                "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f",
-                "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda",
-                "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4",
-                "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e",
-                "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671",
-                "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11",
-                "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455",
-                "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734",
-                "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb",
-                "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.9.0"
+            "version": "==0.19.1"
         },
         "matplotlib-inline": {
             "hashes": [
-                "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311",
-                "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"
+                "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90",
+                "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==0.1.6"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.1.7"
         },
         "mccabe": {
             "hashes": [
@@ -563,42 +572,35 @@
         },
         "parso": {
             "hashes": [
-                "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0",
-                "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"
+                "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18",
+                "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.8.3"
+            "version": "==0.8.4"
         },
         "pexpect": {
             "hashes": [
-                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
-                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+                "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523",
+                "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==4.8.0"
-        },
-        "pickleshare": {
-            "hashes": [
-                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
-                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
-            ],
-            "version": "==0.7.5"
+            "version": "==4.9.0"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:0ade98a4895e87dc51d47151f7d2ec290365a585151d97b4d8d6312ed6132fed",
-                "sha256:e48fabd87db8f3a7df7150a4a5ea22c546ee8bc39bc2473244730d4b56d2cc4e"
+                "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
+                "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.5.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.2"
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b",
-                "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"
+                "sha256:3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d",
+                "sha256:a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.0.38"
+            "version": "==3.0.43"
         },
         "ptyprocess": {
             "hashes": [
@@ -616,19 +618,20 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c",
-                "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"
+                "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+                "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.15.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.18.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1",
-                "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"
+                "sha256:3f8788ab20bb8383e06dd2233e50f8e08949cfd9574804564803441a4946eab4",
+                "sha256:d068ca1dfd735fb92a07d33cb8f288adc0f6bc1287a139ca2425366f7cbe38f8"
             ],
             "index": "pypi",
-            "version": "==2.17.4"
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==3.2.2"
         },
         "six": {
             "hashes": [
@@ -640,10 +643,10 @@
         },
         "stack-data": {
             "hashes": [
-                "sha256:32d2dd0376772d01b6cb9fc996f3c8b57a357089dec328ed4b6553d037eaf815",
-                "sha256:cbb2a53eb64e5785878201a97ed7c7b94883f48b87bfb0bbe8b623c74679e4a8"
+                "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9",
+                "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"
             ],
-            "version": "==0.6.2"
+            "version": "==0.6.3"
         },
         "tomli": {
             "hashes": [
@@ -655,115 +658,34 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171",
-                "sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3"
+                "sha256:af914f5a9c59ed9d0762c7b64d3b5d5df007448eb9cd2edc8a46b1eafead172f",
+                "sha256:eef34fba39834d4d6b73c9ba7f3e4d1c417a4e56f89a7e96e090dd0d24b8fb3c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.8"
+            "version": "==0.12.5"
         },
         "traitlets": {
             "hashes": [
-                "sha256:9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8",
-                "sha256:f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9"
+                "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7",
+                "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==5.9.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==5.14.3"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26",
-                "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.6.3"
+            "version": "==4.11.0"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e",
-                "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"
+                "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859",
+                "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"
             ],
-            "version": "==0.2.6"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0",
-                "sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420",
-                "sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a",
-                "sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c",
-                "sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079",
-                "sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923",
-                "sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f",
-                "sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1",
-                "sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8",
-                "sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86",
-                "sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0",
-                "sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364",
-                "sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e",
-                "sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c",
-                "sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e",
-                "sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c",
-                "sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727",
-                "sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff",
-                "sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e",
-                "sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29",
-                "sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7",
-                "sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72",
-                "sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475",
-                "sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a",
-                "sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317",
-                "sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2",
-                "sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd",
-                "sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640",
-                "sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98",
-                "sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248",
-                "sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e",
-                "sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d",
-                "sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec",
-                "sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1",
-                "sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e",
-                "sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9",
-                "sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92",
-                "sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb",
-                "sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094",
-                "sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46",
-                "sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29",
-                "sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd",
-                "sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705",
-                "sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8",
-                "sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975",
-                "sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb",
-                "sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e",
-                "sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b",
-                "sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418",
-                "sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019",
-                "sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1",
-                "sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba",
-                "sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6",
-                "sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2",
-                "sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3",
-                "sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7",
-                "sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752",
-                "sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416",
-                "sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f",
-                "sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1",
-                "sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc",
-                "sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145",
-                "sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee",
-                "sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a",
-                "sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7",
-                "sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b",
-                "sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653",
-                "sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0",
-                "sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90",
-                "sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29",
-                "sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6",
-                "sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034",
-                "sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09",
-                "sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559",
-                "sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==1.15.0"
+            "version": "==0.2.13"
         }
     }
 }

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -3064,13 +3064,7146 @@ DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
             owl:onProperty :version ;
             owl:someValuesFrom xsd:string ] .
 
+:CAPEC-1 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Accessing Functionality Not Properly Constrained by ACLs" ;
+    rdfs:subClassOf :CAPEC-122 ;
+    :capec-id "CAPEC-1" ;
+    :definition "In applications, particularly web applications, access to functionality is mitigated by an authorization framework. This framework maps Access Control Lists (ACLs) to elements of the application's functionality; particularly URL's for web apps. In the case that the administrator failed to specify an ACL for a particular element, an attacker may be able to access it with impunity. An attacker with the ability to access functionality not properly constrained by ACLs can obtain sensitive information and possibly compromise the entire application. Such an attacker can access resources that must be available only to users at a higher privilege level, can access management sections of the application, or can run queries for data that they otherwise not supposed to." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/1.html> ;
+    :related :CWE-276,
+        :CWE-285,
+        :CWE-434,
+        :CWE-693,
+        :CWE-732,
+        :CWE-1191,
+        :CWE-1193,
+        :CWE-1220,
+        :CWE-1297,
+        :CWE-1311,
+        :CWE-1314,
+        :CWE-1315,
+        :CWE-1318,
+        :CWE-1320,
+        :CWE-1321,
+        :CWE-1327,
+        :T1574.010 .
+
+:CAPEC-2 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Inducing Account Lockout" ;
+    rdfs:subClassOf :CAPEC-212 ;
+    :capec-id "CAPEC-2" ;
+    :definition "An attacker leverages the security functionality of the system aimed at thwarting potential attacks to launch a denial of service attack against a legitimate system user. Many systems, for instance, implement a password throttling mechanism that locks an account after a certain number of incorrect log in attempts. An attacker can leverage this throttling mechanism to lock a legitimate user out of their own account. The weakness that is being leveraged by an attacker is the very security feature that has been put in place to counteract attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/2.html> ;
+    :related :CWE-645,
+        :T1531 .
+
+:CAPEC-3 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Leading 'Ghost' Character Sequences to Bypass Input Filters" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-3" ;
+    :definition "Some APIs will strip certain leading characters from a string of parameters. An adversary can intentionally introduce leading \"ghost\" characters (extra characters that don't affect the validity of the request at the API layer) that enable the input to pass the filters and therefore process the adversary's input. This occurs when the targeted API will accept input data in several syntactic forms and interpret it in the equivalent semantic way, while the filter does not take into account the full spectrum of the syntactic forms acceptable to the targeted API." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/3.html> ;
+    :related :CWE-20,
+        :CWE-41,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-179,
+        :CWE-180,
+        :CWE-181,
+        :CWE-183,
+        :CWE-184,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-4 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Alternative IP Address Encodings" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-4" ;
+    :definition "This attack relies on the adversary using unexpected formats for representing IP addresses. Networked applications may expect network location information in a specific format, such as fully qualified domains names (FQDNs), URL, IP address, or IP Address ranges. If the location information is not validated against a variety of different possible encodings and formats, the adversary can use an alternate format to bypass application access control." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/4.html> ;
+    :related :CWE-173,
+        :CWE-291 .
+
+:CAPEC-5 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "Blue Boxing" ;
+    rdfs:subClassOf :CAPEC-220 ;
+    rdfs:comment "This type of attack against older telephone switches and trunks has been around for decades. A tone is sent by an adversary to impersonate a supervisor signal which has the effect of rerouting or usurping command of the line. While the US infrastructure proper may not contain widespread vulnerabilities to this type of attack, many companies are connected globally through call centers and business process outsourcing. These international systems may be operated in countries which have not upgraded Telco infrastructure and so are vulnerable to Blue boxing. Blue boxing is a result of failure on the part of the system to enforce strong authorization for administrative functions. While the infrastructure is different than standard current applications like web applications, there are historical lessons to be learned to upgrade the access control for administrative functions." ;
+    :capec-id "CAPEC-5" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/5.html> ;
+    :related :CWE-285 .
+
+:CAPEC-6 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Argument Injection" ;
+    rdfs:subClassOf :CAPEC-137 ;
+    :capec-id "CAPEC-6" ;
+    :definition "An attacker changes the behavior or state of a targeted application through injecting data or command syntax through the targets use of non-validated and non-filtered arguments of exposed services or methods." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/6.html> ;
+    :related :CWE-74,
+        :CWE-78,
+        :CWE-146,
+        :CWE-184,
+        :CWE-185,
+        :CWE-697 .
+
+:CAPEC-7 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Blind SQL Injection" ;
+    rdfs:subClassOf :CAPEC-66 ;
+    :capec-id "CAPEC-7" ;
+    :definition "Blind SQL Injection results from an insufficient mitigation for SQL Injection. Although suppressing database error messages are considered best practice, the suppression alone is not sufficient to prevent SQL Injection. Blind SQL Injection is a form of SQL Injection that overcomes the lack of error messages. Without the error messages that facilitate SQL Injection, the adversary constructs input strings that probe the target through simple Boolean SQL expressions. The adversary can determine if the syntax and structure of the injection was successful based on whether the query was executed or not. Applied iteratively, the adversary determines how and where the target is vulnerable to SQL Injection." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/7.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-89,
+        :CWE-209,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-8 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Buffer Overflow in an API Call" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-8" ;
+    :definition "This attack targets libraries or shared code modules which are vulnerable to buffer overflow attacks. An adversary who has knowledge of known vulnerable libraries or shared code can easily target software that makes use of these libraries. All clients that make use of the code library thus become vulnerable by association. This has a very broad effect on security across a system, usually affecting more than one software process." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/8.html> ;
+    :related :CAPEC-46,
+        :CWE-20,
+        :CWE-74,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-680,
+        :CWE-697,
+        :CWE-733 .
+
+:CAPEC-9 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Buffer Overflow in Local Command-Line Utilities" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-9" ;
+    :definition "This attack targets command-line utilities available in a number of shells. An adversary can leverage a vulnerability found in a command-line utility to escalate privilege to root." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/9.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-680,
+        :CWE-697,
+        :CWE-733 .
+
+:CAPEC-10 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Buffer Overflow via Environment Variables" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-10" ;
+    :definition "This attack pattern involves causing a buffer overflow through manipulation of environment variables. Once the adversary finds that they can modify an environment variable, they may try to overflow associated buffers. This attack leverages implicit trust often placed in environment variables." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/10.html> ;
+    :related :CAPEC-13,
+        :CAPEC-46,
+        :CWE-20,
+        :CWE-74,
+        :CWE-99,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-302,
+        :CWE-680,
+        :CWE-697,
+        :CWE-733 .
+
+:CAPEC-11 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cause Web Server Misclassification" ;
+    rdfs:subClassOf :CAPEC-635 ;
+    :capec-id "CAPEC-11" ;
+    :definition "An attack of this type exploits a Web server's decision to take action based on filename or file extension. Because different file types are handled by different server processes, misclassification may force the Web server to take unexpected action, or expected actions in an unexpected sequence. This may cause the server to exhaust resources, supply debug or system data to the attacker, or bind an attacker to a remote process." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/11.html> ;
+    :related :CWE-430,
+        :T1036.006 .
+
+:CAPEC-12 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Choosing Message Identifier" ;
+    rdfs:subClassOf :CAPEC-216 ;
+    :capec-id "CAPEC-12" ;
+    :definition "This pattern of attack is defined by the selection of messages distributed via multicast or public information channels that are intended for another client by determining the parameter value assigned to that client. This attack allows the adversary to gain access to potentially privileged information, and to possibly perpetrate other attacks through the distribution means by impersonation. If the channel/message being manipulated is an input rather than output mechanism for the system, (such as a command bus), this style of attack could be used to change the adversary's identifier to more a privileged one." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/12.html> ;
+    :related :CAPEC-21,
+        :CWE-201,
+        :CWE-306 .
+
+:CAPEC-13 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Subverting Environment Variable Values" ;
+    rdfs:subClassOf :CAPEC-77 ;
+    :capec-id "CAPEC-13" ;
+    :definition "The adversary directly or indirectly modifies environment variables used by or controlling the target software. The adversary's goal is to cause the target software to deviate from its expected operation in a manner that benefits the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/13.html> ;
+    :related :CAPEC-10,
+        :CWE-15,
+        :CWE-20,
+        :CWE-73,
+        :CWE-74,
+        :CWE-200,
+        :CWE-285,
+        :CWE-302,
+        :CWE-353,
+        :T1562.003,
+        :T1574.006,
+        :T1574.007 .
+
+:CAPEC-14 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Client-side Injection-induced Buffer Overflow" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-14" ;
+    :definition "This type of attack exploits a buffer overflow vulnerability in targeted client software through injection of malicious content from a custom-built hostile service. This hostile service is created to deliver the correct content to the client software. For example, if the client-side application is a browser, the service will host a webpage that the browser loads." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/14.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-353,
+        :CWE-680,
+        :CWE-697 .
+
+:CAPEC-15 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Command Delimiters" ;
+    rdfs:subClassOf :CAPEC-137 ;
+    :capec-id "CAPEC-15" ;
+    :definition "An attack of this type exploits a programs' vulnerabilities that allows an attacker's commands to be concatenated onto a legitimate command with the intent of targeting other resources such as the file system or database. The system that uses a filter or denylist input validation, as opposed to allowlist validation is vulnerable to an attacker who predicts delimiters (or combinations of delimiters) not present in the filter or denylist. As with other injection attacks, the attacker uses the command delimiter payload as an entry point to tunnel through the application and activate additional attacks through SQL queries, shell commands, network scanning, and so on." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/15.html> ;
+    :related :CWE-77,
+        :CWE-78,
+        :CWE-93,
+        :CWE-138,
+        :CWE-140,
+        :CWE-146,
+        :CWE-154,
+        :CWE-157,
+        :CWE-184,
+        :CWE-185,
+        :CWE-697 .
+
+:CAPEC-16 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Dictionary-based Password Attack" ;
+    rdfs:subClassOf :CAPEC-49 ;
+    :capec-id "CAPEC-16" ;
+    :definition "An attacker tries each of the words in a dictionary as passwords to gain access to the system via some user's account. If the password chosen by the user was a word within the dictionary, this attack will be successful (in the absence of other mitigations). This is a specific instance of the password brute forcing attack pattern." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/16.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-307,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-654 .
+
+:CAPEC-17 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Malicious Files" ;
+    rdfs:subClassOf :CAPEC-122 ;
+    :capec-id "CAPEC-17" ;
+    :definition "An attack of this type exploits a system's configuration that allows an adversary to either directly access an executable file, for example through shell access; or in a possible worst case allows an adversary to upload a file and then execute it. Web servers, ftp servers, and message oriented middleware systems which have many integration points are particularly vulnerable, because both the programmers and the administrators must be in synch regarding the interfaces and the correct privileges for each interface." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/17.html> ;
+    :related :CWE-59,
+        :CWE-270,
+        :CWE-272,
+        :CWE-282,
+        :CWE-285,
+        :CWE-693,
+        :CWE-732,
+        :T1574.005,
+        :T1574.010 .
+
+:CAPEC-18 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Targeting Non-Script Elements" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-18" ;
+    :definition "This attack is a form of Cross-Site Scripting (XSS) where malicious scripts are embedded in elements that are not expected to host scripts such as image tags (<img>), comments in XML documents (< !-CDATA->), etc. These tags may not be subject to the same input validation, output validation, and other content filtering and checking routines, so this can create an opportunity for an adversary to tunnel through the application's elements and launch a XSS attack through other elements. As with all remote attacks, it is important to differentiate the ability to launch an attack (such as probing an internal network for unpatched servers) and the ability of the remote adversary to collect and interpret the output of said attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/18.html> ;
+    :related :CWE-80 .
+
+:CAPEC-19 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Embedding Scripts within Scripts" ;
+    rdfs:subClassOf :CAPEC-242 ;
+    :capec-id "CAPEC-19" ;
+    :definition "An adversary leverages the capability to execute their own script by embedding it within other scripts that the target software is likely to execute due to programs' vulnerabilities that are brought on by allowing remote hosts to execute scripts." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/19.html> ;
+    :related :CWE-284,
+        :T1027.009,
+        :T1546.004,
+        :T1546.016 .
+
+:CAPEC-20 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Encryption Brute Forcing" ;
+    rdfs:subClassOf :CAPEC-112 ;
+    :capec-id "CAPEC-20" ;
+    :definition "An attacker, armed with the cipher text and the encryption algorithm used, performs an exhaustive (brute force) search on the key space to determine the key that decrypts the cipher text to obtain the plaintext." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/20.html> ;
+    :related :CWE-326,
+        :CWE-327,
+        :CWE-693,
+        :CWE-1204 .
+
+:CAPEC-21 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploitation of Trusted Identifiers" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-21" ;
+    :definition "An adversary guesses, obtains, or \"rides\" a trusted identifier (e.g. session ID, resource ID, cookie, etc.) to perform authorized actions under the guise of an authenticated user or service." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/21.html> ;
+    :related :CAPEC-12,
+        :CWE-6,
+        :CWE-290,
+        :CWE-302,
+        :CWE-346,
+        :CWE-384,
+        :CWE-539,
+        :CWE-602,
+        :CWE-642,
+        :CWE-664,
+        :T1134,
+        :T1528,
+        :T1539 .
+
+:CAPEC-22 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploiting Trust in Client" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-22" ;
+    :definition "An attack of this type exploits vulnerabilities in client/server communication channel authentication and data integrity. It leverages the implicit trust a server places in the client, or more importantly, that which the server believes is the client. An attacker executes this type of attack by communicating directly with the server where the server believes it is communicating only with a valid client. There are numerous variations of this type of attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/22.html> ;
+    :related :CWE-20,
+        :CWE-200,
+        :CWE-287,
+        :CWE-290,
+        :CWE-693 .
+
+:CAPEC-23 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "File Content Injection" ;
+    rdfs:subClassOf :CAPEC-242 ;
+    :capec-id "CAPEC-23" ;
+    :definition "An adversary poisons files with a malicious payload (targeting the file systems accessible by the target software), which may be passed through by standard channels such as via email, and standard web content like PDF and multimedia files. The adversary exploits known vulnerabilities or handling routines in the target processes, in order to exploit the host's trust in executing remote content, including binary files." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/23.html> ;
+    :related :CAPEC-35,
+        :CWE-20 .
+
+:CAPEC-24 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Filter Failure through Buffer Overflow" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-24" ;
+    :definition "In this attack, the idea is to cause an active filter to fail by causing an oversized transaction. An attacker may try to feed overly long input strings to the program in an attempt to overwhelm the filter (by causing a buffer overflow) and hoping that the filter does not fail securely (i.e. the user input is let into the system unfiltered)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/24.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-680,
+        :CWE-697,
+        :CWE-733 .
+
+:CAPEC-25 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Forced Deadlock" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-25" ;
+    :definition "The adversary triggers and exploits a deadlock condition in the target software to cause a denial of service. A deadlock can occur when two or more competing actions are waiting for each other to finish, and thus neither ever does. Deadlock conditions can be difficult to detect." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/25.html> ;
+    :related :CWE-412,
+        :CWE-567,
+        :CWE-662,
+        :CWE-667,
+        :CWE-833,
+        :CWE-1322,
+        :T1499.004 .
+
+:CAPEC-26 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Leveraging Race Conditions" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-26" ;
+    :definition "The adversary targets a race condition occurring when multiple processes access and manipulate the same resource concurrently, and the outcome of the execution depends on the particular order in which the access takes place. The adversary can leverage a race condition by \"running the race\", modifying the resource and modifying the normal execution flow. For instance, a race condition can occur while accessing a file: the adversary can trick the system by replacing the original file with their version and cause the system to read the malicious file." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/26.html> ;
+    :related :CWE-362,
+        :CWE-363,
+        :CWE-366,
+        :CWE-368,
+        :CWE-370,
+        :CWE-662,
+        :CWE-665,
+        :CWE-667,
+        :CWE-689,
+        :CWE-1223,
+        :CWE-1254,
+        :CWE-1298 .
+
+:CAPEC-27 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Leveraging Race Conditions via Symbolic Links" ;
+    rdfs:subClassOf :CAPEC-29 ;
+    :capec-id "CAPEC-27" ;
+    :definition "This attack leverages the use of symbolic links (Symlinks) in order to write to sensitive files. An attacker can create a Symlink link to a target file not otherwise accessible to them. When the privileged program tries to create a temporary file with the same name as the Symlink link, it will actually write to the target file pointed to by the attackers' Symlink link. If the attacker can insert malicious content in the temporary file they will be writing to the sensitive file by using the Symlink. The race occurs because the system checks if the temporary file exists, then creates the file. The attacker would typically create the Symlink during the interval between the check and the creation of the temporary file." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/27.html> ;
+    :related :CWE-61,
+        :CWE-367,
+        :CWE-662,
+        :CWE-667,
+        :CWE-689 .
+
+:CAPEC-28 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Fuzzing" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-28" ;
+    :definition "In this attack pattern, the adversary leverages fuzzing to try to identify weaknesses in the system. Fuzzing is a software security and functionality testing method that feeds randomly constructed input to the system and looks for an indication that a failure in response to that input has occurred. Fuzzing treats the system as a black box and is totally free from any preconceptions or assumptions about the system. Fuzzing can help an attacker discover certain assumptions made about user input in the system. Fuzzing gives an attacker a quick way of potentially uncovering some of these assumptions despite not necessarily knowing anything about the internals of the system. These assumptions can then be turned against the system by specially crafting user input that may allow an attacker to achieve their goals." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/28.html> ;
+    :related :CWE-20,
+        :CWE-74 .
+
+:CAPEC-29 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Leveraging Time-of-Check and Time-of-Use (TOCTOU) Race Conditions" ;
+    rdfs:subClassOf :CAPEC-26 ;
+    :capec-id "CAPEC-29" ;
+    :definition "This attack targets a race condition occurring between the time of check (state) for a resource and the time of use of a resource. A typical example is file access. The adversary can leverage a file access race condition by \"running the race\", meaning that they would modify the resource between the first time the target program accesses the file and the time the target program uses the file. During that period of time, the adversary could replace or modify the file, causing the application to behave unexpectedly." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/29.html> ;
+    :related :CWE-362,
+        :CWE-366,
+        :CWE-367,
+        :CWE-368,
+        :CWE-370,
+        :CWE-662,
+        :CWE-663,
+        :CWE-665,
+        :CWE-691 .
+
+:CAPEC-30 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hijacking a Privileged Thread of Execution" ;
+    rdfs:subClassOf :CAPEC-233 ;
+    :capec-id "CAPEC-30" ;
+    :definition "An adversary hijacks a privileged thread of execution by injecting malicious code into a running process. By using a privleged thread to do their bidding, adversaries can evade process-based detection that would stop an attack that creates a new process. This can lead to an adversary gaining access to the process's memory and can also enable elevated privileges. The most common way to perform this attack is by suspending an existing thread and manipulating its memory." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/30.html> ;
+    :related :CWE-270,
+        :T1055.003 .
+
+:CAPEC-31 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Accessing/Intercepting/Modifying HTTP Cookies" ;
+    rdfs:subClassOf :CAPEC-39,
+        :CAPEC-157 ;
+    :capec-id "CAPEC-31" ;
+    :definition "This attack relies on the use of HTTP Cookies to store credentials, state information and other critical data on client systems. There are several different forms of this attack. The first form of this attack involves accessing HTTP Cookies to mine for potentially sensitive data contained therein. The second form involves intercepting this data as it is transmitted from client to server. This intercepted information is then used by the adversary to impersonate the remote user/session. The third form is when the cookie's content is modified by the adversary before it is sent back to the server. Here the adversary seeks to convince the target server to operate on this falsified information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/31.html> ;
+    :related :CWE-20,
+        :CWE-113,
+        :CWE-302,
+        :CWE-311,
+        :CWE-315,
+        :CWE-384,
+        :CWE-472,
+        :CWE-539,
+        :CWE-565,
+        :CWE-602,
+        :CWE-642,
+        :T1539 .
+
+:CAPEC-32 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Through HTTP Query Strings" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-32" ;
+    :definition "An adversary embeds malicious script code in the parameters of an HTTP query string and convinces a victim to submit the HTTP request that contains the query string to a vulnerable web application. The web application then procedes to use the values parameters without properly validation them first and generates the HTML code that will be executed by the victim's browser." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/32.html> ;
+    :related :CWE-80 .
+
+:CAPEC-33 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP Request Smuggling" ;
+    rdfs:subClassOf :CAPEC-220 ;
+    :capec-id "CAPEC-33" ;
+    :definition "An adversary abuses the flexibility and discrepancies in the parsing and interpretation of HTTP Request messages using various HTTP headers, request-line and body parameters as well as message sizes (denoted by the end of message signaled by a given HTTP header) by different intermediary HTTP agents (e.g., load balancer, reverse proxy, web caching proxies, application firewalls, etc.) to secretly send unauthorized and malicious HTTP requests to a back-end HTTP agent (e.g., web server)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/33.html> ;
+    :related :CAPEC-273,
+        :CWE-444 .
+
+:CAPEC-34 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP Response Splitting" ;
+    rdfs:subClassOf :CAPEC-220 ;
+    :capec-id "CAPEC-34" ;
+    :definition "An adversary manipulates and injects malicious content, in the form of secret unauthorized HTTP responses, into a single HTTP response from a vulnerable or compromised back-end HTTP agent (e.g., web server) or into an already spoofed HTTP response from an adversary controlled domain/site." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/34.html> ;
+    :related :CAPEC-105,
+        :CWE-74,
+        :CWE-113,
+        :CWE-138,
+        :CWE-436 .
+
+:CAPEC-35 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Leverage Executable Code in Non-Executable Files" ;
+    rdfs:subClassOf :CAPEC-636 ;
+    :capec-id "CAPEC-35" ;
+    :definition "An attack of this type exploits a system's trust in configuration and resource files. When the executable loads the resource (such as an image file or configuration file) the attacker has modified the file to either execute malicious code directly or manipulate the target process (e.g. application server) to execute based on the malicious configuration parameters. Since systems are increasingly interrelated mashing up resources from local and remote sources the possibility of this attack occurring is high." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/35.html> ;
+    :related :CAPEC-23,
+        :CAPEC-75,
+        :CWE-59,
+        :CWE-94,
+        :CWE-95,
+        :CWE-96,
+        :CWE-97,
+        :CWE-270,
+        :CWE-272,
+        :CWE-282,
+        :T1027.006,
+        :T1027.009,
+        :T1564.009 .
+
+:CAPEC-36 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Unpublished Interfaces or Functionality" ;
+    rdfs:subClassOf :CAPEC-113 ;
+    :capec-id "CAPEC-36" ;
+    :definition "An adversary searches for and invokes interfaces or functionality that the target system designers did not intend to be publicly available. If interfaces fail to authenticate requests, the attacker may be able to invoke functionality they are not authorized for." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/36.html> ;
+    :related :CWE-306,
+        :CWE-693,
+        :CWE-695,
+        :CWE-1242 .
+
+:CAPEC-37 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Retrieve Embedded Sensitive Data" ;
+    rdfs:subClassOf :CAPEC-167 ;
+    :capec-id "CAPEC-37" ;
+    :definition "An attacker examines a target system to find sensitive data that has been embedded within it. This information can reveal confidential contents, such as account numbers or individual keys/credentials that can be used as an intermediate step in a larger attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/37.html> ;
+    :related :CWE-226,
+        :CWE-311,
+        :CWE-312,
+        :CWE-314,
+        :CWE-315,
+        :CWE-318,
+        :CWE-525,
+        :CWE-1239,
+        :CWE-1258,
+        :CWE-1266,
+        :CWE-1272,
+        :CWE-1278,
+        :CWE-1301,
+        :CWE-1330,
+        :T1005,
+        :T1552.004 .
+
+:CAPEC-38 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Leveraging/Manipulating Configuration File Search Paths" ;
+    rdfs:subClassOf :CAPEC-159 ;
+    :capec-id "CAPEC-38" ;
+    :definition "This pattern of attack sees an adversary load a malicious resource into a program's standard path so that when a known command is executed then the system instead executes the malicious component. The adversary can either modify the search path a program uses, like a PATH variable or classpath, or they can manipulate resources on the path to point to their malicious components. J2EE applications and other component based applications that are built from multiple binaries can have very long list of dependencies to execute. If one of these libraries and/or references is controllable by the attacker then application controls can be circumvented by the attacker." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/38.html> ;
+    :related :CWE-426,
+        :CWE-427,
+        :T1574.007,
+        :T1574.009 .
+
+:CAPEC-39 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulating Opaque Client-based Data Tokens" ;
+    rdfs:subClassOf :CAPEC-22 ;
+    :capec-id "CAPEC-39" ;
+    :definition "In circumstances where an application holds important data client-side in tokens (cookies, URLs, data files, and so forth) that data can be manipulated. If client or server-side application components reinterpret that data as authentication tokens or data (such as store item pricing or wallet information) then even opaquely manipulating that data may bear fruit for an Attacker. In this pattern an attacker undermines the assumption that client side tokens have been adequately protected from tampering through use of encryption or obfuscation." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/39.html> ;
+    :related :CWE-233,
+        :CWE-285,
+        :CWE-302,
+        :CWE-315,
+        :CWE-353,
+        :CWE-384,
+        :CWE-472,
+        :CWE-539,
+        :CWE-565 .
+
+:CAPEC-40 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulating Writeable Terminal Devices" ;
+    rdfs:subClassOf :CAPEC-248 ;
+    :capec-id "CAPEC-40" ;
+    :definition "This attack exploits terminal devices that allow themselves to be written to by other users. The attacker sends command strings to the target terminal device hoping that the target user will hit enter and thereby execute the malicious command with their privileges. The attacker can send the results (such as copying /etc/passwd) to a known directory and collect once the attack has succeeded." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/40.html> ;
+    :related :CWE-77 .
+
+:CAPEC-41 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Meta-characters in E-mail Headers to Inject Malicious Payloads" ;
+    rdfs:subClassOf :CAPEC-134,
+        :CAPEC-242 ;
+    :capec-id "CAPEC-41" ;
+    :definition "This type of attack involves an attacker leveraging meta-characters in email headers to inject improper behavior into email programs. Email software has become increasingly sophisticated and feature-rich. In addition, email applications are ubiquitous and connected directly to the Web making them ideal targets to launch and propagate attacks. As the user demand for new functionality in email applications grows, they become more like browsers with complex rendering and plug in routines. As more email functionality is included and abstracted from the user, this creates opportunities for attackers. Virtually all email applications do not list email header information by default, however the email header contains valuable attacker vectors for the attacker to exploit particularly if the behavior of the email client application is known. Meta-characters are hidden from the user, but can contain scripts, enumerations, probes, and other attacks against the user's system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/41.html> ;
+    :related :CWE-88,
+        :CWE-150,
+        :CWE-697 .
+
+:CAPEC-42 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "MIME Conversion" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-42" ;
+    :definition "An attacker exploits a weakness in the MIME conversion routine to cause a buffer overflow and gain control over the mail server machine. The MIME system is designed to allow various different information formats to be interpreted and sent via e-mail. Attack points exist when data are converted to MIME compatible format and back." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/42.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-119,
+        :CWE-120 .
+
+:CAPEC-43 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploiting Multiple Input Interpretation Layers" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-43" ;
+    :definition "An attacker supplies the target software with input data that contains sequences of special characters designed to bypass input validation logic. This exploit relies on the target making multiples passes over the input data and processing a \"layer\" of special characters with each pass. In this manner, the attacker can disguise input that would otherwise be rejected as invalid by concealing it with layers of special/escape characters that are stripped off by subsequent processing steps. The goal is to first discover cases where the input validation layer executes before one or more parsing layers. That is, user input may go through the following logic in an application: <parser1> --> <input validator> --> <parser2>. In such cases, the attacker will need to provide input that will pass through the input validator, but after passing through parser2, will be converted into something that the input validator was supposed to stop." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/43.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-77,
+        :CWE-78,
+        :CWE-179,
+        :CWE-181,
+        :CWE-183,
+        :CWE-184,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-44 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Overflow Binary Resource File" ;
+    rdfs:subClassOf :CAPEC-23,
+        :CAPEC-100 ;
+    :capec-id "CAPEC-44" ;
+    :definition "An attack of this type exploits a buffer overflow vulnerability in the handling of binary resources. Binary resources may include music files like MP3, image files like JPEG files, and any other binary file. These attacks may pass unnoticed to the client machine through normal usage of files, such as a browser loading a seemingly innocent JPEG file. This can allow the adversary access to the execution stack and execute arbitrary code in the target process." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/44.html> ;
+    :related :CWE-119,
+        :CWE-120,
+        :CWE-697 .
+
+:CAPEC-45 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Buffer Overflow via Symbolic Links" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-45" ;
+    :definition "This type of attack leverages the use of symbolic links to cause buffer overflows. An adversary can try to create or manipulate a symbolic link file such that its contents result in out of bounds data. When the target software processes the symbolic link file, it could potentially overflow internal buffers with insufficient bounds checking." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/45.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-285,
+        :CWE-302,
+        :CWE-680,
+        :CWE-697 .
+
+:CAPEC-46 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Overflow Variables and Tags" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-46" ;
+    :definition "This type of attack leverages the use of tags or variables from a formatted configuration data to cause buffer overflow. The adversary crafts a malicious HTML page or configuration file that includes oversized strings, thus causing an overflow." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/46.html> ;
+    :related :CAPEC-8,
+        :CAPEC-10,
+        :CWE-20,
+        :CWE-74,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-680,
+        :CWE-697,
+        :CWE-733 .
+
+:CAPEC-47 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Buffer Overflow via Parameter Expansion" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-47" ;
+    :definition "In this attack, the target software is given input that the adversary knows will be modified and expanded in size during processing. This attack relies on the target software failing to anticipate that the expanded data may exceed some internal limit, thereby creating a buffer overflow." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/47.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-118,
+        :CWE-119,
+        :CWE-120,
+        :CWE-130,
+        :CWE-131,
+        :CWE-680,
+        :CWE-697 .
+
+:CAPEC-48 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Passing Local Filenames to Functions That Expect a URL" ;
+    rdfs:subClassOf :CAPEC-212 ;
+    :capec-id "CAPEC-48" ;
+    :definition "This attack relies on client side code to access local files and resources instead of URLs. When the client browser is expecting a URL string, but instead receives a request for a local file, that execution is likely to occur in the browser process space with the browser's authority to local files. The attacker can send the results of this request to the local files out to a site that they control. This attack may be used to steal sensitive authentication data (either local or remote), or to gain system profile information to launch further attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/48.html> ;
+    :related :CWE-241,
+        :CWE-706 .
+
+:CAPEC-49 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Password Brute Forcing" ;
+    rdfs:subClassOf :CAPEC-112 ;
+    :capec-id "CAPEC-49" ;
+    :definition "An adversary tries every possible value for a password until they succeed. A brute force attack, if feasible computationally, will always be successful because it will essentially go through all possible passwords given the alphabet used (lower case letters, upper case letters, numbers, symbols, etc.) and the maximum length of the password." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/49.html> ;
+    :related :CWE-257,
+        :CWE-262,
+        :CWE-263,
+        :CWE-307,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-654,
+        :T1110.001 .
+
+:CAPEC-50 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Password Recovery Exploitation" ;
+    rdfs:subClassOf :CAPEC-212 ;
+    :capec-id "CAPEC-50" ;
+    :definition "An attacker may take advantage of the application feature to help users recover their forgotten passwords in order to gain access into the system with the same privileges as the original user. Generally password recovery schemes tend to be weak and insecure." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/50.html> ;
+    :related :CWE-522,
+        :CWE-640 .
+
+:CAPEC-51 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Poison Web Service Registry" ;
+    rdfs:subClassOf :CAPEC-203 ;
+    :capec-id "CAPEC-51" ;
+    :definition "SOA and Web Services often use a registry to perform look up, get schema information, and metadata about services. A poisoned registry can redirect (think phishing for servers) the service requester to a malicious service provider, provide incorrect information in schema or metadata, and delete information about service provider interfaces." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/51.html> ;
+    :related :CWE-74,
+        :CWE-285,
+        :CWE-693 .
+
+:CAPEC-52 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Embedding NULL Bytes" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-52" ;
+    :definition "An adversary embeds one or more null bytes in input to the target software. This attack relies on the usage of a null-valued byte as a string terminator in many environments. The goal is for certain components of the target software to stop processing the input when it encounters the null byte(s)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/52.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-158,
+        :CWE-172,
+        :CWE-173,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-53 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Postfix, Null Terminate, and Backslash" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-53" ;
+    :definition "If a string is passed through a filter of some kind, then a terminal NULL may not be valid. Using alternate representation of NULL allows an adversary to embed the NULL mid-string while postfixing the proper data so that the filter is avoided. One example is a filter that looks for a trailing slash character. If a string insertion is possible, but the slash must exist, an alternate encoding of NULL in mid-string may be used." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/53.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-158,
+        :CWE-172,
+        :CWE-173,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-54 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Query System for Information" ;
+    rdfs:subClassOf :CAPEC-116 ;
+    :capec-id "CAPEC-54" ;
+    :definition "An adversary, aware of an application's location (and possibly authorized to use the application), probes an application's structure and evaluates its robustness by submitting requests and examining responses. Often, this is accomplished by sending variants of expected queries in the hope that these modified queries might return information beyond what the expected set of queries would provide." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/54.html> ;
+    :related :CWE-209 .
+
+:CAPEC-55 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Rainbow Table Password Cracking" ;
+    rdfs:subClassOf :CAPEC-49 ;
+    :capec-id "CAPEC-55" ;
+    :definition "An attacker gets access to the database table where hashes of passwords are stored. They then use a rainbow table of pre-computed hash chains to attempt to look up the original password. Once the original password corresponding to the hash is obtained, the attacker uses the original password to gain access to the system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/55.html> ;
+    :related :CWE-261,
+        :CWE-262,
+        :CWE-263,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-654,
+        :CWE-916,
+        :T1110.002 .
+
+:CAPEC-56 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Removing/short-circuiting 'guard logic'" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-207 : Removing Important Client Functionality. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-56" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/56.html> .
+
+:CAPEC-57 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Utilizing REST's Trust in the System Resource to Obtain Sensitive Data" ;
+    rdfs:subClassOf :CAPEC-157 ;
+    :capec-id "CAPEC-57" ;
+    :definition "This attack utilizes a REST(REpresentational State Transfer)-style applications' trust in the system resources and environment to obtain sensitive data once SSL is terminated." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/57.html> ;
+    :related :CWE-287,
+        :CWE-300,
+        :CWE-693,
+        :T1040 .
+
+:CAPEC-58 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Restful Privilege Elevation" ;
+    rdfs:subClassOf :CAPEC-1,
+        :CAPEC-180 ;
+    :capec-id "CAPEC-58" ;
+    :definition "An adversary identifies a Rest HTTP (Get, Put, Delete) style permission method allowing them to perform various malicious actions upon server data due to lack of access control mechanisms implemented within the application service accepting HTTP messages." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/58.html> ;
+    :related :CWE-267,
+        :CWE-269 .
+
+:CAPEC-59 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Session Credential Falsification through Prediction" ;
+    rdfs:subClassOf :CAPEC-196 ;
+    :capec-id "CAPEC-59" ;
+    :definition "This attack targets predictable session ID in order to gain privileges. The attacker can predict the session ID used during a transaction to perform spoofing and session hijacking." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/59.html> ;
+    :related :CWE-6,
+        :CWE-200,
+        :CWE-285,
+        :CWE-290,
+        :CWE-330,
+        :CWE-331,
+        :CWE-346,
+        :CWE-384,
+        :CWE-488,
+        :CWE-539,
+        :CWE-693 .
+
+:CAPEC-60 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Reusing Session IDs (aka Session Replay)" ;
+    rdfs:subClassOf :CAPEC-593 ;
+    :capec-id "CAPEC-60" ;
+    :definition "This attack targets the reuse of valid session ID to spoof the target system in order to gain privileges. The attacker tries to reuse a stolen session ID used previously during a transaction to perform spoofing and session hijacking. Another name for this type of attack is Session Replay." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/60.html> ;
+    :related :CWE-200,
+        :CWE-285,
+        :CWE-290,
+        :CWE-294,
+        :CWE-346,
+        :CWE-384,
+        :CWE-488,
+        :CWE-539,
+        :CWE-664,
+        :CWE-732,
+        :T1134.001,
+        :T1550.004 .
+
+:CAPEC-61 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Session Fixation" ;
+    rdfs:subClassOf :CAPEC-593 ;
+    :capec-id "CAPEC-61" ;
+    :definition "The attacker induces a client to establish a session with the target software using a session identifier provided by the attacker. Once the user successfully authenticates to the target software, the attacker uses the (now privileged) session identifier in their own transactions. This attack leverages the fact that the target software either relies on client-generated session identifiers or maintains the same session identifiers after privilege elevation." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/61.html> ;
+    :related :CWE-384,
+        :CWE-664,
+        :CWE-732 .
+
+:CAPEC-62 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross Site Request Forgery" ;
+    rdfs:subClassOf :CAPEC-21 ;
+    :capec-id "CAPEC-62" ;
+    :definition "An attacker crafts malicious web links and distributes them (via web pages, email, etc.), typically in a targeted manner, hoping to induce users to click on the link and execute the malicious action against some third-party application. If successful, the action embedded in the malicious link will be processed and accepted by the targeted application with the users' privilege level. This type of attack leverages the persistence and implicit trust placed in user session cookies by many web applications today. In such an architecture, once the user authenticates to an application and a session cookie is created on the user's system, all following transactions for that session are authenticated using that cookie including potential actions initiated by an attacker and simply \"riding\" the existing session cookie." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/62.html> ;
+    :related :CWE-306,
+        :CWE-352,
+        :CWE-664,
+        :CWE-732,
+        :CWE-1275 .
+
+:CAPEC-63 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross-Site Scripting (XSS)" ;
+    rdfs:subClassOf :CAPEC-242 ;
+    :capec-id "CAPEC-63" ;
+    :definition "An adversary embeds malicious scripts in content that will be served to web browsers. The goal of the attack is for the target software, the client-side browser, to execute the script with the users' privilege level. An attack of this type exploits a programs' vulnerabilities that are brought on by allowing remote hosts to execute code and scripts. Web browsers, for example, have some simple security controls in place, but if a remote attacker is allowed to execute scripts (through injecting them in to user-generated content like bulletin boards) then these controls may be bypassed. Further, these attacks are very difficult for an end user to detect." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/63.html> ;
+    :related :CWE-20,
+        :CWE-79 .
+
+:CAPEC-64 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Slashes and URL Encoding Combined to Bypass Validation Logic" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-64" ;
+    :definition "This attack targets the encoding of the URL combined with the encoding of the slash characters. An attacker can take advantage of the multiple ways of encoding a URL and abuse the interpretation of the URL. A URL may contain special character that need special syntax handling in order to be interpreted. Special characters are represented using a percentage character followed by two digits representing the octet code of the original character (%HEX-CODE). For instance US-ASCII space character would be represented with %20. This is often referred as escaped ending or percent-encoding. Since the server decodes the URL from the requests, it may restrict the access to some URL paths by validating and filtering out the URL requests it received. An attacker will try to craft an URL with a sequence of special characters which once interpreted by the server will be equivalent to a forbidden URL. It can be difficult to protect against this attack since the URL can contain other format of encoding such as UTF-8 encoding, Unicode-encoding, etc." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/64.html> ;
+    :related :CAPEC-80,
+        :CWE-20,
+        :CWE-22,
+        :CWE-73,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-177,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-65 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Sniff Application Code" ;
+    rdfs:subClassOf :CAPEC-157 ;
+    :capec-id "CAPEC-65" ;
+    :definition "An adversary passively sniffs network communications and captures application code bound for an authorized client. Once obtained, they can use it as-is, or through reverse-engineering glean sensitive information or exploit the trust relationship between the client and server. Such code may belong to a dynamic update to the client, a patch being applied to a client component or any such interaction where the client is authorized to communicate with the server." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/65.html> ;
+    :related :CWE-311,
+        :CWE-318,
+        :CWE-319,
+        :CWE-693,
+        :T1040 .
+
+:CAPEC-66 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SQL Injection" ;
+    rdfs:subClassOf :CAPEC-248 ;
+    :capec-id "CAPEC-66" ;
+    :definition "This attack exploits target software that constructs SQL statements based on user input. An attacker crafts input strings so that when the target software constructs SQL statements based on the input, the resulting SQL statement performs actions other than those the application intended. SQL Injection results from failure of the application to appropriately validate input." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/66.html> ;
+    :related :CWE-89,
+        :CWE-1286 .
+
+:CAPEC-67 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "String Format Overflow in syslog()" ;
+    rdfs:subClassOf :CAPEC-100,
+        :CAPEC-135 ;
+    :capec-id "CAPEC-67" ;
+    :definition "This attack targets applications and software that uses the syslog() function insecurely. If an application does not explicitely use a format string parameter in a call to syslog(), user input can be placed in the format string parameter leading to a format string injection attack. Adversaries can then inject malicious format string commands into the function call leading to a buffer overflow. There are many reported software vulnerabilities with the root cause being a misuse of the syslog() function." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/67.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-120,
+        :CWE-134,
+        :CWE-680,
+        :CWE-697 .
+
+:CAPEC-68 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Subvert Code-signing Facilities" ;
+    rdfs:subClassOf :CAPEC-233 ;
+    :capec-id "CAPEC-68" ;
+    :definition "Many languages use code signing facilities to vouch for code's identity and to thus tie code to its assigned privileges within an environment. Subverting this mechanism can be instrumental in an attacker escalating privilege. Any means of subverting the way that a virtual machine enforces code signing classifies for this style of attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/68.html> ;
+    :related :CWE-325,
+        :CWE-328,
+        :CWE-1326,
+        :T1553.002 .
+
+:CAPEC-69 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Target Programs with Elevated Privileges" ;
+    rdfs:subClassOf :CAPEC-233 ;
+    :capec-id "CAPEC-69" ;
+    :definition "This attack targets programs running with elevated privileges. The adversary tries to leverage a vulnerability in the running program and get arbitrary code to execute with elevated privileges." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/69.html> ;
+    :related :CWE-15,
+        :CWE-250 .
+
+:CAPEC-70 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Try Common or Default Usernames and Passwords" ;
+    rdfs:subClassOf :CAPEC-49 ;
+    :capec-id "CAPEC-70" ;
+    :definition "An adversary may try certain common or default usernames and passwords to gain access into the system and perform unauthorized actions. An adversary may try an intelligent brute force using empty passwords, known vendor default credentials, as well as a dictionary of common usernames and passwords. Many vendor products come preconfigured with default (and thus well-known) usernames and passwords that should be deleted prior to usage in a production environment. It is a common mistake to forget to remove these default login credentials. Another problem is that users would pick very simple (common) passwords (e.g. \"secret\" or \"password\") that make it easier for the attacker to gain access to the system compared to using a brute force attack or even a dictionary attack using a full dictionary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/70.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-654,
+        :CWE-798,
+        :T1078.001 .
+
+:CAPEC-71 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Unicode Encoding to Bypass Validation Logic" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-71" ;
+    :definition "An attacker may provide a Unicode string to a system component that is not Unicode aware and use that to circumvent the filter or cause the classifying mechanism to fail to properly understanding the request. That may allow the attacker to slip malicious data past the content filter and/or possibly cause the application to route the request incorrectly." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/71.html> ;
+    :related :CAPEC-80,
+        :CWE-20,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-176,
+        :CWE-179,
+        :CWE-180,
+        :CWE-183,
+        :CWE-184,
+        :CWE-692,
+        :CWE-697 .
+
+:CAPEC-72 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "URL Encoding" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-72" ;
+    :definition "This attack targets the encoding of the URL. An adversary can take advantage of the multiple way of encoding an URL and abuse the interpretation of the URL." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/72.html> ;
+    :related :CWE-20,
+        :CWE-73,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-177 .
+
+:CAPEC-73 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "User-Controlled Filename" ;
+    rdfs:subClassOf :CAPEC-165 ;
+    :capec-id "CAPEC-73" ;
+    :definition "An attack of this type involves an adversary inserting malicious characters (such as a XSS redirection) into a filename, directly or indirectly that is then used by the target software to generate HTML text or other potentially executable content. Many websites rely on user-generated content and dynamically build resources like files, filenames, and URL links directly from user supplied data. In this attack pattern, the attacker uploads code that can execute in the client browser and/or redirect the client browser to a site that the attacker owns. All XSS attack payload variants can be used to pass and exploit these vulnerabilities." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/73.html> ;
+    :related :CWE-20,
+        :CWE-86,
+        :CWE-96,
+        :CWE-116,
+        :CWE-184,
+        :CWE-348,
+        :CWE-350,
+        :CWE-697 .
+
+:CAPEC-74 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulating State" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-74" ;
+    :definition "The adversary modifies state information maintained by the target software or causes a state transition in hardware. If successful, the target will use this tainted state and execute in an unintended manner." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/74.html> ;
+    :related :CWE-315,
+        :CWE-353,
+        :CWE-372,
+        :CWE-693,
+        :CWE-1245,
+        :CWE-1253,
+        :CWE-1265,
+        :CWE-1271 .
+
+:CAPEC-75 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulating Writeable Configuration Files" ;
+    rdfs:subClassOf :CAPEC-176 ;
+    :capec-id "CAPEC-75" ;
+    :definition "Generally these are manually edited files that are not in the preview of the system administrators, any ability on the attackers' behalf to modify these files, for example in a CVS repository, gives unauthorized access directly to the application, the same as authorized users." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/75.html> ;
+    :related :CAPEC-35,
+        :CWE-77,
+        :CWE-99,
+        :CWE-346,
+        :CWE-349,
+        :CWE-353,
+        :CWE-354 .
+
+:CAPEC-76 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulating Web Input to File System Calls" ;
+    rdfs:subClassOf :CAPEC-126 ;
+    :capec-id "CAPEC-76" ;
+    :definition "An attacker manipulates inputs to the target software which the target software passes to file system calls in the OS. The goal is to gain access to, and perhaps modify, areas of the file system that the target software did not intend to be accessible." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/76.html> ;
+    :related :CWE-15,
+        :CWE-22,
+        :CWE-23,
+        :CWE-59,
+        :CWE-73,
+        :CWE-74,
+        :CWE-77,
+        :CWE-272,
+        :CWE-285,
+        :CWE-346,
+        :CWE-348 .
+
+:CAPEC-77 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulating User-Controlled Variables" ;
+    rdfs:subClassOf :CAPEC-22 ;
+    :capec-id "CAPEC-77" ;
+    :definition "This attack targets user controlled variables (DEBUG=1, PHP Globals, and So Forth). An adversary can override variables leveraging user-supplied, untrusted query variables directly used on the application server without any data sanitization. In extreme cases, the adversary can change variables controlling the business logic of the application. For instance, in languages like PHP, a number of poorly set default configurations may allow the user to override variables." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/77.html> ;
+    :related :CWE-15,
+        :CWE-94,
+        :CWE-96,
+        :CWE-285,
+        :CWE-302,
+        :CWE-473,
+        :CWE-1321 .
+
+:CAPEC-78 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Escaped Slashes in Alternate Encoding" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-78" ;
+    :definition "This attack targets the use of the backslash in alternate encoding. An adversary can provide a backslash as a leading character and causes a parser to believe that the next character is special. This is called an escape. By using that trick, the adversary tries to exploit alternate ways to encode the same character which leads to filter problems and opens avenues to attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/78.html> ;
+    :related :CWE-20,
+        :CWE-22,
+        :CWE-73,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-180,
+        :CWE-181,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-79 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using Slashes in Alternate Encoding" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-79" ;
+    :definition "This attack targets the encoding of the Slash characters. An adversary would try to exploit common filtering problems related to the use of the slashes characters to gain access to resources on the target host. Directory-driven systems, such as file systems and databases, typically use the slash character to indicate traversal between directories or other container components. For murky historical reasons, PCs (and, as a result, Microsoft OSs) choose to use a backslash, whereas the UNIX world typically makes use of the forward slash. The schizophrenic result is that many MS-based systems are required to understand both forms of the slash. This gives the adversary many opportunities to discover and abuse a number of common filtering problems. The goal of this pattern is to discover server software that only applies filters to one version, but not the other." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/79.html> ;
+    :related :CWE-20,
+        :CWE-22,
+        :CWE-73,
+        :CWE-74,
+        :CWE-173,
+        :CWE-180,
+        :CWE-181,
+        :CWE-185,
+        :CWE-200,
+        :CWE-697,
+        :CWE-707 .
+
+:CAPEC-80 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using UTF-8 Encoding to Bypass Validation Logic" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-80" ;
+    :definition "This attack is a specific variation on leveraging alternate encodings to bypass validation logic. This attack leverages the possibility to encode potentially harmful input in UTF-8 and submit it to applications not expecting or effective at validating this encoding standard making input filtering difficult. UTF-8 (8-bit UCS/Unicode Transformation Format) is a variable-length character encoding for Unicode. Legal UTF-8 characters are one to four bytes long. However, early version of the UTF-8 specification got some entries wrong (in some cases it permitted overlong characters). UTF-8 encoders are supposed to use the \"shortest possible\" encoding, but naive decoders may accept encodings that are longer than necessary. According to the RFC 3629, a particularly subtle form of this attack can be carried out against a parser which performs security-critical validity checks against the UTF-8 encoded form of its input, but interprets certain illegal octet sequences as characters." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/80.html> ;
+    :related :CAPEC-64,
+        :CAPEC-71,
+        :CWE-20,
+        :CWE-73,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-180,
+        :CWE-181,
+        :CWE-692,
+        :CWE-697 .
+
+:CAPEC-81 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Web Server Logs Tampering" ;
+    rdfs:subClassOf :CAPEC-268 ;
+    :capec-id "CAPEC-81" ;
+    :definition "Web Logs Tampering attacks involve an attacker injecting, deleting or otherwise tampering with the contents of web logs typically for the purposes of masking other malicious behavior. Additionally, writing malicious data to log files may target jobs, filters, reports, and other agents that process the logs in an asynchronous attack pattern. This pattern of attack is similar to \"Log Injection-Tampering-Forging\" except that in this case, the attack is targeting the logs of the web server and not the application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/81.html> ;
+    :related :CWE-20,
+        :CWE-75,
+        :CWE-93,
+        :CWE-96,
+        :CWE-116,
+        :CWE-117,
+        :CWE-150,
+        :CWE-221,
+        :CWE-276,
+        :CWE-279 .
+
+:CAPEC-82 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Violating Implicit Assumptions Regarding XML Content (aka XML Denial of Service (XDoS))" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-230: XML Nested Payloads, CAPEC-231: XML Oversized Payloads, and CAPEC-147: XML Ping of Death. Please refer to these CAPECs going forward." ;
+    :capec-id "CAPEC-82" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/82.html> .
+
+:CAPEC-83 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XPath Injection" ;
+    rdfs:subClassOf :CAPEC-250 ;
+    :capec-id "CAPEC-83" ;
+    :definition "An attacker can craft special user-controllable input consisting of XPath expressions to inject the XML database and bypass authentication or glean information that they normally would not be able to. XPath Injection enables an attacker to talk directly to the XML database, thus bypassing the application completely. XPath Injection results from the failure of an application to properly sanitize input used as part of dynamic XPath expressions used to query an XML database." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/83.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-91,
+        :CWE-707 .
+
+:CAPEC-84 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XQuery Injection" ;
+    rdfs:subClassOf :CAPEC-250 ;
+    :capec-id "CAPEC-84" ;
+    :definition "This attack utilizes XQuery to probe and attack server systems; in a similar manner that SQL Injection allows an attacker to exploit SQL calls to RDBMS, XQuery Injection uses improperly validated data that is passed to XQuery commands to traverse and execute commands that the XQuery routines have access to. XQuery injection can be used to enumerate elements on the victim's environment, inject commands to the local host, or execute queries to remote files and data sources." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/84.html> ;
+    :related :CWE-74,
+        :CWE-707 .
+
+:CAPEC-85 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "AJAX Footprinting" ;
+    rdfs:subClassOf :CAPEC-580 ;
+    :capec-id "CAPEC-85" ;
+    :definition "This attack utilizes the frequent client-server roundtrips in Ajax conversation to scan a system. While Ajax does not open up new vulnerabilities per se, it does optimize them from an attacker point of view. A common first step for an attacker is to footprint the target environment to understand what attacks will work. Since footprinting relies on enumeration, the conversational pattern of rapid, multiple requests and responses that are typical in Ajax applications enable an attacker to look for many vulnerabilities, well-known ports, network locations and so on. The knowledge gained through Ajax fingerprinting can be used to support other attacks, such as XSS." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/85.html> ;
+    :related :CWE-20,
+        :CWE-79,
+        :CWE-86,
+        :CWE-96,
+        :CWE-113,
+        :CWE-116,
+        :CWE-184,
+        :CWE-348,
+        :CWE-692 .
+
+:CAPEC-86 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Through HTTP Headers" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-86" ;
+    :definition "An adversary exploits web applications that generate web content, such as links in a HTML page, based on unvalidated or improperly validated data submitted by other actors. XSS in HTTP Headers attacks target the HTTP headers which are hidden from most users and may not be validated by web applications." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/86.html> ;
+    :related :CWE-80 .
+
+:CAPEC-87 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Forceful Browsing" ;
+    rdfs:subClassOf :CAPEC-115 ;
+    :capec-id "CAPEC-87" ;
+    :definition "An attacker employs forceful browsing (direct URL entry) to access portions of a website that are otherwise unreachable. Usually, a front controller or similar design pattern is employed to protect access to portions of a web application. Forceful browsing enables an attacker to access information, perform privileged operations and otherwise reach sections of the web application that have been improperly protected." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/87.html> ;
+    :related :CWE-285,
+        :CWE-425,
+        :CWE-693 .
+
+:CAPEC-88 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "OS Command Injection" ;
+    rdfs:subClassOf :CAPEC-248 ;
+    :capec-id "CAPEC-88" ;
+    :definition "In this type of an attack, an adversary injects operating system commands into existing application functions. An application that uses untrusted input to build command strings is vulnerable. An adversary can leverage OS command injection in an application to elevate privileges, execute arbitrary commands and compromise the underlying operating system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/88.html> ;
+    :related :CWE-20,
+        :CWE-78,
+        :CWE-88,
+        :CWE-697 .
+
+:CAPEC-89 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pharming" ;
+    rdfs:subClassOf :CAPEC-151 ;
+    :capec-id "CAPEC-89" ;
+    :definition "A pharming attack occurs when the victim is fooled into entering sensitive data into supposedly trusted locations, such as an online bank site or a trading platform. An attacker can impersonate these supposedly trusted sites and have the victim be directed to their site rather than the originally intended one. Pharming does not require script injection or clicking on malicious links for the attack to succeed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/89.html> ;
+    :related :CWE-346,
+        :CWE-350 .
+
+:CAPEC-90 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Reflection Attack in Authentication Protocol" ;
+    rdfs:subClassOf :CAPEC-114,
+        :CAPEC-272 ;
+    :capec-id "CAPEC-90" ;
+    :definition "An adversary can abuse an authentication protocol susceptible to reflection attack in order to defeat it. Doing so allows the adversary illegitimate access to the target system, without possessing the requisite credentials. Reflection attacks are of great concern to authentication protocols that rely on a challenge-handshake or similar mechanism. An adversary can impersonate a legitimate user and can gain illegitimate access to the system by successfully mounting a reflection attack during authentication." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/90.html> ;
+    :related :CWE-301,
+        :CWE-303 .
+
+:CAPEC-91 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: XSS in IMG Tags" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is contained in the existing attack pattern \"CAPEC-18 : XSS Targeting Non-Script Elements\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-91" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/91.html> .
+
+:CAPEC-92 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Forced Integer Overflow" ;
+    rdfs:subClassOf :CAPEC-128 ;
+    :capec-id "CAPEC-92" ;
+    :definition "This attack forces an integer variable to go out of range. The integer variable is often used as an offset such as size of memory allocation or similarly. The attacker would typically control the value of such variable and try to get it out of range. For instance the integer in question is incremented past the maximum possible value, it may wrap to become a very small, or negative number, therefore providing a very incorrect value which can lead to unexpected behavior. At worst the attacker can execute arbitrary code." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/92.html> ;
+    :related :CWE-120,
+        :CWE-122,
+        :CWE-128,
+        :CWE-190,
+        :CWE-196,
+        :CWE-680,
+        :CWE-697 .
+
+:CAPEC-93 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Log Injection-Tampering-Forging" ;
+    rdfs:subClassOf :CAPEC-268 ;
+    :capec-id "CAPEC-93" ;
+    :definition "This attack targets the log files of the target host. The attacker injects, manipulates or forges malicious log entries in the log file, allowing them to mislead a log audit, cover traces of attack, or perform other malicious actions. The target host is not properly controlling log access. As a result tainted data is resulting in the log files leading to a failure in accountability, non-repudiation and incident forensics capability." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/93.html> ;
+    :related :CWE-75,
+        :CWE-117,
+        :CWE-150 .
+
+:CAPEC-94 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Adversary in the Middle (AiTM)" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-94" ;
+    :definition "An adversary targets the communication between two components (typically client and server), in order to alter or obtain data from transactions. A general approach entails the adversary placing themself within the communication channel between the two components." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/94.html> ;
+    :related :CWE-287,
+        :CWE-290,
+        :CWE-294,
+        :CWE-300,
+        :CWE-593,
+        :T1557 .
+
+:CAPEC-95 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "WSDL Scanning" ;
+    rdfs:subClassOf :CAPEC-54 ;
+    :capec-id "CAPEC-95" ;
+    :definition "This attack targets the WSDL interface made available by a web service. The attacker may scan the WSDL interface to reveal sensitive information about invocation patterns, underlying technology implementations and associated vulnerabilities. This type of probing is carried out to perform more serious attacks (e.g. parameter tampering, malicious content injection, command injection, etc.). WSDL files provide detailed information about the services ports and bindings available to consumers. For instance, the attacker can submit special characters or malicious content to the Web service and can cause a denial of service condition or illegal access to database records. In addition, the attacker may try to guess other private methods by using the information provided in the WSDL files." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/95.html> ;
+    :related :CWE-538 .
+
+:CAPEC-96 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Block Access to Libraries" ;
+    rdfs:subClassOf :CAPEC-603 ;
+    :capec-id "CAPEC-96" ;
+    :definition "An application typically makes calls to functions that are a part of libraries external to the application. These libraries may be part of the operating system or they may be third party libraries. It is possible that the application does not handle situations properly where access to these libraries has been blocked. Depending on the error handling within the application, blocked access to libraries may leave the system in an insecure state that could be leveraged by an attacker." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/96.html> ;
+    :related :CWE-589 .
+
+:CAPEC-97 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cryptanalysis" ;
+    rdfs:subClassOf :CAPEC-192 ;
+    :capec-id "CAPEC-97" ;
+    :definition "Cryptanalysis is a process of finding weaknesses in cryptographic algorithms and using these weaknesses to decipher the ciphertext without knowing the secret key (instance deduction). Sometimes the weakness is not in the cryptographic algorithm itself, but rather in how it is applied that makes cryptanalysis successful. An attacker may have other goals as well, such as: Total Break (finding the secret key), Global Deduction (finding a functionally equivalent algorithm for encryption and decryption that does not require knowledge of the secret key), Information Deduction (gaining some information about plaintexts or ciphertexts that was not previously known) and Distinguishing Algorithm (the attacker has the ability to distinguish the output of the encryption (ciphertext) from a random permutation of bits)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/97.html> ;
+    :related :CWE-327,
+        :CWE-1204,
+        :CWE-1240,
+        :CWE-1241,
+        :CWE-1279 .
+
+:CAPEC-98 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Phishing" ;
+    rdfs:subClassOf :CAPEC-151 ;
+    :capec-id "CAPEC-98" ;
+    :definition "Phishing is a social engineering technique where an attacker masquerades as a legitimate entity with which the victim might do business in order to prompt the user to reveal some confidential information (very frequently authentication credentials) that can later be used by an attacker. Phishing is essentially a form of information gathering or \"fishing\" for information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/98.html> ;
+    :related :CWE-451,
+        :T1566,
+        :T1598 .
+
+:CAPEC-99 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: XML Parser Attack" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-230: XML Nested Payloads and CAPEC-231: XML Oversized Payloads. Please refer to these CAPECs going forward." ;
+    :capec-id "CAPEC-99" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/99.html> .
+
+:CAPEC-100 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Overflow Buffers" ;
+    rdfs:subClassOf :CAPEC-123 ;
+    :capec-id "CAPEC-100" ;
+    :definition "Buffer Overflow attacks target improper or missing bounds checking on buffer operations, typically triggered by input injected by an adversary. As a consequence, an adversary is able to write past the boundaries of allocated buffer regions in memory, causing a program crash or potentially redirection of execution as per the adversaries' choice." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/100.html> ;
+    :related :CWE-119,
+        :CWE-120,
+        :CWE-129,
+        :CWE-131,
+        :CWE-680,
+        :CWE-805 .
+
+:CAPEC-101 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Server Side Include (SSI) Injection" ;
+    rdfs:subClassOf :CAPEC-253 ;
+    :capec-id "CAPEC-101" ;
+    :definition "An attacker can use Server Side Include (SSI) Injection to send code to a web application that then gets executed by the web server. Doing so enables the attacker to achieve similar results to Cross Site Scripting, viz., arbitrary code execution and information disclosure, albeit on a more limited scale, since the SSI directives are nowhere near as powerful as a full-fledged scripting language. Nonetheless, the attacker can conveniently gain access to sensitive files, such as password files, and execute shell commands." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/101.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-97 .
+
+:CAPEC-102 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Session Sidejacking" ;
+    rdfs:subClassOf :CAPEC-593 ;
+    :capec-id "CAPEC-102" ;
+    :definition "Session sidejacking takes advantage of an unencrypted communication channel between a victim and target system. The attacker sniffs traffic on a network looking for session tokens in unencrypted traffic. Once a session token is captured, the attacker performs malicious actions by using the stolen token with the targeted application to impersonate the victim. This attack is a specific method of session hijacking, which is exploiting a valid session token to gain unauthorized access to a target system or information. Other methods to perform a session hijacking are session fixation, cross-site scripting, or compromising a user or server machine and stealing the session token." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/102.html> ;
+    :related :CWE-294,
+        :CWE-319,
+        :CWE-522,
+        :CWE-523,
+        :CWE-614 .
+
+:CAPEC-103 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Clickjacking" ;
+    rdfs:subClassOf :CAPEC-173 ;
+    :capec-id "CAPEC-103" ;
+    :definition "An adversary tricks a victim into unknowingly initiating some action in one system while interacting with the UI from a seemingly completely different, usually an adversary controlled or intended, system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/103.html> ;
+    :related :CWE-1021 .
+
+:CAPEC-104 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross Zone Scripting" ;
+    rdfs:subClassOf :CAPEC-233 ;
+    :capec-id "CAPEC-104" ;
+    :definition "An attacker is able to cause a victim to load content into their web-browser that bypasses security zone controls and gain access to increased privileges to execute scripting code or other web objects such as unsigned ActiveX controls or applets. This is a privilege elevation attack targeted at zone-based web-browser security." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/104.html> ;
+    :related :CWE-20,
+        :CWE-116,
+        :CWE-250,
+        :CWE-285,
+        :CWE-638 .
+
+:CAPEC-105 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP Request Splitting" ;
+    rdfs:subClassOf :CAPEC-220 ;
+    :capec-id "CAPEC-105" ;
+    :definition "An adversary abuses the flexibility and discrepancies in the parsing and interpretation of HTTP Request messages by different intermediary HTTP agents (e.g., load balancer, reverse proxy, web caching proxies, application firewalls, etc.) to split a single HTTP request into multiple unauthorized and malicious HTTP requests to a back-end HTTP agent (e.g., web server)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/105.html> ;
+    :related :CAPEC-34,
+        :CWE-74,
+        :CWE-113,
+        :CWE-138,
+        :CWE-436 .
+
+:CAPEC-106 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: XSS through Log Files" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it referes to an existing chain relationship between \"CAPEC-93 : Log Injection-Tampering-Forging\" and \"CAPEC-63 : Cross-Site Scripting\". Please refer to these CAPECs going forward." ;
+    :capec-id "CAPEC-106" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/106.html> .
+
+:CAPEC-107 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross Site Tracing" ;
+    rdfs:subClassOf :CAPEC-593 ;
+    :capec-id "CAPEC-107" ;
+    :definition "Cross Site Tracing (XST) enables an adversary to steal the victim's session cookie and possibly other authentication credentials transmitted in the header of the HTTP request when the victim's browser communicates to a destination system's web server." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/107.html> ;
+    :related :CWE-648,
+        :CWE-693 .
+
+:CAPEC-108 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Command Line Execution through SQL Injection" ;
+    rdfs:subClassOf :CAPEC-66 ;
+    :capec-id "CAPEC-108" ;
+    :definition "An attacker uses standard SQL injection methods to inject data into the command line for execution. This could be done directly through misuse of directives such as MSSQL_xp_cmdshell or indirectly through injection of data into the database that would be interpreted as shell commands. Sometime later, an unscrupulous backend application (or could be part of the functionality of the same application) fetches the injected data stored in the database and uses this data as command line arguments without performing proper validation. The malicious data escapes that data plane by spawning new commands to be executed on the host." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/108.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-78,
+        :CWE-89,
+        :CWE-114 .
+
+:CAPEC-109 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Object Relational Mapping Injection" ;
+    rdfs:subClassOf :CAPEC-66 ;
+    :capec-id "CAPEC-109" ;
+    :definition "An attacker leverages a weakness present in the database access layer code generated with an Object Relational Mapping (ORM) tool or a weakness in the way that a developer used a persistence framework to inject their own SQL commands to be executed against the underlying database. The attack here is similar to plain SQL injection, except that the application does not use JDBC to directly talk to the database, but instead it uses a data access layer generated by an ORM tool or framework (e.g. Hibernate). While most of the time code generated by an ORM tool contains safe access methods that are immune to SQL injection, sometimes either due to some weakness in the generated code or due to the fact that the developer failed to use the generated access methods properly, SQL injection is still possible." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/109.html> ;
+    :related :CWE-20,
+        :CWE-89,
+        :CWE-564 .
+
+:CAPEC-110 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SQL Injection through SOAP Parameter Tampering" ;
+    rdfs:subClassOf :CAPEC-66 ;
+    :capec-id "CAPEC-110" ;
+    :definition "An attacker modifies the parameters of the SOAP message that is sent from the service consumer to the service provider to initiate a SQL injection attack. On the service provider side, the SOAP message is parsed and parameters are not properly validated before being used to access a database in a way that does not use parameter binding, thus enabling the attacker to control the structure of the executed SQL query. This pattern describes a SQL injection attack with the delivery mechanism being a SOAP message." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/110.html> ;
+    :related :CWE-20,
+        :CWE-89 .
+
+:CAPEC-111 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "JSON Hijacking (aka JavaScript Hijacking)" ;
+    rdfs:subClassOf :CAPEC-212 ;
+    :capec-id "CAPEC-111" ;
+    :definition "An attacker targets a system that uses JavaScript Object Notation (JSON) as a transport mechanism between the client and the server (common in Web 2.0 systems using AJAX) to steal possibly confidential information transmitted from the server back to the client inside the JSON object by taking advantage of the loophole in the browser's Same Origin Policy that does not prohibit JavaScript from one website to be included and executed in the context of another website." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/111.html> ;
+    :related :CWE-345,
+        :CWE-346,
+        :CWE-352 .
+
+:CAPEC-112 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Brute Force" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-112" ;
+    :definition "In this attack, some asset (information, functionality, identity, etc.) is protected by a finite secret value. The attacker attempts to gain access to this asset by using trial-and-error to exhaustively explore all the possible secret values in the hope of finding the secret (or a value that is functionally equivalent) that will unlock the asset." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/112.html> ;
+    :related :CWE-326,
+        :CWE-330,
+        :CWE-521,
+        :T1110 .
+
+:CAPEC-113 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Interface Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-113" ;
+    :definition "An adversary manipulates the use or processing of an interface (e.g. Application Programming Interface (API) or System-on-Chip (SoC)) resulting in an adverse impact upon the security of the system implementing the interface. This can allow the adversary to bypass access control and/or execute functionality not intended by the interface implementation, possibly compromising the system which integrates the interface. Interface manipulation can take on a number of forms including forcing the unexpected use of an interface or the use of an interface in an unintended way." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/113.html> ;
+    :related :CWE-1192 .
+
+:CAPEC-114 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Authentication Abuse" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-114" ;
+    :definition "An attacker obtains unauthorized access to an application, service or device either through knowledge of the inherent weaknesses of an authentication mechanism, or by exploiting a flaw in the authentication scheme's implementation. In such an attack an authentication mechanism is functioning but a carefully controlled sequence of events causes the mechanism to grant access to the attacker." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/114.html> ;
+    :related :CWE-287,
+        :CWE-1244,
+        :T1548 .
+
+:CAPEC-115 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Authentication Bypass" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-115" ;
+    :definition "An attacker gains access to application, service, or device with the privileges of an authorized or privileged user by evading or circumventing an authentication mechanism. The attacker is therefore able to access protected data without authentication ever having taken place." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/115.html> ;
+    :related :CWE-287,
+        :T1548 .
+
+:CAPEC-116 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Excavation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-116" ;
+    :definition "An adversary actively probes the target in a manner that is designed to solicit information that could be leveraged for malicious purposes." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/116.html> ;
+    :related :CWE-200,
+        :CWE-1243 .
+
+:CAPEC-117 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Interception" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-117" ;
+    :definition "An adversary monitors data streams to or from the target for information gathering purposes. This attack may be undertaken to solely gather sensitive information or to support a further attack against the target. This attack pattern can involve sniffing network traffic as well as other types of data streams (e.g. radio). The adversary can attempt to initiate the establishment of a data stream or passively observe the communications as they unfold. In all variants of this attack, the adversary is not the intended recipient of the data stream. In contrast to other means of gathering information (e.g., targeting data leaks), the adversary must actively position themself so as to observe explicit data channels (e.g. network traffic) and read the content. However, this attack differs from a Adversary-In-the-Middle (CAPEC-94) attack, as the adversary does not alter the content of the communications nor forward data to the intended recipient." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/117.html> ;
+    :related :CWE-319 .
+
+:CAPEC-120 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Double Encoding" ;
+    rdfs:subClassOf :CAPEC-267 ;
+    :capec-id "CAPEC-120" ;
+    :definition "The adversary utilizes a repeating of the encoding process for a set of characters (that is, character encoding a character encoding of a character) to obfuscate the payload of a particular request. This may allow the adversary to bypass filters that attempt to detect illegal characters or strings, such as those that might be used in traversal or injection attacks. Filters may be able to catch illegal encoded strings, but may not catch doubly encoded strings. For example, a dot (.), often used in path traversal attacks and therefore often blocked by filters, could be URL encoded as %2E. However, many filters recognize this encoding and would still block the request. In a double encoding, the % in the above URL encoding would be encoded again as %25, resulting in %252E which some filters might not catch, but which could still be interpreted as a dot (.) by interpreters on the target." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/120.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-177,
+        :CWE-181,
+        :CWE-183,
+        :CWE-184,
+        :CWE-692,
+        :CWE-697 .
+
+:CAPEC-121 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploit Non-Production Interfaces" ;
+    rdfs:subClassOf :CAPEC-113 ;
+    :capec-id "CAPEC-121" ;
+    :definition "An adversary exploits a sample, demonstration, test, or debug interface that is unintentionally enabled on a production system, with the goal of gleaning information or leveraging functionality that would otherwise be unavailable." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/121.html> ;
+    :related :CWE-489,
+        :CWE-1209,
+        :CWE-1259,
+        :CWE-1267,
+        :CWE-1270,
+        :CWE-1294,
+        :CWE-1295,
+        :CWE-1296,
+        :CWE-1302,
+        :CWE-1313 .
+
+:CAPEC-122 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Privilege Abuse" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-122" ;
+    :definition "An adversary is able to exploit features of the target that should be reserved for privileged users or administrators but are exposed to use by lower or non-privileged accounts. Access to sensitive information and functionality must be controlled to ensure that only authorized users are able to access these resources." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/122.html> ;
+    :related :CWE-269,
+        :CWE-732,
+        :CWE-1317,
+        :T1548 .
+
+:CAPEC-123 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Buffer Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-123" ;
+    :definition "An adversary manipulates an application's interaction with a buffer in an attempt to read or modify data they shouldn't have access to. Buffer attacks are distinguished in that it is the buffer space itself that is the target of the attack rather than any code responsible for interpreting the content of the buffer. In virtually all buffer attacks the content that is placed in the buffer is immaterial. Instead, most buffer attacks involve retrieving or providing more input than can be stored in the allocated buffer, resulting in the reading or overwriting of other unintended program memory." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/123.html> ;
+    :related :CWE-119 .
+
+:CAPEC-124 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Shared Resource Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-124" ;
+    :definition "An adversary exploits a resource shared between multiple applications, an application pool or hardware pin multiplexing to affect behavior. Resources may be shared between multiple applications or between multiple threads of a single application. Resource sharing is usually accomplished through mutual access to a single memory location or multiplexed hardware pins. If an adversary can manipulate this shared resource (usually by co-opting one of the applications or threads) the other applications or threads using the shared resource will often continue to trust the validity of the compromised shared resource and use it in their calculations. This can result in invalid trust assumptions, corruption of additional data through the normal operations of the other users of the shared resource, or even cause a crash or compromise of the sharing applications." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/124.html> ;
+    :related :CAPEC-663,
+        :CWE-1189,
+        :CWE-1331 .
+
+:CAPEC-125 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Flooding" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-125" ;
+    :definition "An adversary consumes the resources of a target by rapidly engaging in a large number of interactions with the target. This type of attack generally exposes a weakness in rate limiting or flow. When successful this attack prevents legitimate users from accessing the service and can cause the target to crash. This attack differs from resource depletion through leaks or allocations in that the latter attacks do not rely on the volume of requests made to the target but instead focus on manipulation of the target's operations. The key factor in a flooding attack is the number of requests the adversary can make in a given period of time. The greater this number, the more likely an attack is to succeed against a given target." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/125.html> ;
+    :related :CWE-404,
+        :CWE-770,
+        :T1498.001,
+        :T1499 .
+
+:CAPEC-126 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Path Traversal" ;
+    rdfs:subClassOf :CAPEC-153 ;
+    :capec-id "CAPEC-126" ;
+    :definition "An adversary uses path manipulation methods to exploit insufficient input validation of a target to obtain access to data that should be not be retrievable by ordinary well-formed requests. A typical variety of this attack involves specifying a path to a desired file together with dot-dot-slash characters, resulting in the file access API or function traversing out of the intended directory structure and into the root file system. By replacing or modifying the expected path information the access function or API retrieves the file desired by the attacker. These attacks either involve the attacker providing a complete path to a targeted file or using control characters (e.g. path separators (/ or \\) and/or dots (.)) to reach desired directories or files." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/126.html> ;
+    :related :CWE-22 .
+
+:CAPEC-127 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Directory Indexing" ;
+    rdfs:subClassOf :CAPEC-54 ;
+    :capec-id "CAPEC-127" ;
+    :definition "An adversary crafts a request to a target that results in the target listing/indexing the content of a directory as output. One common method of triggering directory contents as output is to construct a request containing a path that terminates in a directory name rather than a file name since many applications are configured to provide a list of the directory's contents when such a request is received. An adversary can use this to explore the directory tree on a target as well as learn the names of files. This can often end up revealing test files, backup files, temporary files, hidden files, configuration files, user accounts, script contents, as well as naming conventions, all of which can be used by an attacker to mount additional attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/127.html> ;
+    :related :CWE-276,
+        :CWE-285,
+        :CWE-288,
+        :CWE-424,
+        :CWE-425,
+        :CWE-693,
+        :CWE-732,
+        :T1083 .
+
+:CAPEC-128 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Integer Attacks" ;
+    rdfs:subClassOf :CAPEC-153 ;
+    :capec-id "CAPEC-128" ;
+    :definition "An attacker takes advantage of the structure of integer variables to cause these variables to assume values that are not expected by an application. For example, adding one to the largest positive integer in a signed integer variable results in a negative number. Negative numbers may be illegal in an application and the application may prevent an attacker from providing them directly, but the application may not consider that adding two positive numbers can create a negative number do to the structure of integer storage formats." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/128.html> ;
+    :related :CWE-682 .
+
+:CAPEC-129 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pointer Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-129" ;
+    :definition "This attack pattern involves an adversary manipulating a pointer within a target application resulting in the application accessing an unintended memory location. This can result in the crashing of the application or, for certain pointer values, access to data that would not normally be possible or the execution of arbitrary code. Since pointers are simply integer variables, Integer Attacks may often be used in Pointer Attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/129.html> ;
+    :related :CWE-682,
+        :CWE-822,
+        :CWE-823 .
+
+:CAPEC-130 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Excessive Allocation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-130" ;
+    :definition "An adversary causes the target to allocate excessive resources to servicing the attackers' request, thereby reducing the resources available for legitimate services and degrading or denying services. Usually, this attack focuses on memory allocation, but any finite resource on the target could be the attacked, including bandwidth, processing cycles, or other resources. This attack does not attempt to force this allocation through a large number of requests (that would be Resource Depletion through Flooding) but instead uses one or a small number of requests that are carefully formatted to force the target to allocate excessive resources to service this request(s). Often this attack takes advantage of a bug in the target to cause the target to allocate resources vastly beyond what would be needed for a normal request." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/130.html> ;
+    :related :CWE-404,
+        :CWE-770,
+        :CWE-1325,
+        :T1499.003 .
+
+:CAPEC-131 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Resource Leak Exposure" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-131" ;
+    :definition "An adversary utilizes a resource leak on the target to deplete the quantity of the resource available to service legitimate requests." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/131.html> ;
+    :related :CWE-404,
+        :T1499 .
+
+:CAPEC-132 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Symlink Attack" ;
+    rdfs:subClassOf :CAPEC-159 ;
+    :capec-id "CAPEC-132" ;
+    :definition "An adversary positions a symbolic link in such a manner that the targeted user or application accesses the link's endpoint, assuming that it is accessing a file with the link's name." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/132.html> ;
+    :related :CWE-59,
+        :T1547.009 .
+
+:CAPEC-133 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Try All Common Switches" ;
+    rdfs:subClassOf :CAPEC-113 ;
+    :capec-id "CAPEC-133" ;
+    :definition "An attacker attempts to invoke all common switches and options in the target application for the purpose of discovering weaknesses in the target. For example, in some applications, adding a --debug switch causes debugging information to be displayed, which can sometimes reveal sensitive processing or configuration information to an attacker. This attack differs from other forms of API abuse in that the attacker is indiscriminately attempting to invoke options in the hope that one of them will work rather than specifically targeting a known option. Nonetheless, even if the attacker is familiar with the published options of a targeted application this attack method may still be fruitful as it might discover unpublicized functionality." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/133.html> ;
+    :related :CWE-912 .
+
+:CAPEC-134 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Email Injection" ;
+    rdfs:subClassOf :CAPEC-137 ;
+    :capec-id "CAPEC-134" ;
+    :definition "An adversary manipulates the headers and content of an email message by injecting data via the use of delimiter characters native to the protocol." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/134.html> ;
+    :related :CWE-150 .
+
+:CAPEC-135 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Format String Injection" ;
+    rdfs:subClassOf :CAPEC-137 ;
+    :capec-id "CAPEC-135" ;
+    :definition "An adversary includes formatting characters in a string input field on the target application. Most applications assume that users will provide static text and may respond unpredictably to the presence of formatting character. For example, in certain functions of the C programming languages such as printf, the formatting character %s will print the contents of a memory location expecting this location to identify a string and the formatting character %n prints the number of DWORD written in the memory. An adversary can use this to read or write to memory locations or files, or simply to manipulate the value of the resulting text in unexpected ways. Reading or writing memory may result in program crashes and writing memory could result in the execution of arbitrary code if the adversary can write to the program stack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/135.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-134 .
+
+:CAPEC-136 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "LDAP Injection" ;
+    rdfs:subClassOf :CAPEC-248 ;
+    :capec-id "CAPEC-136" ;
+    :definition "An attacker manipulates or crafts an LDAP query for the purpose of undermining the security of the target. Some applications use user input to create LDAP queries that are processed by an LDAP server. For example, a user might provide their username during authentication and the username might be inserted in an LDAP query during the authentication process. An attacker could use this input to inject additional commands into an LDAP query that could disclose sensitive information. For example, entering a * in the aforementioned query might return information about all users on the system. This attack is very similar to an SQL injection attack in that it manipulates a query to gather additional information or coerce a particular return value." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/136.html> ;
+    :related :CWE-20,
+        :CWE-77,
+        :CWE-90 .
+
+:CAPEC-137 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Parameter Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-137" ;
+    :definition "An adversary manipulates the content of request parameters for the purpose of undermining the security of the target. Some parameter encodings use text characters as separators. For example, parameters in a HTTP GET message are encoded as name-value pairs separated by an ampersand (&). If an attacker can supply text strings that are used to fill in these parameters, then they can inject special characters used in the encoding scheme to add or modify parameters. For example, if user input is fed directly into an HTTP GET request and the user provides the value \"myInput&new_param=myValue\", then the input parameter is set to myInput, but a new parameter (new_param) is also added with a value of myValue. This can significantly change the meaning of the query that is processed by the server. Any encoding scheme where parameters are identified and separated by text characters is potentially vulnerable to this attack - the HTTP GET encoding used above is just one example." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/137.html> ;
+    :related :CWE-88 .
+
+:CAPEC-138 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Reflection Injection" ;
+    rdfs:subClassOf :CAPEC-137 ;
+    :capec-id "CAPEC-138" ;
+    :definition "An adversary supplies a value to the target application which is then used by reflection methods to identify a class, method, or field. For example, in the Java programming language the reflection libraries permit an application to inspect, load, and invoke classes and their components by name. If an adversary can control the input into these methods including the name of the class/method/field or the parameters passed to methods, they can cause the targeted application to invoke incorrect methods, read random fields, or even to load and utilize malicious classes that the adversary created. This can lead to the application revealing sensitive information, returning incorrect results, or even having the adversary take control of the targeted application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/138.html> ;
+    :related :CWE-470 .
+
+:CAPEC-139 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Relative Path Traversal" ;
+    rdfs:subClassOf :CAPEC-126 ;
+    :capec-id "CAPEC-139" ;
+    :definition "An attacker exploits a weakness in input validation on the target by supplying a specially constructed path utilizing dot and slash characters for the purpose of obtaining access to arbitrary files or resources. An attacker modifies a known path on the target in order to reach material that is not available through intended channels. These attacks normally involve adding additional path separators (/ or \\) and/or dots (.), or encodings thereof, in various combinations in order to reach parent directories or entirely separate trees of the target's directory structure." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/139.html> ;
+    :related :CWE-23 .
+
+:CAPEC-140 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bypassing of Intermediate Forms in Multiple-Form Sets" ;
+    rdfs:subClassOf :CAPEC-74 ;
+    :capec-id "CAPEC-140" ;
+    :definition "Some web applications require users to submit information through an ordered sequence of web forms. This is often done if there is a very large amount of information being collected or if information on earlier forms is used to pre-populate fields or determine which additional information the application needs to collect. An attacker who knows the names of the various forms in the sequence may be able to explicitly type in the name of a later form and navigate to it without first going through the previous forms. This can result in incomplete collection of information, incorrect assumptions about the information submitted by the attacker, or other problems that can impair the functioning of the application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/140.html> ;
+    :related :CWE-372 .
+
+:CAPEC-141 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cache Poisoning" ;
+    rdfs:subClassOf :CAPEC-161 ;
+    :capec-id "CAPEC-141" ;
+    :definition "An attacker exploits the functionality of cache technologies to cause specific data to be cached that aids the attackers' objectives. This describes any attack whereby an attacker places incorrect or harmful material in cache. The targeted cache can be an application's cache (e.g. a web browser cache) or a public cache (e.g. a DNS or ARP cache). Until the cache is refreshed, most applications or clients will treat the corrupted cache value as valid. This can lead to a wide range of exploits including redirecting web browsers towards sites that install malware and repeatedly incorrect calculations based on the incorrect value." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/141.html> ;
+    :related :CWE-345,
+        :CWE-346,
+        :CWE-348,
+        :CWE-349,
+        :T1557.002 .
+
+:CAPEC-142 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DNS Cache Poisoning" ;
+    rdfs:subClassOf :CAPEC-141 ;
+    :capec-id "CAPEC-142" ;
+    :definition "A domain name server translates a domain name (such as www.example.com) into an IP address that Internet hosts use to contact Internet resources. An adversary modifies a public DNS cache to cause certain names to resolve to incorrect addresses that the adversary specifies. The result is that client applications that rely upon the targeted cache for domain name resolution will be directed not to the actual address of the specified domain name but to some other address. Adversaries can use this to herd clients to sites that install malware on the victim's computer or to masquerade as part of a Pharming attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/142.html> ;
+    :related :CWE-345,
+        :CWE-346,
+        :CWE-348,
+        :CWE-349,
+        :CWE-350,
+        :T1584.002 .
+
+:CAPEC-143 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Detect Unpublicized Web Pages" ;
+    rdfs:subClassOf :CAPEC-150 ;
+    :capec-id "CAPEC-143" ;
+    :definition "An adversary searches a targeted web site for web pages that have not been publicized. In doing this, the adversary may be able to gain access to information that the targeted site did not intend to make public." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/143.html> ;
+    :related :CWE-425 .
+
+:CAPEC-144 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Detect Unpublicized Web Services" ;
+    rdfs:subClassOf :CAPEC-150 ;
+    :capec-id "CAPEC-144" ;
+    :definition "An adversary searches a targeted web site for web services that have not been publicized. This attack can be especially dangerous since unpublished but available services may not have adequate security controls placed upon them given that an administrator may believe they are unreachable." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/144.html> ;
+    :related :CWE-425 .
+
+:CAPEC-145 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Checksum Spoofing" ;
+    rdfs:subClassOf :CAPEC-148 ;
+    :capec-id "CAPEC-145" ;
+    :definition "An adversary spoofs a checksum message for the purpose of making a payload appear to have a valid corresponding checksum. Checksums are used to verify message integrity. They consist of some value based on the value of the message they are protecting. Hash codes are a common checksum mechanism. Both the sender and recipient are able to compute the checksum based on the contents of the message. If the message contents change between the sender and recipient, the sender and recipient will compute different checksum values. Since the sender's checksum value is transmitted with the message, the recipient would know that a modification occurred. In checksum spoofing an adversary modifies the message body and then modifies the corresponding checksum so that the recipient's checksum calculation will match the checksum (created by the adversary) in the message. This would prevent the recipient from realizing that a change occurred." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/145.html> ;
+    :related :CWE-354 .
+
+:CAPEC-146 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XML Schema Poisoning" ;
+    rdfs:subClassOf :CAPEC-271 ;
+    :capec-id "CAPEC-146" ;
+    :definition "An adversary corrupts or modifies the content of XML schema information passed between a client and server for the purpose of undermining the security of the target. XML Schemas provide the structure and content definitions for XML documents. Schema poisoning is the ability to manipulate a schema either by replacing or modifying it to compromise the programs that process documents that use this schema." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/146.html> ;
+    :related :CWE-15,
+        :CWE-472 .
+
+:CAPEC-147 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XML Ping of the Death" ;
+    rdfs:subClassOf :CAPEC-528 ;
+    :capec-id "CAPEC-147" ;
+    :definition "An attacker initiates a resource depletion attack where a large number of small XML messages are delivered at a sufficiently rapid rate to cause a denial of service or crash of the target. Transactions such as repetitive SOAP transactions can deplete resources faster than a simple flooding attack because of the additional resources used by the SOAP protocol and the resources necessary to process SOAP messages. The transactions used are immaterial as long as they cause resource utilization on the target. In other words, this is a normal flooding attack augmented by using messages that will require extra processing on the target." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/147.html> ;
+    :related :CWE-400,
+        :CWE-770 .
+
+:CAPEC-148 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Content Spoofing" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-148" ;
+    :definition "An adversary modifies content to make it contain something other than what the original content producer intended while keeping the apparent source of the content unchanged. The term content spoofing is most often used to describe modification of web pages hosted by a target to display the adversary's content instead of the owner's content. However, any content can be spoofed, including the content of email messages, file transfers, or the content of other network communication protocols. Content can be modified at the source (e.g. modifying the source file for a web page) or in transit (e.g. intercepting and modifying a message between the sender and recipient). Usually, the adversary will attempt to hide the fact that the content has been modified, but in some cases, such as with web site defacement, this is not necessary. Content Spoofing can lead to malware exposure, financial fraud (if the content governs financial transactions), privacy violations, and other unwanted outcomes." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/148.html> ;
+    :related :CAPEC-665,
+        :CWE-345,
+        :T1491 .
+
+:CAPEC-149 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Explore for Predictable Temporary File Names" ;
+    rdfs:subClassOf :CAPEC-497 ;
+    :capec-id "CAPEC-149" ;
+    :definition "An attacker explores a target to identify the names and locations of predictable temporary files for the purpose of launching further attacks against the target. This involves analyzing naming conventions and storage locations of the temporary files created by a target application. If an attacker can predict the names of temporary files they can use this information to mount other attacks, such as information gathering and symlink attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/149.html> ;
+    :related :CWE-377 .
+
+:CAPEC-150 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Collect Data from Common Resource Locations" ;
+    rdfs:subClassOf :CAPEC-116 ;
+    :capec-id "CAPEC-150" ;
+    :definition "An adversary exploits well-known locations for resources for the purposes of undermining the security of the target. In many, if not most systems, files and resources are organized in a default tree structure. This can be useful for adversaries because they often know where to look for resources or files that are necessary for attacks. Even when the precise location of a targeted resource may not be known, naming conventions may indicate a small area of the target machine's file tree where the resources are typically located. For example, configuration files are normally stored in the /etc director on Unix systems. Adversaries can take advantage of this to commit other types of attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/150.html> ;
+    :related :CWE-552,
+        :CWE-1239,
+        :CWE-1258,
+        :CWE-1266,
+        :CWE-1272,
+        :CWE-1323,
+        :CWE-1330,
+        :T1003,
+        :T1119,
+        :T1213,
+        :T1530,
+        :T1555,
+        :T1602 .
+
+:CAPEC-151 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Identity Spoofing" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-151" ;
+    :definition "Identity Spoofing refers to the action of assuming (i.e., taking on) the identity of some other entity (human or non-human) and then using that identity to accomplish a goal. An adversary may craft messages that appear to come from a different principle or use stolen / spoofed authentication credentials." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/151.html> ;
+    :related :CAPEC-665,
+        :CWE-287 .
+
+:CAPEC-153 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Input Data Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-153" ;
+    :definition "An attacker exploits a weakness in input validation by controlling the format, structure, and composition of data to an input-processing interface. By supplying input of a non-standard or unexpected form an attacker can adversely impact the security of the target." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/153.html> ;
+    :related :CWE-20 .
+
+:CAPEC-154 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Resource Location Spoofing" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-154" ;
+    :definition "An adversary deceives an application or user and convinces them to request a resource from an unintended location. By spoofing the location, the adversary can cause an alternate resource to be used, often one that the adversary controls and can be used to help them achieve their malicious goals." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/154.html> ;
+    :related :CWE-451 .
+
+:CAPEC-155 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Screen Temporary Files for Sensitive Information" ;
+    rdfs:subClassOf :CAPEC-150 ;
+    :capec-id "CAPEC-155" ;
+    :definition "An adversary exploits the temporary, insecure storage of information by monitoring the content of files used to store temp data during an application's routine execution flow. Many applications use temporary files to accelerate processing or to provide records of state across multiple executions of the application. Sometimes, however, these temporary files may end up storing sensitive information. By screening an application's temporary files, an adversary might be able to discover such sensitive information. For example, web browsers often cache content to accelerate subsequent lookups. If the content contains sensitive information then the adversary could recover this from the web cache." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/155.html> ;
+    :related :CWE-377 .
+
+:CAPEC-157 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Sniffing Attacks" ;
+    rdfs:subClassOf :CAPEC-117 ;
+    :capec-id "CAPEC-157" ;
+    :definition "In this attack pattern, the adversary intercepts information transmitted between two third parties. The adversary must be able to observe, read, and/or hear the communication traffic, but not necessarily block the communication or change its content. Any transmission medium can theoretically be sniffed if the adversary can examine the contents between the sender and recipient. Sniffing Attacks are similar to Adversary-In-The-Middle attacks (CAPEC-94), but are entirely passive. AiTM attacks are predominantly active and often alter the content of the communications themselves." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/157.html> ;
+    :related :CWE-311 .
+
+:CAPEC-158 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Sniffing Network Traffic" ;
+    rdfs:subClassOf :CAPEC-157 ;
+    :capec-id "CAPEC-158" ;
+    :definition "In this attack pattern, the adversary monitors network traffic between nodes of a public or multicast network in an attempt to capture sensitive information at the protocol level. Network sniffing applications can reveal TCP/IP, DNS, Ethernet, and other low-level network communication information. The adversary takes a passive role in this attack pattern and simply observes and analyzes the traffic. The adversary may precipitate or indirectly influence the content of the observed transaction, but is never the intended recipient of the target information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/158.html> ;
+    :related :CWE-311,
+        :T1040,
+        :T1111 .
+
+:CAPEC-159 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Redirect Access to Libraries" ;
+    rdfs:subClassOf :CAPEC-154 ;
+    :capec-id "CAPEC-159" ;
+    :definition "An adversary exploits a weakness in the way an application searches for external libraries to manipulate the execution flow to point to an adversary supplied library or code base. This pattern of attack allows the adversary to compromise the application or server via the execution of unauthorized code. An application typically makes calls to functions that are a part of libraries external to the application. These libraries may be part of the operating system or they may be third party libraries. If an adversary can redirect an application's attempts to access these libraries to other libraries that the adversary supplies, the adversary will be able to force the targeted application to execute arbitrary code. This is especially dangerous if the targeted application has enhanced privileges. Access can be redirected through a number of techniques, including the use of symbolic links, search path modification, and relative path manipulation." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/159.html> ;
+    :related :CWE-706,
+        :T1574.008 .
+
+:CAPEC-160 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploit Script-Based APIs" ;
+    rdfs:subClassOf :CAPEC-113 ;
+    :capec-id "CAPEC-160" ;
+    :definition "Some APIs support scripting instructions as arguments. Methods that take scripted instructions (or references to scripted instructions) can be very flexible and powerful. However, if an attacker can specify the script that serves as input to these methods they can gain access to a great deal of functionality. For example, HTML pages support <script> tags that allow scripting languages to be embedded in the page and then interpreted by the receiving web browser. If the content provider is malicious, these scripts can compromise the client application. Some applications may even execute the scripts under their own identity (rather than the identity of the user providing the script) which can allow attackers to perform activities that would otherwise be denied to them." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/160.html> ;
+    :related :CWE-346 .
+
+:CAPEC-161 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Infrastructure Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-161" ;
+    :definition "An attacker exploits characteristics of the infrastructure of a network entity in order to perpetrate attacks or information gathering on network objects or effect a change in the ordinary information flow between network objects. Most often, this involves manipulation of the routing of network messages so, instead of arriving at their proper destination, they are directed towards an entity of the attackers' choosing, usually a server controlled by the attacker. The victim is often unaware that their messages are not being processed correctly. For example, a targeted client may believe they are connecting to their own bank but, in fact, be connecting to a Pharming site controlled by the attacker which then collects the user's login information in order to hijack the actual bank account." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/161.html> ;
+    :related :CWE-923 .
+
+:CAPEC-162 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulating Hidden Fields" ;
+    rdfs:subClassOf :CAPEC-77 ;
+    :capec-id "CAPEC-162" ;
+    :definition "An adversary exploits a weakness in the server's trust of client-side processing by modifying data on the client-side, such as price information, and then submitting this data to the server, which processes the modified data. For example, eShoplifting is a data manipulation attack against an on-line merchant during a purchasing transaction. The manipulation of price, discount or quantity fields in the transaction message allows the adversary to acquire items at a lower cost than the merchant intended. The adversary performs a normal purchasing transaction but edits hidden fields within the HTML form response that store price or other information to give themselves a better deal. The merchant then uses the modified pricing information in calculating the cost of the selected items." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/162.html> ;
+    :related :CWE-602 .
+
+:CAPEC-163 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Spear Phishing" ;
+    rdfs:subClassOf :CAPEC-98 ;
+    :capec-id "CAPEC-163" ;
+    :definition "An adversary targets a specific user or group with a Phishing (CAPEC-98) attack tailored to a category of users in order to have maximum relevance and deceptive capability. Spear Phishing is an enhanced version of the Phishing attack targeted to a specific user or group. The quality of the targeted email is usually enhanced by appearing to come from a known or trusted entity. If the email account of some trusted entity has been compromised the message may be digitally signed. The message will contain information specific to the targeted users that will enhance the probability that they will follow the URL to the compromised site. For example, the message may indicate knowledge of the targets employment, residence, interests, or other information that suggests familiarity. As soon as the user follows the instructions in the message, the attack proceeds as a standard Phishing attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/163.html> ;
+    :related :CWE-451,
+        :T1534,
+        :T1566.001,
+        :T1566.002,
+        :T1566.003,
+        :T1598.001,
+        :T1598.002,
+        :T1598.003 .
+
+:CAPEC-164 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Mobile Phishing" ;
+    rdfs:subClassOf :CAPEC-98 ;
+    :capec-id "CAPEC-164" ;
+    :definition "An adversary targets mobile phone users with a phishing attack for the purpose of soliciting account passwords or sensitive information from the user. Mobile Phishing is a variation of the Phishing social engineering technique where the attack is initiated via a text or SMS message, rather than email. The user is enticed to provide information or visit a compromised web site via this message. Apart from the manner in which the attack is initiated, the attack proceeds as a standard Phishing attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/164.html> ;
+    :related :CWE-451 .
+
+:CAPEC-165 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "File Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-165" ;
+    :definition "An attacker modifies file contents or attributes (such as extensions or names) of files in a manner to cause incorrect processing by an application. Attackers use this class of attacks to cause applications to enter unstable states, overwrite or expose sensitive information, and even execute arbitrary code with the application's privileges. This class of attacks differs from attacks on configuration information (even if file-based) in that file manipulation causes the file processing to result in non-standard behaviors, such as buffer overflows or use of the incorrect interpreter. Configuration attacks rely on the application interpreting files correctly in order to insert harmful configuration information. Likewise, resource location attacks rely on controlling an application's ability to locate files, whereas File Manipulation attacks do not require the application to look in a non-default location, although the two classes of attacks are often combined." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/165.html> ;
+    :related :T1036.003 .
+
+:CAPEC-166 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Force the System to Reset Values" ;
+    rdfs:subClassOf :CAPEC-161 ;
+    :capec-id "CAPEC-166" ;
+    :definition "An attacker forces the target into a previous state in order to leverage potential weaknesses in the target dependent upon a prior configuration or state-dependent factors. Even in cases where an attacker may not be able to directly control the configuration of the targeted application, they may be able to reset the configuration to a prior state since many applications implement reset functions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/166.html> ;
+    :related :CWE-306,
+        :CWE-1221,
+        :CWE-1232 .
+
+:CAPEC-167 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "White Box Reverse Engineering" ;
+    rdfs:subClassOf :CAPEC-188 ;
+    :capec-id "CAPEC-167" ;
+    :definition "An attacker discovers the structure, function, and composition of a type of computer software through white box analysis techniques. White box techniques involve methods which can be applied to a piece of software when an executable or some other compiled object can be directly subjected to analysis, revealing at least a portion of its machine instructions that can be observed upon execution." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/167.html> ;
+    :related :CWE-1323 .
+
+:CAPEC-168 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Windows ::DATA Alternate Data Stream" ;
+    rdfs:subClassOf :CAPEC-636 ;
+    :capec-id "CAPEC-168" ;
+    :definition "An attacker exploits the functionality of Microsoft NTFS Alternate Data Streams (ADS) to undermine system security. ADS allows multiple \"files\" to be stored in one directory entry referenced as filename:streamname. One or more alternate data streams may be stored in any file or directory. Normal Microsoft utilities do not show the presence of an ADS stream attached to a file. The additional space for the ADS is not recorded in the displayed file size. The additional space for ADS is accounted for in the used space on the volume. An ADS can be any type of file. ADS are copied by standard Microsoft utilities between NTFS volumes. ADS can be used by an attacker or intruder to hide tools, scripts, and data from detection by normal system utilities. Many anti-virus programs do not check for or scan ADS. Windows Vista does have a switch (-R) on the command line DIR command that will display alternate streams." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/168.html> ;
+    :related :CWE-69,
+        :CWE-212 .
+
+:CAPEC-169 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Footprinting" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-169" ;
+    :definition "An adversary engages in probing and exploration activities to identify constituents and properties of the target." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/169.html> ;
+    :related :CWE-200,
+        :T1217,
+        :T1592,
+        :T1595 .
+
+:CAPEC-170 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Web Application Fingerprinting" ;
+    rdfs:subClassOf :CAPEC-541 ;
+    :capec-id "CAPEC-170" ;
+    :definition "An attacker sends a series of probes to a web application in order to elicit version-dependent and type-dependent behavior that assists in identifying the target. An attacker could learn information such as software versions, error pages, and response headers, variations in implementations of the HTTP protocol, directory structures, and other similar information about the targeted service. This information can then be used by an attacker to formulate a targeted attack plan. While web application fingerprinting is not intended to be damaging (although certain activities, such as network scans, can sometimes cause disruptions to vulnerable applications inadvertently) it may often pave the way for more damaging attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/170.html> ;
+    :related :CWE-497 .
+
+:CAPEC-171 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Variable Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-77 : Manipulating User-Controlled Variables\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-171" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/171.html> .
+
+:CAPEC-173 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Action Spoofing" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-173" ;
+    :definition "An adversary is able to disguise one action for another and therefore trick a user into initiating one type of action when they intend to initiate a different action. For example, a user might be led to believe that clicking a button will submit a query, but in fact it downloads software. Adversaries may perform this attack through social means, such as by simply convincing a victim to perform the action or relying on a user's natural inclination to do so, or through technical means, such as a clickjacking attack where a user sees one interface but is actually interacting with a second, invisible, interface." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/173.html> ;
+    :related :CWE-451 .
+
+:CAPEC-174 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Flash Parameter Injection" ;
+    rdfs:subClassOf :CAPEC-182 ;
+    :capec-id "CAPEC-174" ;
+    :definition "An adversary takes advantage of improper data validation to inject malicious global parameters into a Flash file embedded within an HTML document. Flash files can leverage user-submitted data to configure the Flash document and access the embedding HTML document." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/174.html> ;
+    :related :CWE-88 .
+
+:CAPEC-175 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Code Inclusion" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-175" ;
+    :definition "An adversary exploits a weakness on the target to force arbitrary code to be retrieved locally or from a remote location and executed. This differs from code injection in that code injection involves the direct inclusion of code while code inclusion involves the addition or replacement of a reference to a code file, which is subsequently loaded by the target and used as part of the code of some application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/175.html> ;
+    :related :CWE-829 .
+
+:CAPEC-176 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Configuration/Environment Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-176" ;
+    :definition "An attacker manipulates files or settings external to a target application which affect the behavior of that application. For example, many applications use external configuration files and libraries - modification of these entities or otherwise affecting the application's ability to use them would constitute a configuration/environment manipulation attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/176.html> ;
+    :related :CWE-15,
+        :CWE-1233,
+        :CWE-1234,
+        :CWE-1304,
+        :CWE-1328 .
+
+:CAPEC-177 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Create files with the same name as files protected with a higher classification" ;
+    rdfs:subClassOf :CAPEC-17 ;
+    :capec-id "CAPEC-177" ;
+    :definition "An attacker exploits file location algorithms in an operating system or application by creating a file with the same name as a protected or privileged file. The attacker could manipulate the system if the attacker-created file is trusted by the operating system or an application component that attempts to load the original file. Applications often load or include external files, such as libraries or configuration files. These files should be protected against malicious manipulation. However, if the application only uses the name of the file when locating it, an attacker may be able to create a file with the same name and place it in a directory that the application will search before the directory with the legitimate file is searched. Because the attackers' file is discovered first, it would be used by the target application. This attack can be extremely destructive if the referenced file is executable and/or is granted special privileges based solely on having a particular name." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/177.html> ;
+    :related :CWE-706,
+        :T1036 .
+
+:CAPEC-178 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross-Site Flashing" ;
+    rdfs:subClassOf :CAPEC-182 ;
+    :capec-id "CAPEC-178" ;
+    :definition "An attacker is able to trick the victim into executing a Flash document that passes commands or calls to a Flash player browser plugin, allowing the attacker to exploit native Flash functionality in the client browser. This attack pattern occurs where an attacker can provide a crafted link to a Flash document (SWF file) which, when followed, will cause additional malicious instructions to be executed. The attacker does not need to serve or control the Flash document. The attack takes advantage of the fact that Flash files can reference external URLs. If variables that serve as URLs that the Flash application references can be controlled through parameters, then by creating a link that includes values for those parameters, an attacker can cause arbitrary content to be referenced and possibly executed by the targeted Flash application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/178.html> ;
+    :related :CWE-601 .
+
+:CAPEC-179 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Calling Micro-Services Directly" ;
+    rdfs:subClassOf :CAPEC-554 ;
+    :capec-id "CAPEC-179" ;
+    :definition "An attacker is able to discover and query Micro-services at a web location and thereby expose the Micro-services to further exploitation by gathering information about their implementation and function. Micro-services in web pages allow portions of a page to connect to the server and update content without needing to cause the entire page to update. This allows user activity to change portions of the page more quickly without causing disruptions elsewhere." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/179.html> .
+
+:CAPEC-180 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploiting Incorrectly Configured Access Control Security Levels" ;
+    rdfs:subClassOf :CAPEC-122 ;
+    :capec-id "CAPEC-180" ;
+    :definition "An attacker exploits a weakness in the configuration of access controls and is able to bypass the intended protection that these measures guard against and thereby obtain unauthorized access to the system or network. Sensitive functionality should always be protected with access controls. However configuring all but the most trivial access control systems can be very complicated and there are many opportunities for mistakes. If an attacker can learn of incorrectly configured access security settings, they may be able to exploit this in an attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/180.html> ;
+    :related :CAPEC-663,
+        :CWE-732,
+        :CWE-1190,
+        :CWE-1191,
+        :CWE-1193,
+        :CWE-1220,
+        :CWE-1268,
+        :CWE-1280,
+        :CWE-1297,
+        :CWE-1311,
+        :CWE-1315,
+        :CWE-1318,
+        :CWE-1320,
+        :CWE-1321,
+        :T1574.010 .
+
+:CAPEC-181 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Flash File Overlay" ;
+    rdfs:subClassOf :CAPEC-103 ;
+    :capec-id "CAPEC-181" ;
+    :definition "An attacker creates a transparent overlay using flash in order to intercept user actions for the purpose of performing a clickjacking attack. In this technique, the Flash file provides a transparent overlay over HTML content. Because the Flash application is on top of the content, user actions, such as clicks, are caught by the Flash application rather than the underlying HTML. The action is then interpreted by the overlay to perform the actions the attacker wishes." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/181.html> ;
+    :related :CWE-1021 .
+
+:CAPEC-182 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Flash Injection" ;
+    rdfs:subClassOf :CAPEC-137 ;
+    :capec-id "CAPEC-182" ;
+    :definition "An attacker tricks a victim to execute malicious flash content that executes commands or makes flash calls specified by the attacker. One example of this attack is cross-site flashing, an attacker controlled parameter to a reference call loads from content specified by the attacker." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/182.html> ;
+    :related :CWE-20,
+        :CWE-184,
+        :CWE-697 .
+
+:CAPEC-183 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "IMAP/SMTP Command Injection" ;
+    rdfs:subClassOf :CAPEC-248 ;
+    :capec-id "CAPEC-183" ;
+    :definition "An adversary exploits weaknesses in input validation on web-mail servers to execute commands on the IMAP/SMTP server. Web-mail servers often sit between the Internet and the IMAP or SMTP mail server. User requests are received by the web-mail servers which then query the back-end mail server for the requested information and return this response to the user. In an IMAP/SMTP command injection attack, mail-server commands are embedded in parts of the request sent to the web-mail server. If the web-mail server fails to adequately sanitize these requests, these commands are then sent to the back-end mail server when it is queried by the web-mail server, where the commands are then executed. This attack can be especially dangerous since administrators may assume that the back-end server is protected against direct Internet access and therefore may not secure it adequately against the execution of malicious commands." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/183.html> ;
+    :related :CWE-77 .
+
+:CAPEC-184 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Software Integrity Attack" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-184" ;
+    :definition "An attacker initiates a series of events designed to cause a user, program, server, or device to perform actions which undermine the integrity of software code, device data structures, or device firmware, achieving the modification of the target's integrity to achieve an insecure state." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/184.html> ;
+    :related :CWE-494 .
+
+:CAPEC-185 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Software Download" ;
+    rdfs:subClassOf :CAPEC-184 ;
+    :capec-id "CAPEC-185" ;
+    :definition "An attacker uses deceptive methods to cause a user or an automated process to download and install dangerous code that originates from an attacker controlled source. There are several variations to this strategy of attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/185.html> ;
+    :related :CWE-494 .
+
+:CAPEC-186 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Software Update" ;
+    rdfs:subClassOf :CAPEC-184 ;
+    :capec-id "CAPEC-186" ;
+    :definition "An adversary uses deceptive methods to cause a user or an automated process to download and install dangerous code believed to be a valid update that originates from an adversary controlled source." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/186.html> ;
+    :related :CWE-494,
+        :T1195.002 .
+
+:CAPEC-187 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Automated Software Update via Redirection" ;
+    rdfs:subClassOf :CAPEC-186 ;
+    :capec-id "CAPEC-187" ;
+    :definition "An attacker exploits two layers of weaknesses in server or client software for automated update mechanisms to undermine the integrity of the target code-base. The first weakness involves a failure to properly authenticate a server as a source of update or patch content. This type of weakness typically results from authentication mechanisms which can be defeated, allowing a hostile server to satisfy the criteria that establish a trust relationship. The second weakness is a systemic failure to validate the identity and integrity of code downloaded from a remote location, hence the inability to distinguish malicious code from a legitimate update." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/187.html> ;
+    :related :CWE-494,
+        :T1072 .
+
+:CAPEC-188 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Reverse Engineering" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-188" ;
+    :definition "An adversary discovers the structure, function, and composition of an object, resource, or system by using a variety of analysis techniques to effectively determine how the analyzed entity was constructed or operates. The goal of reverse engineering is often to duplicate the function, or a part of the function, of an object in order to duplicate or \"back engineer\" some aspect of its functioning. Reverse engineering techniques can be applied to mechanical objects, electronic devices, or software, although the methodology and techniques involved in each type of analysis differ widely." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/188.html> ;
+    :related :CWE-1278 .
+
+:CAPEC-189 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Black Box Reverse Engineering" ;
+    rdfs:subClassOf :CAPEC-188 ;
+    :capec-id "CAPEC-189" ;
+    :definition "An adversary discovers the structure, function, and composition of a type of computer software through black box analysis techniques. 'Black Box' methods involve interacting with the software indirectly, in the absence of direct access to the executable object. Such analysis typically involves interacting with the software at the boundaries of where the software interfaces with a larger execution environment, such as input-output vectors, libraries, or APIs. Black Box Reverse Engineering also refers to gathering physical side effects of a hardware device, such as electromagnetic radiation or sounds." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/189.html> ;
+    :related :CWE-203,
+        :CWE-1255,
+        :CWE-1300 .
+
+:CAPEC-190 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Reverse Engineer an Executable to Expose Assumed Hidden Functionality" ;
+    rdfs:subClassOf :CAPEC-167 ;
+    :capec-id "CAPEC-190" ;
+    :definition "An attacker analyzes a binary file or executable for the purpose of discovering the structure, function, and possibly source-code of the file by using a variety of analysis techniques to effectively determine how the software functions and operates. This type of analysis is also referred to as Reverse Code Engineering, as techniques exist for extracting source code from an executable. Several techniques are often employed for this purpose, both black box and white box. The use of computer bus analyzers and packet sniffers allows the binary to be studied at a level of interactions with its computing environment, such as a host OS, inter-process communication, and/or network communication. This type of analysis falls into the 'black box' category because it involves behavioral analysis of the software without reference to source code, object code, or protocol specifications." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/190.html> ;
+    :related :CWE-912 .
+
+:CAPEC-191 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Read Sensitive Constants Within an Executable" ;
+    rdfs:subClassOf :CAPEC-167 ;
+    :capec-id "CAPEC-191" ;
+    :definition "An adversary engages in activities to discover any sensitive constants present within the compiled code of an executable. These constants may include literal ASCII strings within the file itself, or possibly strings hard-coded into particular routines that can be revealed by code refactoring methods including static and dynamic analysis." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/191.html> ;
+    :related :CWE-798,
+        :T1552.001 .
+
+:CAPEC-192 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Protocol Analysis" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-192" ;
+    :definition "An adversary engages in activities to decipher and/or decode protocol information for a network or application communication protocol used for transmitting information between interconnected nodes or systems on a packet-switched data network. While this type of analysis involves the analysis of a networking protocol inherently, it does not require the presence of an actual or physical network." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/192.html> ;
+    :related :CWE-326 .
+
+:CAPEC-193 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "PHP Remote File Inclusion" ;
+    rdfs:subClassOf :CAPEC-253 ;
+    :capec-id "CAPEC-193" ;
+    :definition "In this pattern the adversary is able to load and execute arbitrary code remotely available from the application. This is usually accomplished through an insecurely configured PHP runtime environment and an improperly sanitized \"include\" or \"require\" call, which the user can then control to point to any web-accessible file. This allows adversaries to hijack the targeted application and force it to execute their own instructions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/193.html> ;
+    :related :CWE-80,
+        :CWE-98 .
+
+:CAPEC-194 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Fake the Source of Data" ;
+    rdfs:subClassOf :CAPEC-151 ;
+    :capec-id "CAPEC-194" ;
+    :definition "An adversary takes advantage of improper authentication to provide data or services under a falsified identity. The purpose of using the falsified identity may be to prevent traceability of the provided data or to assume the rights granted to another individual. One of the simplest forms of this attack would be the creation of an email message with a modified \"From\" field in order to appear that the message was sent from someone other than the actual sender. The root of the attack (in this case the email system) fails to properly authenticate the source and this results in the reader incorrectly performing the instructed action. Results of the attack vary depending on the details of the attack, but common results include privilege escalation, obfuscation of other attacks, and data corruption/manipulation." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/194.html> ;
+    :related :CWE-287 .
+
+:CAPEC-195 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Principal Spoof" ;
+    rdfs:subClassOf :CAPEC-151 ;
+    :capec-id "CAPEC-195" ;
+    :definition "A Principal Spoof is a form of Identity Spoofing where an adversary pretends to be some other person in an interaction. This is often accomplished by crafting a message (either written, verbal, or visual) that appears to come from a person other than the adversary. Phishing and Pharming attacks often attempt to do this so that their attempts to gather sensitive information appear to come from a legitimate source. A Principal Spoof does not use stolen or spoofed authentication credentials, instead relying on the appearance and content of the message to reflect identity." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/195.html> .
+
+:CAPEC-196 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Session Credential Falsification through Forging" ;
+    rdfs:subClassOf :CAPEC-21 ;
+    :capec-id "CAPEC-196" ;
+    :definition "An attacker creates a false but functional session credential in order to gain or usurp access to a service. Session credentials allow users to identify themselves to a service after an initial authentication without needing to resend the authentication information (usually a username and password) with every message. If an attacker is able to forge valid session credentials they may be able to bypass authentication or piggy-back off some other authenticated user's session. This attack differs from Reuse of Session IDs and Session Sidejacking attacks in that in the latter attacks an attacker uses a previous or existing credential without modification while, in a forging attack, the attacker must create their own credential, although it may be based on previously observed credentials." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/196.html> ;
+    :related :CWE-384,
+        :CWE-664,
+        :T1134.002,
+        :T1134.003,
+        :T1606 .
+
+:CAPEC-197 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exponential Data Expansion" ;
+    rdfs:subClassOf :CAPEC-230 ;
+    :capec-id "CAPEC-197" ;
+    :definition "An adversary submits data to a target application which contains nested exponential data expansion to produce excessively large output. Many data format languages allow the definition of macro-like structures that can be used to simplify the creation of complex structures. However, this capability can be abused to create excessive demands on a processor's CPU and memory. A small number of nested expansions can result in an exponential growth in demands on memory." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/197.html> ;
+    :related :CWE-770,
+        :CWE-776 .
+
+:CAPEC-198 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Targeting Error Pages" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-198" ;
+    :definition "An adversary distributes a link (or possibly some other query structure) with a request to a third party web server that is malformed and also contains a block of exploit code in order to have the exploit become live code in the resulting error page." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/198.html> ;
+    :related :CWE-81 .
+
+:CAPEC-199 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Using Alternate Syntax" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-199" ;
+    :definition "An adversary uses alternate forms of keywords or commands that result in the same action as the primary form but which may not be caught by filters. For example, many keywords are processed in a case insensitive manner. If the site's web filtering algorithm does not convert all tags into a consistent case before the comparison with forbidden keywords it is possible to bypass filters (e.g., incomplete black lists) by using an alternate case structure. For example, the \"script\" tag using the alternate forms of \"Script\" or \"ScRiPt\" may bypass filters where \"script\" is the only form tested. Other variants using different syntax representations are also possible as well as using pollution meta-characters or entities that are eventually ignored by the rendering engine. The attack can result in the execution of otherwise prohibited functionality." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/199.html> ;
+    :related :CWE-87 .
+
+:CAPEC-200 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Removal of filters: Input filters, output filters, data masking" ;
+    rdfs:subClassOf :CAPEC-207 ;
+    :capec-id "CAPEC-200" ;
+    :definition "An attacker removes or disables filtering mechanisms on the target application. Input filters prevent invalid data from being sent to an application (for example, overly large inputs that might cause a buffer overflow or other malformed inputs that may not be correctly handled by an application). Input filters might also be designed to constrained executable content." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/200.html> .
+
+:CAPEC-201 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Serialized Data External Linking" ;
+    rdfs:subClassOf :CAPEC-122,
+        :CAPEC-278 ;
+    :capec-id "CAPEC-201" ;
+    :definition "An adversary creates a serialized data file (e.g. XML, YAML, etc...) that contains an external data reference. Because serialized data parsers may not validate documents with external references, there may be no checks on the nature of the reference in the external data. This can allow an adversary to open arbitrary files or connections, which may further lead to the adversary gaining access to information on the system that they would normally be unable to obtain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/201.html> ;
+    :related :CWE-829 .
+
+:CAPEC-202 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Create Malicious Client" ;
+    rdfs:subClassOf :CAPEC-22 ;
+    :capec-id "CAPEC-202" ;
+    :definition "An adversary creates a client application to interface with a target service where the client violates assumptions the service makes about clients. Services that have designated client applications (as opposed to services that use general client applications, such as IMAP or POP mail servers which can interact with any IMAP or POP client) may assume that the client will follow specific procedures." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/202.html> ;
+    :related :CWE-602 .
+
+:CAPEC-203 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulate Registry Information" ;
+    rdfs:subClassOf :CAPEC-176 ;
+    :capec-id "CAPEC-203" ;
+    :definition "An adversary exploits a weakness in authorization in order to modify content within a registry (e.g., Windows Registry, Mac plist, application registry). Editing registry information can permit the adversary to hide configuration information or remove indicators of compromise to cover up activity. Many applications utilize registries to store configuration and service information. As such, modification of registry information can affect individual services (affecting billing, authorization, or even allowing for identity spoofing) or the overall configuration of a targeted application. For example, both Java RMI and SOAP use registries to track available services. Changing registry values is sometimes a preliminary step towards completing another attack pattern, but given the long term usage of many registry values, manipulation of registry information could be its own end." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/203.html> ;
+    :related :CWE-15,
+        :T1112,
+        :T1647 .
+
+:CAPEC-204 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Lifting Sensitive Data Embedded in Cache" ;
+    rdfs:subClassOf :CAPEC-167 ;
+    :capec-id "CAPEC-204" ;
+    :definition "An adversary examines a target application's cache, or a browser cache, for sensitive information. Many applications that communicate with remote entities or which perform intensive calculations utilize caches to improve efficiency. However, if the application computes or receives sensitive information and the cache is not appropriately protected, an attacker can browse the cache and retrieve this information. This can result in the disclosure of sensitive information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/204.html> ;
+    :related :CWE-311,
+        :CWE-524,
+        :CWE-1239,
+        :CWE-1258,
+        :T1005 .
+
+:CAPEC-205 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Lifting credential(s)/key material embedded in client distributions (thick or thin)" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-37 : Retrieve Embedded Sensitive Data. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-205" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/205.html> .
+
+:CAPEC-206 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signing Malicious Code" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-206" ;
+    :definition "The adversary extracts credentials used for code signing from a production environment and then uses these credentials to sign malicious content with the developer's key. Many developers use signing keys to sign code or hashes of code. When users or applications verify the signatures are accurate they are led to believe that the code came from the owner of the signing key and that the code has not been modified since the signature was applied. If the adversary has extracted the signing credentials then they can use those credentials to sign their own code bundles. Users or tools that verify the signatures attached to the code will likely assume the code came from the legitimate developer and install or run the code, effectively allowing the adversary to execute arbitrary code on the victim's computer. This differs from CAPEC-673, because the adversary is performing the code signing." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/206.html> ;
+    :related :CWE-732,
+        :T1553.002 .
+
+:CAPEC-207 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Removing Important Client Functionality" ;
+    rdfs:subClassOf :CAPEC-22 ;
+    :capec-id "CAPEC-207" ;
+    :definition "An adversary removes or disables functionality on the client that the server assumes to be present and trustworthy." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/207.html> ;
+    :related :CWE-602 .
+
+:CAPEC-208 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Removing/short-circuiting 'Purse' logic: removing/mutating 'cash' decrements" ;
+    rdfs:subClassOf :CAPEC-207 ;
+    :capec-id "CAPEC-208" ;
+    :definition "An attacker removes or modifies the logic on a client associated with monetary calculations resulting in incorrect information being sent to the server. A server may rely on a client to correctly compute monetary information. For example, a server might supply a price for an item and then rely on the client to correctly compute the total cost of a purchase given the number of items the user is buying. If the attacker can remove or modify the logic that controls these calculations, they can return incorrect values to the server. The attacker can use this to make purchases for a fraction of the legitimate cost or otherwise avoid correct billing for activities." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/208.html> ;
+    :related :CWE-602 .
+
+:CAPEC-209 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Using MIME Type Mismatch" ;
+    rdfs:subClassOf :CAPEC-592 ;
+    :capec-id "CAPEC-209" ;
+    :definition "An adversary creates a file with scripting content but where the specified MIME type of the file is such that scripting is not expected. The adversary tricks the victim into accessing a URL that responds with the script file. Some browsers will detect that the specified MIME type of the file does not match the actual type of its content and will automatically switch to using an interpreter for the real content type. If the browser does not invoke script filters before doing this, the adversary's script may run on the target unsanitized, possibly revealing the victim's cookies or executing arbitrary script in their browser." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/209.html> ;
+    :related :CWE-20,
+        :CWE-79,
+        :CWE-646 .
+
+:CAPEC-211 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Leveraging web tools (e.g. Mozilla's GreaseMonkey, Firebug) to change application behavior" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern." ;
+    :capec-id "CAPEC-211" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/211.html> .
+
+:CAPEC-212 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Functionality Misuse" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-212" ;
+    :definition "An adversary leverages a legitimate capability of an application in such a way as to achieve a negative technical impact. The system functionality is not altered or modified but used in a way that was not intended. This is often accomplished through the overuse of a specific functionality or by leveraging functionality with design flaws that enables the adversary to gain access to unauthorized, sensitive data." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/212.html> ;
+    :related :CAPEC-663,
+        :CWE-1242,
+        :CWE-1246,
+        :CWE-1281 .
+
+:CAPEC-213 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Directory Traversal" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-126 : Path Traversal\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-213" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/213.html> .
+
+:CAPEC-214 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Fuzzing for garnering J2EE/.NET-based stack traces, for application mapping" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was merged into \"CAPEC-215 : Fuzzing for application mapping\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-214" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/214.html> .
+
+:CAPEC-215 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Fuzzing for application mapping" ;
+    rdfs:subClassOf :CAPEC-28,
+        :CAPEC-54 ;
+    :capec-id "CAPEC-215" ;
+    :definition "An attacker sends random, malformed, or otherwise unexpected messages to a target application and observes the application's log or error messages returned. The attacker does not initially know how a target will respond to individual messages but by attempting a large number of message variants they may find a variant that trigger's desired behavior. In this attack, the purpose of the fuzzing is to observe the application's log and error messages, although fuzzing a target can also sometimes cause the target to enter an unstable state, causing a crash." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/215.html> ;
+    :related :CWE-209,
+        :CWE-532 .
+
+:CAPEC-216 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Communication Channel Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-216" ;
+    :definition "An adversary manipulates a setting or parameter on communications channel in order to compromise its security. This can result in information exposure, insertion/removal of information from the communications stream, and/or potentially system compromise." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/216.html> ;
+    :related :CWE-306 .
+
+:CAPEC-217 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploiting Incorrectly Configured SSL/TLS" ;
+    rdfs:subClassOf :CAPEC-216 ;
+    :capec-id "CAPEC-217" ;
+    :definition "An adversary takes advantage of incorrectly configured SSL/TLS communications that enables access to data intended to be encrypted. The adversary may also use this type of attack to inject commands or other traffic into the encrypted stream to cause compromise of either the client or server." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/217.html> ;
+    :related :CWE-201 .
+
+:CAPEC-218 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Spoofing of UDDI/ebXML Messages" ;
+    rdfs:subClassOf :CAPEC-148 ;
+    :capec-id "CAPEC-218" ;
+    :definition "An attacker spoofs a UDDI, ebXML, or similar message in order to impersonate a service provider in an e-business transaction. UDDI, ebXML, and similar standards are used to identify businesses in e-business transactions. Among other things, they identify a particular participant, WSDL information for SOAP transactions, and supported communication protocols, including security protocols. By spoofing one of these messages an attacker could impersonate a legitimate business in a transaction or could manipulate the protocols used between a client and business. This could result in disclosure of sensitive information, loss of message integrity, or even financial fraud." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/218.html> ;
+    :related :CWE-345 .
+
+:CAPEC-219 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XML Routing Detour Attacks" ;
+    rdfs:subClassOf :CAPEC-94 ;
+    :capec-id "CAPEC-219" ;
+    :definition "An attacker subverts an intermediate system used to process XML content and forces the intermediate to modify and/or re-route the processing of the content. XML Routing Detour Attacks are Adversary in the Middle type attacks (CAPEC-94). The attacker compromises or inserts an intermediate system in the processing of the XML message. For example, WS-Routing can be used to specify a series of nodes or intermediaries through which content is passed. If any of the intermediate nodes in this route are compromised by an attacker they could be used for a routing detour attack. From the compromised system the attacker is able to route the XML process to other nodes of their choice and modify the responses so that the normal chain of processing is unaware of the interception. This system can forward the message to an outside entity and hide the forwarding and processing from the legitimate processing systems by altering the header information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/219.html> ;
+    :related :CWE-441,
+        :CWE-610 .
+
+:CAPEC-220 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Client-Server Protocol Manipulation" ;
+    rdfs:subClassOf :CAPEC-272 ;
+    :capec-id "CAPEC-220" ;
+    :definition "An adversary takes advantage of weaknesses in the protocol by which a client and server are communicating to perform unexpected actions. Communication protocols are necessary to transfer messages between client and server applications. Moreover, different protocols may be used for different types of interactions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/220.html> ;
+    :related :CWE-757 .
+
+:CAPEC-221 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Data Serialization External Entities Blowup" ;
+    rdfs:subClassOf :CAPEC-231,
+        :CAPEC-278 ;
+    :capec-id "CAPEC-221" ;
+    :definition "This attack takes advantage of the entity replacement property of certain data serialization languages (e.g., XML, YAML, etc.) where the value of the replacement is a URI. A well-crafted file could have the entity refer to a URI that consumes a large amount of resources to create a denial of service condition. This can cause the system to either freeze, crash, or execute arbitrary code depending on the URI." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/221.html> ;
+    :related :CWE-611 .
+
+:CAPEC-222 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "iFrame Overlay" ;
+    rdfs:subClassOf :CAPEC-103 ;
+    :capec-id "CAPEC-222" ;
+    :definition "In an iFrame overlay attack the victim is tricked into unknowingly initiating some action in one system while interacting with the UI from seemingly completely different system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/222.html> ;
+    :related :CWE-1021 .
+
+:CAPEC-224 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Fingerprinting" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-224" ;
+    :definition "An adversary compares output from a target system to known indicators that uniquely identify specific details about the target. Most commonly, fingerprinting is done to determine operating system and application versions. Fingerprinting can be done passively as well as actively. Fingerprinting by itself is not usually detrimental to the target. However, the information gathered through fingerprinting often enables an adversary to discover existing weaknesses in the target." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/224.html> ;
+    :related :CWE-200 .
+
+:CAPEC-226 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Session Credential Falsification through Manipulation" ;
+    rdfs:subClassOf :CAPEC-196 ;
+    :capec-id "CAPEC-226" ;
+    :definition "An attacker manipulates an existing credential in order to gain access to a target application. Session credentials allow users to identify themselves to a service after an initial authentication without needing to resend the authentication information (usually a username and password) with every message. An attacker may be able to manipulate a credential sniffed from an existing connection in order to gain access to a target server." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/226.html> ;
+    :related :CWE-472,
+        :CWE-565 .
+
+:CAPEC-227 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Sustained Client Engagement" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-227" ;
+    :definition "An adversary attempts to deny legitimate users access to a resource by continually engaging a specific resource in an attempt to keep the resource tied up as long as possible. The adversary's primary goal is not to crash or flood the target, which would alert defenders; rather it is to repeatedly perform actions or abuse algorithmic flaws such that a given resource is tied up and not available to a legitimate user. By carefully crafting a requests that keep the resource engaged through what is seemingly benign requests, legitimate users are limited or completely denied access to the resource." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/227.html> ;
+    :related :CWE-400,
+        :T1499 .
+
+:CAPEC-228 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DTD Injection" ;
+    rdfs:subClassOf :CAPEC-250 ;
+    :capec-id "CAPEC-228" ;
+    :definition "An attacker injects malicious content into an application's DTD in an attempt to produce a negative technical impact. DTDs are used to describe how XML documents are processed. Certain malformed DTDs (for example, those with excessive entity expansion as described in CAPEC 197) can cause the XML parsers that process the DTDs to consume excessive resources resulting in resource depletion." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/228.html> ;
+    :related :CWE-829 .
+
+:CAPEC-229 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Serialized Data Parameter Blowup" ;
+    rdfs:subClassOf :CAPEC-231 ;
+    :capec-id "CAPEC-229" ;
+    :definition "This attack exploits certain serialized data parsers (e.g., XML, YAML, etc.) which manage data in an inefficient manner. The attacker crafts an serialized data file with multiple configuration parameters in the same dataset. In a vulnerable parser, this results in a denial of service condition where CPU resources are exhausted because of the parsing algorithm. The weakness being exploited is tied to parser implementation and not language specific." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/229.html> ;
+    :related :CWE-770 .
+
+:CAPEC-230 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Serialized Data with Nested Payloads" ;
+    rdfs:subClassOf :CAPEC-130 ;
+    :capec-id "CAPEC-230" ;
+    :definition "Applications often need to transform data in and out of a data format (e.g., XML and YAML) by using a parser. It may be possible for an adversary to inject data that may have an adverse effect on the parser when it is being processed. Many data format languages allow the definition of macro-like structures that can be used to simplify the creation of complex structures. By nesting these structures, causing the data to be repeatedly substituted, an adversary can cause the parser to consume more resources while processing, causing excessive memory consumption and CPU utilization." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/230.html> ;
+    :related :CWE-20,
+        :CWE-112,
+        :CWE-674,
+        :CWE-770 .
+
+:CAPEC-231 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Oversized Serialized Data Payloads" ;
+    rdfs:subClassOf :CAPEC-130 ;
+    :capec-id "CAPEC-231" ;
+    :definition "An adversary injects oversized serialized data payloads into a parser during data processing to produce adverse effects upon the parser such as exhausting system resources and arbitrary code execution." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/231.html> ;
+    :related :CWE-20,
+        :CWE-112,
+        :CWE-674,
+        :CWE-770 .
+
+:CAPEC-233 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Privilege Escalation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-233" ;
+    :definition "An adversary exploits a weakness enabling them to elevate their privilege and perform an action that they are not supposed to be authorized to perform." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/233.html> ;
+    :related :CWE-269,
+        :CWE-1264,
+        :CWE-1311,
+        :T1548 .
+
+:CAPEC-234 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hijacking a privileged process" ;
+    rdfs:subClassOf :CAPEC-233 ;
+    :capec-id "CAPEC-234" ;
+    :definition "An adversary gains control of a process that is assigned elevated privileges in order to execute arbitrary code with those privileges. Some processes are assigned elevated privileges on an operating system, usually through association with a particular user, group, or role. If an attacker can hijack this process, they will be able to assume its level of privilege in order to execute their own code." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/234.html> ;
+    :related :CWE-648,
+        :CWE-732 .
+
+:CAPEC-235 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Implementing a callback to system routine (old AWT Queue)" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated. Please refer to CAPEC:30 - Hijacking a Privileged Thread of Execution." ;
+    :capec-id "CAPEC-235" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/235.html> .
+
+:CAPEC-236 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Catching exception throw/signal from privileged block" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it did not have enough distinction from CAPEC-30 : Hijacking a Privileged Thread of Execution. Please refer to CAPEC-30 moving forward." ;
+    :capec-id "CAPEC-236" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/236.html> .
+
+:CAPEC-237 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Escaping a Sandbox by Calling Code in Another Language" ;
+    rdfs:subClassOf :CAPEC-480 ;
+    :capec-id "CAPEC-237" ;
+    :definition "The attacker may submit malicious code of another language to obtain access to privileges that were not intentionally exposed by the sandbox, thus escaping the sandbox. For instance, Java code cannot perform unsafe operations, such as modifying arbitrary memory locations, due to restrictions placed on it by the Byte code Verifier and the JVM. If allowed, Java code can call directly into native C code, which may perform unsafe operations, such as call system calls and modify arbitrary memory locations on their behalf. To provide isolation, Java does not grant untrusted code with unmediated access to native C code. Instead, the sandboxed code is typically allowed to call some subset of the pre-existing native code that is part of standard libraries." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/237.html> ;
+    :related :CWE-693 .
+
+:CAPEC-238 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Using URL/codebase / G.A.C. (code source) to convince sandbox of privilege" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it did not appear to be a valid attack pattern." ;
+    :capec-id "CAPEC-238" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/238.html> .
+
+:CAPEC-239 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Subversion of Authorization Checks: Cache Filtering, Programmatic Security, etc." ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it did not contain any content and did not serve any useful purpose. Please refer to \"CAPEC-207: removing Important Client Functionality\" going forward." ;
+    :capec-id "CAPEC-239" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/239.html> .
+
+:CAPEC-240 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Resource Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-240" ;
+    :definition "An adversary exploits weaknesses in input validation by manipulating resource identifiers enabling the unintended modification or specification of a resource." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/240.html> ;
+    :related :CWE-99 .
+
+:CAPEC-241 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Code Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-242 : Code Injection\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-241" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/241.html> .
+
+:CAPEC-242 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Code Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-242" ;
+    :definition "An adversary exploits a weakness in input validation on the target to inject new code into that which is currently executing. This differs from code inclusion in that code inclusion involves the addition or replacement of a reference to a code file, which is subsequently loaded by the target and used as part of the code of some application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/242.html> ;
+    :related :CWE-94 .
+
+:CAPEC-243 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Targeting HTML Attributes" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-243" ;
+    :definition "An adversary inserts commands to perform cross-site scripting (XSS) actions in HTML attributes. Many filters do not adequately sanitize attributes against the presence of potentially dangerous commands even if they adequately sanitize tags. For example, dangerous expressions could be inserted into a style attribute in an anchor tag, resulting in the execution of malicious code when the resulting page is rendered. If a victim is tricked into viewing the rendered page the attack proceeds like a normal XSS attack, possibly resulting in the loss of sensitive cookies or other malicious activities." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/243.html> ;
+    :related :CWE-83 .
+
+:CAPEC-244 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Targeting URI Placeholders" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-244" ;
+    :definition "An attack of this type exploits the ability of most browsers to interpret \"data\", \"javascript\" or other URI schemes as client-side executable content placeholders. This attack consists of passing a malicious URI in an anchor tag HREF attribute or any other similar attributes in other HTML tags. Such malicious URI contains, for example, a base64 encoded HTML content with an embedded cross-site scripting payload. The attack is executed when the browser interprets the malicious content i.e., for example, when the victim clicks on the malicious link." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/244.html> ;
+    :related :CWE-83 .
+
+:CAPEC-245 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Using Doubled Characters" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-245" ;
+    :definition "The adversary bypasses input validation by using doubled characters in order to perform a cross-site scripting attack. Some filters fail to recognize dangerous sequences if they are preceded by repeated characters. For example, by doubling the < before a script command, (<<script or %3C%3script using URI encoding) the filters of some web applications may fail to recognize the presence of a script tag. If the targeted server is vulnerable to this type of bypass, the adversary can create a crafted URL or other trap to cause a victim to view a page on the targeted server where the malicious content is executed, as per a normal XSS attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/245.html> ;
+    :related :CWE-85 .
+
+:CAPEC-246 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: XSS Using Flash" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This pattern has been deprecated as it is covered by a chaining relationship between CAPEC-174: Flash Parameter Injection and CAPEC-591: Stored XSS. Please refer to these CAPECs going forward." ;
+    :capec-id "CAPEC-246" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/246.html> .
+
+:CAPEC-247 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XSS Using Invalid Characters" ;
+    rdfs:subClassOf :CAPEC-588,
+        :CAPEC-591,
+        :CAPEC-592 ;
+    :capec-id "CAPEC-247" ;
+    :definition "An adversary inserts invalid characters in identifiers to bypass application filtering of input. Filters may not scan beyond invalid characters but during later stages of processing content that follows these invalid characters may still be processed. This allows the adversary to sneak prohibited commands past filters and perform normally prohibited operations. Invalid characters may include null, carriage return, line feed or tab in an identifier. Successful bypassing of the filter can result in a XSS attack, resulting in the disclosure of web cookies or possibly other results." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/247.html> ;
+    :related :CWE-86 .
+
+:CAPEC-248 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Command Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-248" ;
+    :definition "An adversary looking to execute a command of their choosing, injects new items into an existing command thus modifying interpretation away from what was intended. Commands in this context are often standalone strings that are interpreted by a downstream component and cause specific responses. This type of attack is possible when untrusted values are used to build these command strings. Weaknesses in input validation or command construction can enable the attack and lead to successful exploitation." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/248.html> ;
+    :related :CWE-77 .
+
+:CAPEC-249 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Linux Terminal Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is covered by \"CAPEC-40 : Manipulating Writeable Terminal Devices\". Please refer to this CAPEC going forward." ;
+    :capec-id "CAPEC-249" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/249.html> .
+
+:CAPEC-250 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XML Injection" ;
+    rdfs:subClassOf :CAPEC-248 ;
+    :capec-id "CAPEC-250" ;
+    :definition "An attacker utilizes crafted XML user-controllable input to probe, attack, and inject data into the XML database, using techniques similar to SQL injection. The user-controllable input can allow for unauthorized viewing of data, bypassing authentication or the front-end application for direct XML database access, and possibly altering database information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/250.html> ;
+    :related :CWE-20,
+        :CWE-74,
+        :CWE-91,
+        :CWE-707 .
+
+:CAPEC-251 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Local Code Inclusion" ;
+    rdfs:subClassOf :CAPEC-175 ;
+    :capec-id "CAPEC-251" ;
+    :definition "The attacker forces an application to load arbitrary code files from the local machine. The attacker could use this to try to load old versions of library files that have known vulnerabilities, to load files that the attacker placed on the local machine during a prior attack, or to otherwise change the functionality of the targeted application in unexpected ways." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/251.html> ;
+    :related :CWE-829,
+        :T1055 .
+
+:CAPEC-252 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "PHP Local File Inclusion" ;
+    rdfs:subClassOf :CAPEC-251 ;
+    :capec-id "CAPEC-252" ;
+    :definition "The attacker loads and executes an arbitrary local PHP file on a target machine. The attacker could use this to try to load old versions of PHP files that have known vulnerabilities, to load PHP files that the attacker placed on the local machine during a prior attack, or to otherwise change the functionality of the targeted application in unexpected ways." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/252.html> ;
+    :related :CWE-829 .
+
+:CAPEC-253 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Remote Code Inclusion" ;
+    rdfs:subClassOf :CAPEC-175 ;
+    :capec-id "CAPEC-253" ;
+    :definition "The attacker forces an application to load arbitrary code files from a remote location. The attacker could use this to try to load old versions of library files that have known vulnerabilities, to load malicious files that the attacker placed on the remote machine, or to otherwise change the functionality of the targeted application in unexpected ways." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/253.html> ;
+    :related :CWE-829 .
+
+:CAPEC-254 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: DTD Injection in a SOAP Message" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the pattern CAPEC-228 : DTD Injection going forward." ;
+    :capec-id "CAPEC-254" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/254.html> .
+
+:CAPEC-256 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SOAP Array Overflow" ;
+    rdfs:subClassOf :CAPEC-100 ;
+    :capec-id "CAPEC-256" ;
+    :definition "An attacker sends a SOAP request with an array whose actual length exceeds the length indicated in the request. If the server processing the transmission naively trusts the specified size, then an attacker can intentionally understate the size of the array, possibly resulting in a buffer overflow if the server attempts to read the entire data set into the memory it allocated for a smaller array." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/256.html> ;
+    :related :CWE-805 .
+
+:CAPEC-257 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Abuse of Transaction Data Structure" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern." ;
+    :capec-id "CAPEC-257" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/257.html> .
+
+:CAPEC-258 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Passively Sniffing and Capturing Application Code Bound for an Authorized Client During Dynamic Update" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-65 : Sniff Application Code\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-258" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/258.html> .
+
+:CAPEC-259 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Passively Sniffing and Capturing Application Code Bound for an Authorized Client During Patching" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-65 : Sniff Application Code\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-259" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/259.html> .
+
+:CAPEC-260 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Passively Sniffing and Capturing Application Code Bound for an Authorized Client During Initial Distribution" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-65 : Sniff Application Code\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-260" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/260.html> .
+
+:CAPEC-261 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Fuzzing for garnering other adjacent user/sensitive data" ;
+    rdfs:subClassOf :CAPEC-54 ;
+    :capec-id "CAPEC-261" ;
+    :definition "An adversary who is authorized to send queries to a target sends variants of expected queries in the hope that these modified queries might return information (directly or indirectly through error logs) beyond what the expected set of queries should provide." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/261.html> ;
+    :related :CWE-20 .
+
+:CAPEC-263 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Force Use of Corrupted Files" ;
+    rdfs:subClassOf :CAPEC-17 ;
+    :capec-id "CAPEC-263" ;
+    :definition "This describes an attack where an application is forced to use a file that an attacker has corrupted. The result is often a denial of service caused by the application being unable to process the corrupted file, but other results, including the disabling of filters or access controls (if the application fails in an unsafe way rather than failing by locking down) or buffer overflows are possible." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/263.html> ;
+    :related :CWE-829 .
+
+:CAPEC-264 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Environment Variable Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-13 : Subverting Environment Variable Values\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-264" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/264.html> .
+
+:CAPEC-265 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Global variable manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-77 : Manipulating User-Controlled Variables\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-265" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/265.html> .
+
+:CAPEC-266 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Manipulate Canonicalization" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated." ;
+    :capec-id "CAPEC-266" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/266.html> .
+
+:CAPEC-267 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Leverage Alternate Encoding" ;
+    rdfs:subClassOf :CAPEC-153 ;
+    :capec-id "CAPEC-267" ;
+    :definition "An adversary leverages the possibility to encode potentially harmful input or content used by applications such that the applications are ineffective at validating this encoding standard." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/267.html> ;
+    :related :CWE-20,
+        :CWE-73,
+        :CWE-74,
+        :CWE-172,
+        :CWE-173,
+        :CWE-180,
+        :CWE-181,
+        :CWE-692,
+        :CWE-697,
+        :T1027 .
+
+:CAPEC-268 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Audit Log Manipulation" ;
+    rdfs:subClassOf :CAPEC-161 ;
+    :capec-id "CAPEC-268" ;
+    :definition "The attacker injects, manipulates, deletes, or forges malicious log entries into the log file, in an attempt to mislead an audit of the log file or cover tracks of an attack. Due to either insufficient access controls of the log files or the logging mechanism, the attacker is able to perform such actions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/268.html> ;
+    :related :CWE-117,
+        :T1070,
+        :T1562.002,
+        :T1562.003,
+        :T1562.008 .
+
+:CAPEC-269 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Registry Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This pattern has been deprecated as it was determined to be a duplicate of another pattern. Please refer to the pattern CAPEC-203 : Manipulate Application Registry Values going forward." ;
+    :capec-id "CAPEC-269" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/269.html> .
+
+:CAPEC-270 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Modification of Registry Run Keys" ;
+    rdfs:subClassOf :CAPEC-203 ;
+    :capec-id "CAPEC-270" ;
+    :definition "An adversary adds a new entry to the \"run keys\" in the Windows registry so that an application of their choosing is executed when a user logs in. In this way, the adversary can get their executable to operate and run on the target system with the authorized user's level of permissions. This attack is a good way for an adversary to run persistent spyware on a user's machine, such as a keylogger." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/270.html> ;
+    :related :CWE-15,
+        :T1547.001,
+        :T1547.014 .
+
+:CAPEC-271 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Schema Poisoning" ;
+    rdfs:subClassOf :CAPEC-176 ;
+    :capec-id "CAPEC-271" ;
+    :definition "An adversary corrupts or modifies the content of a schema for the purpose of undermining the security of the target. Schemas provide the structure and content definitions for resources used by an application. By replacing or modifying a schema, the adversary can affect how the application handles or interprets a resource, often leading to possible denial of service, entering into an unexpected state, or recording incomplete data." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/271.html> ;
+    :related :CWE-15 .
+
+:CAPEC-272 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Protocol Manipulation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-272" ;
+    :definition "An adversary subverts a communications protocol to perform an attack. This type of attack can allow an adversary to impersonate others, discover sensitive information, control the outcome of a session, or perform other attacks. This type of attack targets invalid assumptions that may be inherent in implementers of the protocol, incorrect implementations of the protocol, or vulnerabilities in the protocol itself." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/272.html> .
+
+:CAPEC-273 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP Response Smuggling" ;
+    rdfs:subClassOf :CAPEC-220 ;
+    :capec-id "CAPEC-273" ;
+    :definition "An adversary manipulates and injects malicious content in the form of secret unauthorized HTTP responses, into a single HTTP response from a vulnerable or compromised back-end HTTP agent (e.g., server)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/273.html> ;
+    :related :CAPEC-33,
+        :CWE-74,
+        :CWE-436,
+        :CWE-444 .
+
+:CAPEC-274 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP Verb Tampering" ;
+    rdfs:subClassOf :CAPEC-220 ;
+    :capec-id "CAPEC-274" ;
+    :definition "An attacker modifies the HTTP Verb (e.g. GET, PUT, TRACE, etc.) in order to bypass access restrictions. Some web environments allow administrators to restrict access based on the HTTP Verb used with requests. However, attackers can often provide a different HTTP Verb, or even provide a random string as a verb in order to bypass these protections. This allows the attacker to access data that should otherwise be protected." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/274.html> ;
+    :related :CWE-302,
+        :CWE-654 .
+
+:CAPEC-275 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DNS Rebinding" ;
+    rdfs:subClassOf :CAPEC-194 ;
+    :capec-id "CAPEC-275" ;
+    :definition "An adversary serves content whose IP address is resolved by a DNS server that the adversary controls. After initial contact by a web browser (or similar client), the adversary changes the IP address to which its name resolves, to an address within the target organization that is not publicly accessible. This allows the web browser to examine this internal address on behalf of the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/275.html> ;
+    :related :CWE-350 .
+
+:CAPEC-276 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Inter-component Protocol Manipulation" ;
+    rdfs:subClassOf :CAPEC-272 ;
+    :capec-id "CAPEC-276" ;
+    :definition "Inter-component protocols are used to communicate between different software and hardware modules within a single computer. Common examples are: interrupt signals and data pipes. Subverting the protocol can allow an adversary to impersonate others, discover sensitive information, control the outcome of a session, or perform other attacks. This type of attack targets invalid assumptions that may be inherent in implementers of the protocol, incorrect implementations of the protocol, or vulnerabilities in the protocol itself." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/276.html> ;
+    :related :CWE-707 .
+
+:CAPEC-277 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Data Interchange Protocol Manipulation" ;
+    rdfs:subClassOf :CAPEC-272 ;
+    :capec-id "CAPEC-277" ;
+    :definition "Data Interchange Protocols are used to transmit structured data between entities. These protocols are often specific to a particular domain (B2B: purchase orders, invoices, transport logistics and waybills, medical records). They are often, but not always, XML-based. Subverting the protocol can allow an adversary to impersonate others, discover sensitive information, control the outcome of a session, or perform other attacks. This type of attack targets invalid assumptions that may be inherent in implementers of the protocol, incorrect implementations of the protocol, or vulnerabilities in the protocol itself." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/277.html> ;
+    :related :CWE-707 .
+
+:CAPEC-278 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Web Services Protocol Manipulation" ;
+    rdfs:subClassOf :CAPEC-272 ;
+    :capec-id "CAPEC-278" ;
+    :definition "An adversary manipulates a web service related protocol to cause a web application or service to react differently than intended. This can either be performed through the manipulation of call parameters to include unexpected values, or by changing the called function to one that should normally be restricted or limited. By leveraging this pattern of attack, the adversary is able to gain access to data or resources normally restricted, or to cause the application or service to crash." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/278.html> ;
+    :related :CWE-707 .
+
+:CAPEC-279 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SOAP Manipulation" ;
+    rdfs:subClassOf :CAPEC-278 ;
+    :capec-id "CAPEC-279" ;
+    :definition "Simple Object Access Protocol (SOAP) is used as a communication protocol between a client and server to invoke web services on the server. It is an XML-based protocol, and therefore suffers from many of the same shortcomings as other XML-based protocols. Adversaries can make use of these shortcomings and manipulate the content of SOAP paramters, leading to undesirable behavior on the server and allowing the adversary to carry out a number of further attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/279.html> ;
+    :related :CWE-707 .
+
+:CAPEC-280 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: SOAP Parameter Tampering" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as its contents have been included in CAPEC-279 : SOAP Manipulation. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-280" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/280.html> .
+
+:CAPEC-285 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP Echo Request Ping" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-285" ;
+    :definition "An adversary sends out an ICMP Type 8 Echo Request, commonly known as a 'Ping', in order to determine if a target system is responsive. If the request is not blocked by a firewall or ACL, the target host will respond with an ICMP Type 0 Echo Reply datagram. This type of exchange is usually referred to as a 'Ping' due to the Ping utility present in almost all operating systems. Ping, as commonly implemented, allows a user to test for alive hosts, measure round-trip time, and measure the percentage of packet loss." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/285.html> ;
+    :related :CWE-200 .
+
+:CAPEC-287 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP SYN Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-287" ;
+    :definition "An adversary uses a SYN scan to determine the status of ports on the remote target. SYN scanning is the most common type of port scanning that is used because of its many advantages and few drawbacks. As a result, novice attackers tend to overly rely on the SYN scan while performing system reconnaissance. As a scanning method, the primary advantages of SYN scanning are its universality and speed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/287.html> ;
+    :related :CWE-200 .
+
+:CAPEC-288 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: ICMP Echo Request Ping" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-285\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-288" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/288.html> .
+
+:CAPEC-289 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Infrastructure-based footprinting" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the meta level pattern CAPEC-169 : going forward, or to any of its children patterns." ;
+    :capec-id "CAPEC-289" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/289.html> .
+
+:CAPEC-290 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Enumerate Mail Exchange (MX) Records" ;
+    rdfs:subClassOf :CAPEC-309 ;
+    :capec-id "CAPEC-290" ;
+    :definition "An adversary enumerates the MX records for a given via a DNS query. This type of information gathering returns the names of mail servers on the network. Mail servers are often not exposed to the Internet but are located within the DMZ of a network protected by a firewall. A side effect of this configuration is that enumerating the MX records for an organization my reveal the IP address of the firewall or possibly other internal systems. Attackers often resort to MX record enumeration when a DNS Zone Transfer is not possible." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/290.html> ;
+    :related :CWE-200 .
+
+:CAPEC-291 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DNS Zone Transfers" ;
+    rdfs:subClassOf :CAPEC-309 ;
+    :capec-id "CAPEC-291" ;
+    :definition "An attacker exploits a DNS misconfiguration that permits a ZONE transfer. Some external DNS servers will return a list of IP address and valid hostnames. Under certain conditions, it may even be possible to obtain Zone data about the organization's internal network. When successful the attacker learns valuable information about the topology of the target organization, including information about particular servers, their role within the IT structure, and possibly information about the operating systems running upon the network. This is configuration dependent behavior so it may also be required to search out multiple DNS servers while attempting to find one with ZONE transfers allowed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/291.html> ;
+    :related :CWE-200 .
+
+:CAPEC-292 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Host Discovery" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-292" ;
+    :definition "An adversary sends a probe to an IP address to determine if the host is alive. Host discovery is one of the earliest phases of network reconnaissance. The adversary usually starts with a range of IP addresses belonging to a target network and uses various methods to determine if a host is present at that IP address. Host discovery is usually referred to as 'Ping' scanning using a sonar analogy. The goal is to send a packet through to the IP address and solicit a response from the host. As such, a 'ping' can be virtually any crafted packet whatsoever, provided the adversary can identify a functional host based on its response. An attack of this nature is usually carried out with a 'ping sweep,' where a particular kind of ping is sent to a range of IP addresses." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/292.html> ;
+    :related :CWE-200,
+        :T1018 .
+
+:CAPEC-293 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Traceroute Route Enumeration" ;
+    rdfs:subClassOf :CAPEC-309 ;
+    :capec-id "CAPEC-293" ;
+    :definition "An adversary uses a traceroute utility to map out the route which data flows through the network in route to a target destination. Tracerouting can allow the adversary to construct a working topology of systems and routers by listing the systems through which data passes through on their way to the targeted machine. This attack can return varied results depending upon the type of traceroute that is performed. Traceroute works by sending packets to a target while incrementing the Time-to-Live field in the packet header. As the packet traverses each hop along its way to the destination, its TTL expires generating an ICMP diagnostic message that identifies where the packet expired. Traditional techniques for tracerouting involved the use of ICMP and UDP, but as more firewalls began to filter ingress ICMP, methods of traceroute using TCP were developed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/293.html> ;
+    :related :CWE-200 .
+
+:CAPEC-294 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP Address Mask Request" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-294" ;
+    :definition "An adversary sends an ICMP Type 17 Address Mask Request to gather information about a target's networking configuration. ICMP Address Mask Requests are defined by RFC-950, \"Internet Standard Subnetting Procedure.\" An Address Mask Request is an ICMP type 17 message that triggers a remote system to respond with a list of its related subnets, as well as its default gateway and broadcast address via an ICMP type 18 Address Mask Reply datagram. Gathering this type of information helps the adversary plan router-based attacks as well as denial-of-service attacks against the broadcast address." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/294.html> ;
+    :related :CWE-200 .
+
+:CAPEC-295 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Timestamp Request" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-295" ;
+    :definition "This pattern of attack leverages standard requests to learn the exact time associated with a target system. An adversary may be able to use the timestamp returned from the target to attack time-based security algorithms, such as random number generators, or time-based authentication mechanisms." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/295.html> ;
+    :related :CWE-200,
+        :T1124 .
+
+:CAPEC-296 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP Information Request" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-296" ;
+    :definition "An adversary sends an ICMP Information Request to a host to determine if it will respond to this deprecated mechanism. ICMP Information Requests are a deprecated message type. Information Requests were originally used for diskless machines to automatically obtain their network configuration, but this message type has been superseded by more robust protocol implementations like DHCP." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/296.html> ;
+    :related :CWE-200 .
+
+:CAPEC-297 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP ACK Ping" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-297" ;
+    :definition "An adversary sends a TCP segment with the ACK flag set to a remote host for the purpose of determining if the host is alive. This is one of several TCP 'ping' types. The RFC 793 expected behavior for a service is to respond with a RST 'reset' packet to any unsolicited ACK segment that is not part of an existing connection. So by sending an ACK segment to a port, the adversary can identify that the host is alive by looking for a RST packet. Typically, a remote server will respond with a RST regardless of whether a port is open or closed. In this way, TCP ACK pings cannot discover the state of a remote port because the behavior is the same in either case. The firewall will look up the ACK packet in its state-table and discard the segment because it does not correspond to any active connection. A TCP ACK Ping can be used to discover if a host is alive via RST response packets sent from the host." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/297.html> ;
+    :related :CWE-200 .
+
+:CAPEC-298 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "UDP Ping" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-298" ;
+    :definition "An adversary sends a UDP datagram to the remote host to determine if the host is alive. If a UDP datagram is sent to an open UDP port there is very often no response, so a typical strategy for using a UDP ping is to send the datagram to a random high port on the target. The goal is to solicit an 'ICMP port unreachable' message from the target, indicating that the host is alive. UDP pings are useful because some firewalls are not configured to block UDP datagrams sent to strange or typically unused ports, like ports in the 65K range. Additionally, while some firewalls may filter incoming ICMP, weaknesses in firewall rule-sets may allow certain types of ICMP (host unreachable, port unreachable) which are useful for UDP ping attempts." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/298.html> ;
+    :related :CWE-200 .
+
+:CAPEC-299 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP SYN Ping" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-299" ;
+    :definition "An adversary uses TCP SYN packets as a means towards host discovery. Typical RFC 793 behavior specifies that when a TCP port is open, a host must respond to an incoming SYN \"synchronize\" packet by completing stage two of the 'three-way handshake' - by sending an SYN/ACK in response. When a port is closed, RFC 793 behavior is to respond with a RST \"reset\" packet. This behavior can be used to 'ping' a target to see if it is alive by sending a TCP SYN packet to a port and then looking for a RST or an ACK packet in response." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/299.html> ;
+    :related :CWE-200 .
+
+:CAPEC-300 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Port Scanning" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-300" ;
+    :definition "An adversary uses a combination of techniques to determine the state of the ports on a remote target. Any service or application available for TCP or UDP networking will have a port open for communications over the network." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/300.html> ;
+    :related :CWE-200,
+        :T1046 .
+
+:CAPEC-301 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Connect Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-301" ;
+    :definition "An adversary uses full TCP connection attempts to determine if a port is open on the target system. The scanning process involves completing a 'three-way handshake' with a remote port, and reports the port as closed if the full handshake cannot be established. An advantage of TCP connect scanning is that it works against any TCP/IP stack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/301.html> ;
+    :related :CWE-200 .
+
+:CAPEC-302 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP FIN Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-302" ;
+    :definition "An adversary uses a TCP FIN scan to determine if ports are closed on the target machine. This scan type is accomplished by sending TCP segments with the FIN bit set in the packet header. The RFC 793 expected behavior is that any TCP segment with an out-of-state Flag sent to an open port is discarded, whereas segments with out-of-state flags sent to closed ports should be handled with a RST in response. This behavior should allow the adversary to scan for closed ports by sending certain types of rule-breaking packets (out of sync or disallowed by the TCB) and detect closed ports via RST packets." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/302.html> ;
+    :related :CWE-200 .
+
+:CAPEC-303 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Xmas Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-303" ;
+    :definition "An adversary uses a TCP XMAS scan to determine if ports are closed on the target machine. This scan type is accomplished by sending TCP segments with all possible flags set in the packet header, generating packets that are illegal based on RFC 793. The RFC 793 expected behavior is that any TCP segment with an out-of-state Flag sent to an open port is discarded, whereas segments with out-of-state flags sent to closed ports should be handled with a RST in response. This behavior should allow an attacker to scan for closed ports by sending certain types of rule-breaking packets (out of sync or disallowed by the TCB) and detect closed ports via RST packets." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/303.html> ;
+    :related :CWE-200 .
+
+:CAPEC-304 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Null Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-304" ;
+    :definition "An adversary uses a TCP NULL scan to determine if ports are closed on the target machine. This scan type is accomplished by sending TCP segments with no flags in the packet header, generating packets that are illegal based on RFC 793. The RFC 793 expected behavior is that any TCP segment with an out-of-state Flag sent to an open port is discarded, whereas segments with out-of-state flags sent to closed ports should be handled with a RST in response. This behavior should allow an attacker to scan for closed ports by sending certain types of rule-breaking packets (out of sync or disallowed by the TCB) and detect closed ports via RST packets." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/304.html> ;
+    :related :CWE-200 .
+
+:CAPEC-305 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP ACK Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-305" ;
+    :definition "An adversary uses TCP ACK segments to gather information about firewall or ACL configuration. The purpose of this type of scan is to discover information about filter configurations rather than port state. This type of scanning is rarely useful alone, but when combined with SYN scanning, gives a more complete picture of the type of firewall rules that are present." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/305.html> ;
+    :related :CWE-200 .
+
+:CAPEC-306 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Window Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-306" ;
+    :definition "An adversary engages in TCP Window scanning to analyze port status and operating system type. TCP Window scanning uses the ACK scanning method but examine the TCP Window Size field of response RST packets to make certain inferences. While TCP Window Scans are fast and relatively stealthy, they work against fewer TCP stack implementations than any other type of scan. Some operating systems return a positive TCP window size when a RST packet is sent from an open port, and a negative value when the RST originates from a closed port. TCP Window scanning is one of the most complex scan types, and its results are difficult to interpret. Window scanning alone rarely yields useful information, but when combined with other types of scanning is more useful. It is a generally more reliable means of making inference about operating system versions than port status." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/306.html> ;
+    :related :CWE-200 .
+
+:CAPEC-307 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP RPC Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-307" ;
+    :definition "An adversary scans for RPC services listing on a Unix/Linux host." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/307.html> ;
+    :related :CWE-200 .
+
+:CAPEC-308 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "UDP Scan" ;
+    rdfs:subClassOf :CAPEC-300 ;
+    :capec-id "CAPEC-308" ;
+    :definition "An adversary engages in UDP scanning to gather information about UDP port status on the target system. UDP scanning methods involve sending a UDP datagram to the target port and looking for evidence that the port is closed. Open UDP ports usually do not respond to UDP datagrams as there is no stateful mechanism within the protocol that requires building or establishing a session. Responses to UDP datagrams are therefore application specific and cannot be relied upon as a method of detecting an open port. UDP scanning relies heavily upon ICMP diagnostic messages in order to determine the status of a remote port." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/308.html> ;
+    :related :CWE-200 .
+
+:CAPEC-309 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Network Topology Mapping" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-309" ;
+    :definition "An adversary engages in scanning activities to map network nodes, hosts, devices, and routes. Adversaries usually perform this type of network reconnaissance during the early stages of attack against an external network. Many types of scanning utilities are typically employed, including ICMP tools, network mappers, port scanners, and route testing utilities such as traceroute." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/309.html> ;
+    :related :CWE-200,
+        :T1016,
+        :T1049,
+        :T1590 .
+
+:CAPEC-310 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Scanning for Vulnerable Software" ;
+    rdfs:subClassOf :CAPEC-541 ;
+    :capec-id "CAPEC-310" ;
+    :definition "An attacker engages in scanning activity to find vulnerable software versions or types, such as operating system versions or network services. Vulnerable or exploitable network configurations, such as improperly firewalled systems, or misconfigured systems in the DMZ or external network, provide windows of opportunity for an attacker. Common types of vulnerable software include unpatched operating systems or services (e.g FTP, Telnet, SMTP, SNMP) running on open ports that the attacker has identified. Attackers usually begin probing for vulnerable software once the external network has been port scanned and potential targets have been revealed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/310.html> ;
+    :related :CWE-200 .
+
+:CAPEC-311 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: OS Fingerprinting" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level patterns CAPEC-312 : Active OS Fingerprinting or CAPEC-313 : Passive OS Fingerprinting going forward, or to any of the detailed patterns that are children of them." ;
+    :capec-id "CAPEC-311" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/311.html> .
+
+:CAPEC-312 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Active OS Fingerprinting" ;
+    rdfs:subClassOf :CAPEC-224 ;
+    :capec-id "CAPEC-312" ;
+    :definition "An adversary engages in activity to detect the operating system or firmware version of a remote target by interrogating a device, server, or platform with a probe designed to solicit behavior that will reveal information about the operating systems or firmware in the environment. Operating System detection is possible because implementations of common protocols (Such as IP or TCP) differ in distinct ways. While the implementation differences are not sufficient to 'break' compatibility with the protocol the differences are detectable because the target will respond in unique ways to specific probing activity that breaks the semantic or logical rules of packet construction for a protocol. Different operating systems will have a unique response to the anomalous input, providing the basis to fingerprint the OS behavior. This type of OS fingerprinting can distinguish between operating system types and versions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/312.html> ;
+    :related :CWE-200,
+        :T1082 .
+
+:CAPEC-313 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Passive OS Fingerprinting" ;
+    rdfs:subClassOf :CAPEC-224 ;
+    :capec-id "CAPEC-313" ;
+    :definition "An adversary engages in activity to detect the version or type of OS software in a an environment by passively monitoring communication between devices, nodes, or applications. Passive techniques for operating system detection send no actual probes to a target, but monitor network or client-server communication between nodes in order to identify operating systems based on observed behavior as compared to a database of known signatures or values. While passive OS fingerprinting is not usually as reliable as active methods, it is generally better able to evade detection." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/313.html> ;
+    :related :CWE-200,
+        :T1082 .
+
+:CAPEC-314 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: IP Fingerprinting Probes" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level pattern CAPEC-312 : Active OS Fingerprinting going forward, or to any of the detailed patterns that children of CAPEC-312." ;
+    :capec-id "CAPEC-314" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/314.html> .
+
+:CAPEC-315 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: TCP/IP Fingerprinting Probes" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level pattern CAPEC-312 : Active OS Fingerprinting going forward, or to any of the detailed patterns that are children of CAPEC-312." ;
+    :capec-id "CAPEC-315" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/315.html> .
+
+:CAPEC-316 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: ICMP Fingerprinting Probes" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level pattern CAPEC-312 : Active OS Fingerprinting going forward, or to any of the detailed patterns that are children of CAPEC-312." ;
+    :capec-id "CAPEC-316" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/316.html> .
+
+:CAPEC-317 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "IP ID Sequencing Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-317" ;
+    :definition "This OS fingerprinting probe analyzes the IP 'ID' field sequence number generation algorithm of a remote host. Operating systems generate IP 'ID' numbers differently, allowing an attacker to identify the operating system of the host by examining how is assigns ID numbers when generating response packets. RFC 791 does not specify how ID numbers are chosen or their ranges, so ID sequence generation differs from implementation to implementation. There are two kinds of IP 'ID' sequence number analysis - IP 'ID' Sequencing: analyzing the IP 'ID' sequence generation algorithm for one protocol used by a host and Shared IP 'ID' Sequencing: analyzing the packet ordering via IP 'ID' values spanning multiple protocols, such as between ICMP and TCP." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/317.html> ;
+    :related :CWE-200 .
+
+:CAPEC-318 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "IP 'ID' Echoed Byte-Order Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-318" ;
+    :definition "This OS fingerprinting probe tests to determine if the remote host echoes back the IP 'ID' value from the probe packet. An attacker sends a UDP datagram with an arbitrary IP 'ID' value to a closed port on the remote host to observe the manner in which this bit is echoed back in the ICMP error message. The identification field (ID) is typically utilized for reassembling a fragmented packet. Some operating systems or router firmware reverse the bit order of the ID field when echoing the IP Header portion of the original datagram within an ICMP error message." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/318.html> ;
+    :related :CWE-200 .
+
+:CAPEC-319 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "IP (DF) 'Don't Fragment Bit' Echoing Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-319" ;
+    :definition "This OS fingerprinting probe tests to determine if the remote host echoes back the IP 'DF' (Don't Fragment) bit in a response packet. An attacker sends a UDP datagram with the DF bit set to a closed port on the remote host to observe whether the 'DF' bit is set in the response packet. Some operating systems will echo the bit in the ICMP error message while others will zero out the bit in the response packet." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/319.html> ;
+    :related :CWE-200 .
+
+:CAPEC-320 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Timestamp Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-320" ;
+    :definition "This OS fingerprinting probe examines the remote server's implementation of TCP timestamps. Not all operating systems implement timestamps within the TCP header, but when timestamps are used then this provides the attacker with a means to guess the operating system of the target. The attacker begins by probing any active TCP service in order to get response which contains a TCP timestamp. Different Operating systems update the timestamp value using different intervals. This type of analysis is most accurate when multiple timestamp responses are received and then analyzed. TCP timestamps can be found in the TCP Options field of the TCP header." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/320.html> ;
+    :related :CWE-200 .
+
+:CAPEC-321 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Sequence Number Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-321" ;
+    :definition "This OS fingerprinting probe tests the target system's assignment of TCP sequence numbers. One common way to test TCP Sequence Number generation is to send a probe packet to an open port on the target and then compare the how the Sequence Number generated by the target relates to the Acknowledgement Number in the probe packet. Different operating systems assign Sequence Numbers differently, so a fingerprint of the operating system can be obtained by categorizing the relationship between the acknowledgement number and sequence number as follows: 1) the Sequence Number generated by the target is Zero, 2) the Sequence Number generated by the target is the same as the acknowledgement number in the probe, 3) the Sequence Number generated by the target is the acknowledgement number plus one, or 4) the Sequence Number is any other non-zero number." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/321.html> ;
+    :related :CWE-200 .
+
+:CAPEC-322 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP (ISN) Greatest Common Divisor Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-322" ;
+    :definition "This OS fingerprinting probe sends a number of TCP SYN packets to an open port of a remote machine. The Initial Sequence Number (ISN) in each of the SYN/ACK response packets is analyzed to determine the smallest number that the target host uses when incrementing sequence numbers. This information can be useful for identifying an operating system because particular operating systems and versions increment sequence numbers using different values. The result of the analysis is then compared against a database of OS behaviors to determine the OS type and/or version." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/322.html> ;
+    :related :CWE-200 .
+
+:CAPEC-323 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP (ISN) Counter Rate Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-323" ;
+    :definition "This OS detection probe measures the average rate of initial sequence number increments during a period of time. Sequence numbers are incremented using a time-based algorithm and are susceptible to a timing analysis that can determine the number of increments per unit time. The result of this analysis is then compared against a database of operating systems and versions to determine likely operation system matches." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/323.html> ;
+    :related :CWE-200 .
+
+:CAPEC-324 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP (ISN) Sequence Predictability Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-324" ;
+    :definition "This type of operating system probe attempts to determine an estimate for how predictable the sequence number generation algorithm is for a remote host. Statistical techniques, such as standard deviation, can be used to determine how predictable the sequence number generation is for a system. This result can then be compared to a database of operating system behaviors to determine a likely match for operating system and version." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/324.html> ;
+    :related :CWE-200 .
+
+:CAPEC-325 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Congestion Control Flag (ECN) Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-325" ;
+    :definition "This OS fingerprinting probe checks to see if the remote host supports explicit congestion notification (ECN) messaging. ECN messaging was designed to allow routers to notify a remote host when signal congestion problems are occurring. Explicit Congestion Notification messaging is defined by RFC 3168. Different operating systems and versions may or may not implement ECN notifications, or may respond uniquely to particular ECN flag types." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/325.html> ;
+    :related :CWE-200 .
+
+:CAPEC-326 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Initial Window Size Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-326" ;
+    :definition "This OS fingerprinting probe checks the initial TCP Window size. TCP stacks limit the range of sequence numbers allowable within a session to maintain the \"connected\" state within TCP protocol logic. The initial window size specifies a range of acceptable sequence numbers that will qualify as a response to an ACK packet within a session. Various operating systems use different Initial window sizes. The initial window size can be sampled by establishing an ordinary TCP connection." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/326.html> ;
+    :related :CWE-200 .
+
+:CAPEC-327 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Options Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-327" ;
+    :definition "This OS fingerprinting probe analyzes the type and order of any TCP header options present within a response segment. Most operating systems use unique ordering and different option sets when options are present. RFC 793 does not specify a required order when options are present, so different implementations use unique ways of ordering or structuring TCP options. TCP options can be generated by ordinary TCP traffic." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/327.html> ;
+    :related :CWE-200 .
+
+:CAPEC-328 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP 'RST' Flag Checksum Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-328" ;
+    :definition "This OS fingerprinting probe performs a checksum on any ASCII data contained within the data portion or a RST packet. Some operating systems will report a human-readable text message in the payload of a 'RST' (reset) packet when specific types of connection errors occur. RFC 1122 allows text payloads within reset packets but not all operating systems or routers implement this functionality." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/328.html> ;
+    :related :CWE-200 .
+
+:CAPEC-329 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP Error Message Quoting Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-329" ;
+    :definition "An adversary uses a technique to generate an ICMP Error message (Port Unreachable, Destination Unreachable, Redirect, Source Quench, Time Exceeded, Parameter Problem) from a target and then analyze the amount of data returned or \"Quoted\" from the originating request that generated the ICMP error message." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/329.html> ;
+    :related :CWE-200 .
+
+:CAPEC-330 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP Error Message Echoing Integrity Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-330" ;
+    :definition "An adversary uses a technique to generate an ICMP Error message (Port Unreachable, Destination Unreachable, Redirect, Source Quench, Time Exceeded, Parameter Problem) from a target and then analyze the integrity of data returned or \"Quoted\" from the originating request that generated the error message." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/330.html> ;
+    :related :CWE-200 .
+
+:CAPEC-331 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP IP Total Length Field Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-331" ;
+    :definition "An adversary sends a UDP packet to a closed port on the target machine to solicit an IP Header's total length field value within the echoed 'Port Unreachable\" error message. This type of behavior is useful for building a signature-base of operating system responses, particularly when error messages contain other types of information that is useful identifying specific operating system responses." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/331.html> ;
+    :related :CWE-204 .
+
+:CAPEC-332 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP IP 'ID' Field Error Message Probe" ;
+    rdfs:subClassOf :CAPEC-312 ;
+    :capec-id "CAPEC-332" ;
+    :definition "An adversary sends a UDP datagram having an assigned value to its internet identification field (ID) to a closed port on a target to observe the manner in which this bit is echoed back in the ICMP error message. This allows the attacker to construct a fingerprint of specific OS behaviors." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/332.html> ;
+    :related :CWE-204 .
+
+:CAPEC-383 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Harvesting Information via API Event Monitoring" ;
+    rdfs:subClassOf :CAPEC-407 ;
+    :capec-id "CAPEC-383" ;
+    :definition "An adversary hosts an event within an application framework and then monitors the data exchanged during the course of the event for the purpose of harvesting any important data leaked during the transactions. One example could be harvesting lists of usernames or userIDs for the purpose of sending spam messages to those users. One example of this type of attack involves the adversary creating an event within the sub-application. Assume the adversary hosts a \"virtual sale\" of rare items. As other users enter the event, the attacker records via AiTM (CAPEC-94) proxy the user_ids and usernames of everyone who attends. The adversary would then be able to spam those users within the application using an automated script." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/383.html> ;
+    :related :CWE-311,
+        :CWE-319,
+        :CWE-419,
+        :CWE-602,
+        :T1056.004 .
+
+:CAPEC-384 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Application API Message Manipulation via Man-in-the-Middle" ;
+    rdfs:subClassOf :CAPEC-94 ;
+    :capec-id "CAPEC-384" ;
+    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the content of messages. Performing this attack can allow the attacker to gain unauthorized privileges within the application, or conduct attacks such as phishing, deceptive strategies to spread malware, or traditional web-application attacks. The techniques require use of specialized software that allow the attacker to perform adversary-in-the-middle (CAPEC-94) communications between the web browser and the remote system. Despite the use of AiTH software, the attack is actually directed at the server, as the client is one node in a series of content brokers that pass information along to the application framework. Additionally, it is not true \"Adversary-in-the-Middle\" attack at the network layer, but an application-layer attack the root cause of which is the master applications trust in the integrity of code supplied by the client." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/384.html> ;
+    :related :CWE-311,
+        :CWE-345,
+        :CWE-346,
+        :CWE-471,
+        :CWE-602 .
+
+:CAPEC-385 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Transaction or Event Tampering via Application API Manipulation" ;
+    rdfs:subClassOf :CAPEC-384 ;
+    :capec-id "CAPEC-385" ;
+    :definition "An attacker hosts or joins an event or transaction within an application framework in order to change the content of messages or items that are being exchanged. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that look authentic but may contain deceptive links, substitute one item or another, spoof an existing item and conduct a false exchange, or otherwise change the amounts or identity of what is being exchanged. The techniques require use of specialized software that allow the attacker to man-in-the-middle communications between the web browser and the remote system in order to change the content of various application elements. Often, items exchanged in game can be monetized via sales for coin, virtual dollars, etc. The purpose of the attack is for the attack to scam the victim by trapping the data packets involved the exchange and altering the integrity of the transfer process." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/385.html> ;
+    :related :CWE-311,
+        :CWE-345,
+        :CWE-346,
+        :CWE-471,
+        :CWE-602 .
+
+:CAPEC-386 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Application API Navigation Remapping" ;
+    rdfs:subClassOf :CAPEC-94 ;
+    :capec-id "CAPEC-386" ;
+    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the destination and/or content of links/buttons displayed to a user within API messages. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that looks authentic but contains links/buttons that point to an attacker controlled destination. Some applications make navigation remapping more difficult to detect because the actual HREF values of images, profile elements, and links/buttons are masked. One example would be to place an image in a user's photo gallery that when clicked upon redirected the user to an off-site location. Also, traditional web vulnerabilities (such as CSRF) can be constructed with remapped buttons or links. In some cases navigation remapping can be used for Phishing attacks or even means to artificially boost the page view, user site reputation, or click-fraud." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/386.html> ;
+    :related :CWE-311,
+        :CWE-345,
+        :CWE-346,
+        :CWE-471,
+        :CWE-602 .
+
+:CAPEC-387 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Navigation Remapping To Propagate Malicious Content" ;
+    rdfs:subClassOf :CAPEC-386 ;
+    :capec-id "CAPEC-387" ;
+    :definition "An adversary manipulates either egress or ingress data from a client within an application framework in order to change the content of messages and thereby circumvent the expected application logic." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/387.html> ;
+    :related :CWE-311,
+        :CWE-345,
+        :CWE-346,
+        :CWE-471,
+        :CWE-602 .
+
+:CAPEC-388 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Application API Button Hijacking" ;
+    rdfs:subClassOf :CAPEC-386 ;
+    :capec-id "CAPEC-388" ;
+    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the destination and/or content of buttons displayed to a user within API messages. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that looks authentic but contains buttons that point to an attacker controlled destination." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/388.html> ;
+    :related :CWE-311,
+        :CWE-345,
+        :CWE-346,
+        :CWE-471,
+        :CWE-602 .
+
+:CAPEC-389 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Content Spoofing Via Application API Manipulation" ;
+    rdfs:subClassOf :CAPEC-384 ;
+    :capec-id "CAPEC-389" ;
+    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the content of messages. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that look authentic but may contain deceptive links, spam-like content, or links to the attackers' code. In general, content-spoofing within an application API can be employed to stage many different types of attacks varied based on the attackers' intent. The techniques require use of specialized software that allow the attacker to use adversary-in-the-middle (CAPEC-94) communications between the web browser and the remote system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/389.html> ;
+    :related :CWE-353 .
+
+:CAPEC-390 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bypassing Physical Security" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-390" ;
+    :definition "Facilities often used layered models for physical security such as traditional locks, Electronic-based card entry systems, coupled with physical alarms. Hardware security mechanisms range from the use of computer case and cable locks as well as RFID tags for tracking computer assets. This layered approach makes it difficult for random physical security breaches to go unnoticed, but is less effective at stopping deliberate and carefully planned break-ins. Avoiding detection begins with evading building security and surveillance and methods for bypassing the electronic or physical locks which secure entry points." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/390.html> .
+
+:CAPEC-391 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bypassing Physical Locks" ;
+    rdfs:subClassOf :CAPEC-390 ;
+    :capec-id "CAPEC-391" ;
+    :definition "An attacker uses techniques and methods to bypass physical security measures of a building or facility. Physical locks may range from traditional lock and key mechanisms, cable locks used to secure laptops or servers, locks on server cases, or other such devices. Techniques such as lock bumping, lock forcing via snap guns, or lock picking can be employed to bypass those locks and gain access to the facilities or devices they protect, although stealth, evidence of tampering, and the integrity of the lock following an attack, are considerations that may determine the method employed. Physical locks are limited by the complexity of the locking mechanism. While some locks may offer protections such as shock resistant foam to prevent bumping or lock forcing methods, many commonly employed locks offer no such countermeasures." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/391.html> .
+
+:CAPEC-392 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Lock Bumping" ;
+    rdfs:subClassOf :CAPEC-391 ;
+    :capec-id "CAPEC-392" ;
+    :definition "An attacker uses a bump key to force a lock on a building or facility and gain entry. Lock Bumping is the use of a special type of key that can be tapped or bumped to cause the pins within the lock to fall into temporary alignment, allowing the lock to be opened. Lock bumping allows an attacker to open a lock without having the correct key. A standard lock is secured by a set of internal pins that prevent the device from turning. Spring loaded driver pins push down on the key pins. When the correct key is inserted, the ridges on the key push the key pins up and against the driver pins, causing correct alignment which allows the lock cylinder to rotate. A bump key is a specially constructed key that exploits this design. When the bump key is struck or firmly tapped, its teeth transfer the force of the tap into the key pins, causing the lock to momentarily shift into proper alignment for the mechanism to be opened." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/392.html> .
+
+:CAPEC-393 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Lock Picking" ;
+    rdfs:subClassOf :CAPEC-391 ;
+    :capec-id "CAPEC-393" ;
+    :definition "An attacker uses lock picking tools and techniques to bypass the locks on a building or facility. Lock picking is the use of a special set of tools to manipulate the pins within a lock. Different sets of tools are required for each type of lock. Lock picking attacks have the advantage of being non-invasive in that if performed correctly the lock will not be damaged. A standard lock pin-and-tumbler lock is secured by a set of internal pins that prevent the tumbler device from turning. Spring loaded driver pins push down on the key pins preventing rotation so that the bolt remains in a locked position.. When the correct key is inserted, the ridges on the key push the key pins up and against the driver pins, causing correct alignment which allows the lock cylinder to rotate. Most common locks, such as domestic locks in the US, can be picked using a standard 2 tools (i.e. a torsion wrench and a hook pick)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/393.html> .
+
+:CAPEC-394 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Using a Snap Gun Lock to Force a Lock" ;
+    rdfs:subClassOf :CAPEC-391 ;
+    :capec-id "CAPEC-394" ;
+    :definition "An attacker uses a Snap Gun, also known as a Pick Gun, to force the lock on a building or facility. A Pick Gun is a special type of lock picking instrument that works on similar principles as lock bumping. A snap gun is a hand-held device with an attached metal pick. The metal pick strikes the pins within the lock, transferring motion from the key pins to the driver pins and forcing the lock into momentary alignment. A standard lock is secured by a set of internal pins that prevent the device from turning. Spring loaded driver pins push down on the key pins. When the correct key is inserted, the ridges on the key push the key pins up and against the driver pins, causing correct alignment which allows the lock cylinder to rotate. A Snap Gun exploits this design by using a metal pin to strike all of the key pins at once, forcing the driver pins to shift into an unlocked position. Unlike bump keys or lock picks, a Snap Gun may damage the lock more easily, leaving evidence that the lock has been tampered with." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/394.html> .
+
+:CAPEC-395 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bypassing Electronic Locks and Access Controls" ;
+    rdfs:subClassOf :CAPEC-390 ;
+    :capec-id "CAPEC-395" ;
+    :definition "An attacker exploits security assumptions to bypass electronic locks or other forms of access controls. Most attacks against electronic access controls follow similar methods but utilize different tools. Some electronic locks utilize magnetic strip cards, others employ RFID tags embedded within a card or badge, or may involve more sophisticated protections such as voice-print, thumb-print, or retinal biometrics. Magnetic Strip and RFID technologies are the most widespread because they are cost effective to deploy and more easily integrated with other electronic security measures. These technologies share common weaknesses that an attacker can exploit to gain access to a facility protected by the mechanisms via copying legitimate cards or badges, or generating new cards using reverse-engineered algorithms." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/395.html> .
+
+:CAPEC-396 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Bypassing Card or Badge-Based Systems" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-397: Cloning Magnetic Strip Cards, CAPEC-398: Magnetic Strip Card Brute Force Attacks, CAPEC-399: Cloning RFID Cards or Chips and CAPEC-400: RFID Chip Deactivation or Destruction. Please refer to these CAPECs going forward." ;
+    :capec-id "CAPEC-396" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/396.html> .
+
+:CAPEC-397 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cloning Magnetic Strip Cards" ;
+    rdfs:subClassOf :CAPEC-395 ;
+    :capec-id "CAPEC-397" ;
+    :definition "An attacker duplicates the data on a Magnetic strip card (i.e. 'swipe card' or 'magstripe') to gain unauthorized access to a physical location or a person's private information. Magstripe cards encode data on a band of iron-based magnetic particles arrayed in a stripe along a rectangular card. Most magstripe card data formats conform to ISO standards 7810, 7811, 7813, 8583, and 4909. The primary advantage of magstripe technology is ease of encoding and portability, but this also renders magnetic strip cards susceptible to unauthorized duplication. If magstripe cards are used for access control, all an attacker need do is obtain a valid card long enough to make a copy of the card and then return the card to its location (i.e. a co-worker's desk). Magstripe reader/writers are widely available as well as software for analyzing data encoded on the cards. By swiping a valid card, it becomes trivial to make any number of duplicates that function as the original." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/397.html> .
+
+:CAPEC-398 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Magnetic Strip Card Brute Force Attacks" ;
+    rdfs:subClassOf :CAPEC-395 ;
+    :capec-id "CAPEC-398" ;
+    :definition "An adversary analyzes the data on two or more magnetic strip cards and is able to generate new cards containing valid sequences that allow unauthorized access and/or impersonation of individuals." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/398.html> .
+
+:CAPEC-399 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cloning RFID Cards or Chips" ;
+    rdfs:subClassOf :CAPEC-395 ;
+    :capec-id "CAPEC-399" ;
+    :definition "An attacker analyzes data returned by an RFID chip and uses this information to duplicate a RFID signal that responds identically to the target chip. In some cases RFID chips are used for building access control, employee identification, or as markers on products being delivered along a supply chain. Some organizations also embed RFID tags inside computer assets to trigger alarms if they are removed from particular rooms, zones, or buildings. Similar to Magnetic strip cards, RFID cards are susceptible to duplication (cloning) and reuse." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/399.html> .
+
+:CAPEC-400 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "RFID Chip Deactivation or Destruction" ;
+    rdfs:subClassOf :CAPEC-395 ;
+    :capec-id "CAPEC-400" ;
+    :definition "An attacker uses methods to deactivate a passive RFID tag for the purpose of rendering the tag, badge, card, or object containing the tag unresponsive. RFID tags are used primarily for access control, inventory, or anti-theft devices. The purpose of attacking the RFID chip is to disable or damage the chip without causing damage to the object housing it." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/400.html> .
+
+:CAPEC-401 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Physically Hacking Hardware" ;
+    rdfs:subClassOf :CAPEC-440 ;
+    :capec-id "CAPEC-401" ;
+    :definition "An adversary exploits a weakness in access control to gain access to currently installed hardware and precedes to implement changes or secretly replace a hardware component which undermines the system's integrity for the purpose of carrying out an attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/401.html> ;
+    :related :CWE-1263 .
+
+:CAPEC-402 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bypassing ATA Password Security" ;
+    rdfs:subClassOf :CAPEC-401 ;
+    :capec-id "CAPEC-402" ;
+    :definition "An adversary exploits a weakness in ATA security on a drive to gain access to the information the drive contains without supplying the proper credentials. ATA Security is often employed to protect hard disk information from unauthorized access. The mechanism requires the user to type in a password before the BIOS is allowed access to drive contents. Some implementations of ATA security will accept the ATA command to update the password without the user having authenticated with the BIOS. This occurs because the security mechanism assumes the user has first authenticated via the BIOS prior to sending commands to the drive. Various methods exist for exploiting this flaw, the most common being installing the ATA protected drive into a system lacking ATA security features (a.k.a. hot swapping). Once the drive is installed into the new system the BIOS can be used to reset the drive password." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/402.html> ;
+    :related :CWE-285 .
+
+:CAPEC-404 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Social Information Gathering Attacks" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
+    :capec-id "CAPEC-404" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/404.html> .
+
+:CAPEC-405 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Social Information Gathering via Research" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
+    :capec-id "CAPEC-405" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/405.html> .
+
+:CAPEC-406 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Dumpster Diving" ;
+    rdfs:subClassOf :CAPEC-150 ;
+    :capec-id "CAPEC-406" ;
+    :definition "An adversary cases an establishment and searches through trash bins, dumpsters, or areas where company information may have been accidentally discarded for information items which may be useful to the dumpster diver. The devastating nature of the items and/or information found can be anything from medical records, resumes, personal photos and emails, bank statements, account details or information about software, tech support logs and so much more, including hardware devices. By collecting this information an adversary may be able to learn important facts about the person or organization that play a role in helping the adversary in their attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/406.html> .
+
+:CAPEC-407 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pretexting" ;
+    rdfs:subClassOf :CAPEC-410,
+        :CAPEC-416 ;
+    :capec-id "CAPEC-407" ;
+    :definition "An adversary engages in pretexting behavior to solicit information from target persons, or manipulate the target into performing some action that serves the adversary's interests. During a pretexting attack, the adversary creates an invented scenario, assuming an identity or role to persuade a targeted victim to release information or perform some action. It is more than just creating a lie; in some cases it can be creating a whole new identity and then using that identity to manipulate the receipt of information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/407.html> ;
+    :related :T1589 .
+
+:CAPEC-408 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Information Gathering from Traditional Sources" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
+    :capec-id "CAPEC-408" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/408.html> .
+
+:CAPEC-409 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Information Gathering from Non-Traditional Sources" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
+    :capec-id "CAPEC-409" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/409.html> .
+
+:CAPEC-410 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Information Elicitation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-410" ;
+    :definition "An adversary engages an individual using any combination of social engineering methods for the purpose of extracting information. Accurate contextual and environmental queues, such as knowing important information about the target company or individual can greatly increase the success of the attack and the quality of information gathered. Authentic mimicry combined with detailed knowledge increases the success of elicitation attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/410.html> .
+
+:CAPEC-411 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Pretexting" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-407 : Social Information Gathering via Pretexting\". Please refer to this other CAPEC going forward." ;
+    :capec-id "CAPEC-411" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/411.html> .
+
+:CAPEC-412 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pretexting via Customer Service" ;
+    rdfs:subClassOf :CAPEC-407 ;
+    :capec-id "CAPEC-412" ;
+    :definition "An adversary engages in pretexting behavior, assuming the role of someone who works for Customer Service, to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. One example of a scenario such as this would be to call an individual, articulate your false affiliation with a credit card company, and then attempt to get the individual to verify their credit card number." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/412.html> .
+
+:CAPEC-413 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pretexting via Tech Support" ;
+    rdfs:subClassOf :CAPEC-407 ;
+    :capec-id "CAPEC-413" ;
+    :definition "An adversary engages in pretexting behavior, assuming the role of a tech support worker, to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. An adversary who uses social engineering to impersonate a tech support worker can have devastating effects on a network. This is an effective attack vector, because it can give an adversary physical access to network computers. It only takes a matter of seconds for someone to compromise a computer with physical access. One of the best technological tools at the disposal of a social engineer, posing as a technical support person, is a USB thumb drive. These are small, easy to conceal, and can be loaded with different payloads depending on what task needs to be done. However, this form of attack does not require physical access as it can also be effectively carried out via phone or email." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/413.html> .
+
+:CAPEC-414 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pretexting via Delivery Person" ;
+    rdfs:subClassOf :CAPEC-407 ;
+    :capec-id "CAPEC-414" ;
+    :definition "An adversary engages in pretexting behavior, assuming the role of a delivery person, to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. Impersonating a delivery person is an effective attack and an easy attack since not much acting is involved. Usually the hardest part is looking the part and having all of the proper credentials, papers and \"deliveries\" in order to be able to pull it off." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/414.html> .
+
+:CAPEC-415 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pretexting via Phone" ;
+    rdfs:subClassOf :CAPEC-407 ;
+    :capec-id "CAPEC-415" ;
+    :definition "An adversary engages in pretexting behavior, assuming some sort of trusted role, and contacting the targeted individual or organization via phone to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. This is the most common social engineering attack. Some of the most commonly effective approaches are to impersonate a fellow employee, impersonate a computer technician or to target help desk personnel." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/415.html> .
+
+:CAPEC-416 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulate Human Behavior" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-416" ;
+    :definition "An adversary exploits inherent human psychological predisposition to influence a targeted individual or group to solicit information or manipulate the target into performing an action that serves the adversary's interests. Many interpersonal social engineering techniques do not involve outright deception, although they can; many are subtle ways of manipulating a target to remove barriers, make the target feel comfortable, and produce an exchange in which the target is either more likely to share information directly, or let key information slip out unintentionally. A skilled adversary uses these techniques when appropriate to produce the desired outcome. Manipulation techniques vary from the overt, such as pretending to be a supervisor to a help desk, to the subtle, such as making the target feel comfortable with the adversary's speech and thought patterns." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/416.html> .
+
+:CAPEC-417 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence Perception" ;
+    rdfs:subClassOf :CAPEC-416 ;
+    :capec-id "CAPEC-417" ;
+    :definition "The adversary uses social engineering to exploit the target's perception of the relationship between the adversary and themselves. This goal is to persuade the target to unknowingly perform an action or divulge information that is advantageous to the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/417.html> .
+
+:CAPEC-418 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence Perception of Reciprocation" ;
+    rdfs:subClassOf :CAPEC-417 ;
+    :capec-id "CAPEC-418" ;
+    :definition "An adversary uses a social engineering techniques to produce a sense of obligation in the target to perform a certain action or concede some sensitive or key piece of information. Obligation has to do with actions one feels they need to take due to some sort of social, legal, or moral requirement, duty, contract, or promise. There are various techniques for fostering a sense of obligation to reciprocate or concede during ordinary modes of communication. One method is to compliment the target, and follow up the compliment with a question. If performed correctly the target may volunteer a key piece of information, sometimes involuntarily." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/418.html> .
+
+:CAPEC-419 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Target Influence via Perception of Concession" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate pattern." ;
+    :capec-id "CAPEC-419" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/419.html> .
+
+:CAPEC-420 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence Perception of Scarcity" ;
+    rdfs:subClassOf :CAPEC-417 ;
+    :capec-id "CAPEC-420" ;
+    :definition "The adversary leverages a perception of scarcity to persuade the target to perform an action or divulge information that is advantageous to the adversary. By conveying a perception of scarcity, or a situation of limited supply, the adversary aims to create a sense of urgency in the context of a target's decision-making process." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/420.html> .
+
+:CAPEC-421 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence Perception of Authority" ;
+    rdfs:subClassOf :CAPEC-417 ;
+    :capec-id "CAPEC-421" ;
+    :definition "An adversary uses a social engineering technique to convey a sense of authority that motivates the target to reveal specific information or take specific action. There are various techniques for producing a sense of authority during ordinary modes of communication. One common method is impersonation. By impersonating someone with a position of power within an organization, an adversary may motivate the target individual to reveal some piece of sensitive information or perform an action that benefits the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/421.html> .
+
+:CAPEC-422 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence Perception of Commitment and Consistency" ;
+    rdfs:subClassOf :CAPEC-417 ;
+    :capec-id "CAPEC-422" ;
+    :definition "An adversary uses social engineering to convince the target to do minor tasks as opposed to larger actions. After complying with a request, individuals are more likely to agree to subsequent requests that are similar in type and required effort." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/422.html> .
+
+:CAPEC-423 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence Perception of Liking" ;
+    rdfs:subClassOf :CAPEC-417 ;
+    :capec-id "CAPEC-423" ;
+    :definition "The adversary influences the target's actions by building a relationship where the target has a liking to the adversary. People are more likely to be influenced by people of whom they are fond, so the adversary attempts to ingratiate themself with the target via actions, appearance, or a combination thereof." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/423.html> .
+
+:CAPEC-424 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence Perception of Consensus or Social Proof" ;
+    rdfs:subClassOf :CAPEC-417 ;
+    :capec-id "CAPEC-424" ;
+    :definition "The adversary influences the target's actions by leveraging the inherent human nature to assume behavior of others is appropriate. In situations of uncertainty, people tend to behave in ways they see others behaving. The adversary convinces the target of adopting behavior or actions that is advantageous to the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/424.html> .
+
+:CAPEC-425 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Target Influence via Framing" ;
+    rdfs:subClassOf :CAPEC-416 ;
+    :capec-id "CAPEC-425" ;
+    :definition "An adversary uses framing techniques to contextualize a conversation so that the target is more likely to be influenced by the adversary's point of view. Framing is information and experiences in life that alter the way we react to decisions we must make. This type of persuasive technique exploits the way people are conditioned to perceive data and its significance, while avoiding negative or avoidance responses from the target. Rather than a specific technique framing is a methodology of conversation that slowly encourages the target to adopt to the adversary's perspective. One technique of framing is to avoid the use of the word \"No\" and to contextualize responses in a manner that is positive. When performed skillfully the target is much more likely to volunteer information or perform actions favorable to the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/425.html> .
+
+:CAPEC-426 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence via Incentives" ;
+    rdfs:subClassOf :CAPEC-416 ;
+    :capec-id "CAPEC-426" ;
+    :definition "The adversary incites a behavior from the target by manipulating something of influence. This is commonly associated with financial, social, or ideological incentivization. Examples include monetary fraud, peer pressure, and preying on the target's morals or ethics. The most effective incentive against one target might not be as effective against another, therefore the adversary must gather information about the target's vulnerability to particular incentives." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/426.html> .
+
+:CAPEC-427 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence via Psychological Principles" ;
+    rdfs:subClassOf :CAPEC-416 ;
+    :capec-id "CAPEC-427" ;
+    :definition "The adversary shapes the target's actions or behavior by focusing on the ways human interact and learn, leveraging such elements as cognitive and social psychology. In a variety of ways, a target can be influenced to behave or perform an action through capitalizing on what scholarship and research has learned about how and why humans react to specific scenarios and cues." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/427.html> .
+
+:CAPEC-428 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Influence via Modes of Thinking" ;
+    rdfs:subClassOf :CAPEC-427 ;
+    :capec-id "CAPEC-428" ;
+    :definition "The adversary tailors their communication to the language and thought patterns of the target thereby weakening barriers or reluctance to communication. This method is a way of building rapport with a target by matching their speech patterns and the primary ways or dominant senses with which they make abstractions. This technique can be used to make the target more receptive to sharing information because the adversary has adapted their communication forms to match those of the target. When skillfully employed, the target is likely to be unaware that they are being manipulated." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/428.html> .
+
+:CAPEC-429 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Target Influence via Eye Cues" ;
+    rdfs:subClassOf :CAPEC-427 ;
+    :capec-id "CAPEC-429" ;
+    :definition "The adversary gains information via non-verbal means from the target through eye movements." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/429.html> .
+
+:CAPEC-430 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED:  Target Influence via Micro-Expressions" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated." ;
+    :capec-id "CAPEC-430" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/430.html> .
+
+:CAPEC-431 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED:  Target Influence via Neuro-Linguistic Programming (NLP)" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated." ;
+    :capec-id "CAPEC-431" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/431.html> .
+
+:CAPEC-432 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED:  Target Influence via Voice in NLP" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated." ;
+    :capec-id "CAPEC-432" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/432.html> .
+
+:CAPEC-433 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Target Influence via The Human Buffer Overflow" ;
+    rdfs:subClassOf :CAPEC-427 ;
+    :capec-id "CAPEC-433" ;
+    :definition "An attacker utilizes a technique to insinuate commands to the subconscious mind of the target via communication patterns. The human buffer overflow methodology does not rely on over-stimulating the mind of the target, but rather embedding messages within communication that the mind of the listener assembles at a subconscious level. The human buffer-overflow method is similar to subconscious programming to the extent that messages are embedded within the message." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/433.html> .
+
+:CAPEC-434 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Target Influence via Interview and Interrogation" ;
+    rdfs:subClassOf :CAPEC-427 ;
+    :capec-id "CAPEC-434" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/434.html> .
+
+:CAPEC-435 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Target Influence via Instant Rapport" ;
+    rdfs:subClassOf :CAPEC-427 ;
+    :capec-id "CAPEC-435" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/435.html> .
+
+:CAPEC-438 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Modification During Manufacture" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-438" ;
+    :definition "An attacker modifies a technology, product, or component during a stage in its manufacture for the purpose of carrying out an attack against some entity involved in the supply chain lifecycle. There are an almost limitless number of ways an attacker can modify a technology when they are involved in its manufacture, as the attacker has potential inroads to the software composition, hardware design and assembly, firmware, or basic design mechanics. Additionally, manufacturing of key components is often outsourced with the final product assembled by the primary manufacturer. The greatest risk, however, is deliberate manipulation of design specifications to produce malicious hardware or devices. There are billions of transistors in a single integrated circuit and studies have shown that fewer than 10 transistors are required to create malicious functionality." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/438.html> ;
+    :related :T1195 .
+
+:CAPEC-439 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Manipulation During Distribution" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-439" ;
+    :definition "An attacker undermines the integrity of a product, software, or technology at some stage of the distribution channel. The core threat of modification or manipulation during distribution arise from the many stages of distribution, as a product may traverse multiple suppliers and integrators as the final asset is delivered. Components and services provided from a manufacturer to a supplier may be tampered with during integration or packaging." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/439.html> ;
+    :related :CWE-1269,
+        :T1195 .
+
+:CAPEC-440 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardware Integrity Attack" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-440" ;
+    :definition "An adversary exploits a weakness in the system maintenance process and causes a change to be made to a technology, product, component, or sub-component or a new one installed during its deployed use at the victim location for the purpose of carrying out an attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/440.html> ;
+    :related :T1195.003,
+        :T1200 .
+
+:CAPEC-441 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Logic Insertion" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-441" ;
+    :definition "An adversary installs or adds malicious logic (also known as malware) into a seemingly benign component of a fielded system. This logic is often hidden from the user of the system and works behind the scenes to achieve negative impacts. With the proliferation of mass digital storage and inexpensive multimedia devices, Bluetooth and 802.11 support, new attack vectors for spreading malware are emerging for things we once thought of as innocuous greeting cards, picture frames, or digital projectors. This pattern of attack focuses on systems already fielded and used in operation as opposed to systems and their components that are still under development and part of the supply chain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/441.html> ;
+    :related :CWE-284 .
+
+:CAPEC-442 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Infected Software" ;
+    rdfs:subClassOf :CAPEC-441 ;
+    :capec-id "CAPEC-442" ;
+    :definition "An adversary adds malicious logic, often in the form of a computer virus, to otherwise benign software. This logic is often hidden from the user of the software and works behind the scenes to achieve negative impacts. Many times, the malicious logic is inserted into empty space between legitimate code, and is then called when the software is executed. This pattern of attack focuses on software already fielded and used in operation as opposed to software that is still under development and part of the supply chain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/442.html> ;
+    :related :CWE-506,
+        :T1195.001,
+        :T1195.002 .
+
+:CAPEC-443 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Logic Inserted Into Product by Authorized Developer" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-443" ;
+    :definition "An adversary uses their privileged position within an authorized development organization to inject malicious logic into a codebase or product." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/443.html> ;
+    :related :T1195.002,
+        :T1195.003 .
+
+:CAPEC-444 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Development Alteration" ;
+    rdfs:subClassOf :CAPEC-438 ;
+    :capec-id "CAPEC-444" ;
+    :definition "An adversary modifies a technology, product, or component during its development to acheive a negative impact once the system is deployed. The goal of the adversary is to modify the system in such a way that the negative impact can be leveraged when the system is later deployed. Development alteration attacks may include attacks that insert malicious logic into the system's software, modify or replace hardware components, and other attacks which negatively impact the system during development. These attacks generally require insider access to modify source code or to tamper with hardware components. The product is then delivered to the user where the negative impact can be leveraged at a later time." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/444.html> .
+
+:CAPEC-445 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Logic Insertion into Product Software via Configuration Management Manipulation" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-445" ;
+    :definition "An adversary exploits a configuration management system so that malicious logic is inserted into a software products build, update or deployed environment. If an adversary can control the elements included in a product's configuration management for build they can potentially replace, modify or insert code files containing malicious logic. If an adversary can control elements of a product's ongoing operational configuration management baseline they can potentially force clients receiving updates from the system to install insecure software when receiving updates from the server." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/445.html> ;
+    :related :T1195.001 .
+
+:CAPEC-446 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Logic Insertion into Product via Inclusion of Third-Party Component" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-446" ;
+    :definition "An adversary conducts supply chain attacks by the inclusion of insecure third-party components into a technology, product, or code-base, possibly packaging a malicious driver or component along with the product before shipping it to the consumer or acquirer." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/446.html> ;
+    :related :T1195 .
+
+:CAPEC-447 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Design Alteration" ;
+    rdfs:subClassOf :CAPEC-438 ;
+    :capec-id "CAPEC-447" ;
+    :definition "An adversary modifies the design of a technology, product, or component to acheive a negative impact once the system is deployed. In this type of attack, the goal of the adversary is to modify the design of the system, prior to development starting, in such a way that the negative impact can be leveraged when the system is later deployed. Design alteration attacks differ from development alteration attacks in that design alteration attacks take place prior to development and which then may or may not be developed by the adverary. Design alteration attacks include modifying system designs to degrade system performance, cause unexpected states or errors, and general design changes that may lead to additional vulnerabilities. These attacks generally require insider access to modify design documents, but they may also be spoofed via web communications. The product is then developed and delivered to the user where the negative impact can be leveraged at a later time." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/447.html> .
+
+:CAPEC-448 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Embed Virus into DLL" ;
+    rdfs:subClassOf :CAPEC-442 ;
+    :capec-id "CAPEC-448" ;
+    :definition "An adversary tampers with a DLL and embeds a computer virus into gaps between legitimate machine instructions. These gaps may be the result of compiler optimizations that pad memory blocks for performance gains. The embedded virus then attempts to infect any machine which interfaces with the product, and possibly steal private data or eavesdrop." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/448.html> ;
+    :related :CWE-506,
+        :T1027.009 .
+
+:CAPEC-449 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Malware Propagation via USB Stick" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-448 : Malware Infection into Product Software. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-449" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/449.html> .
+
+:CAPEC-450 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Malware Propagation via USB U3 Autorun" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-448 : Embed Virus into DLL. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-450" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/450.html> .
+
+:CAPEC-451 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Malware Propagation via Infected Peripheral Device" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-448 : Malware Infection into Product Software. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-451" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/451.html> .
+
+:CAPEC-452 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Infected Hardware" ;
+    rdfs:subClassOf :CAPEC-441 ;
+    :capec-id "CAPEC-452" ;
+    :definition "An adversary inserts malicious logic into hardware, typically in the form of a computer virus or rootkit. This logic is often hidden from the user of the hardware and works behind the scenes to achieve negative impacts. This pattern of attack focuses on hardware already fielded and used in operation as opposed to hardware that is still under development and part of the supply chain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/452.html> .
+
+:CAPEC-453 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Malicious Logic Insertion via Counterfeit Hardware" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-452 : Malicious Logic Insertion into Product Hardware. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-453" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/453.html> .
+
+:CAPEC-454 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Modification of Existing Components with Counterfeit Hardware" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-452 : Malicious Logic Insertion into Product Hardware. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-454" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/454.html> .
+
+:CAPEC-455 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Malicious Logic Insertion via Inclusion of Counterfeit Hardware Components" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-457 : Malicious Logic Insertion into Product Hardware. Please refer to this other pattern going forward." ;
+    :capec-id "CAPEC-455" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/455.html> .
+
+:CAPEC-456 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Infected Memory" ;
+    rdfs:subClassOf :CAPEC-441 ;
+    :capec-id "CAPEC-456" ;
+    :definition "An adversary inserts malicious logic into memory enabling them to achieve a negative impact. This logic is often hidden from the user of the system and works behind the scenes to achieve negative impacts. This pattern of attack focuses on systems already fielded and used in operation as opposed to systems that are still under development and part of the supply chain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/456.html> ;
+    :related :CWE-1257,
+        :CWE-1260,
+        :CWE-1274,
+        :CWE-1312,
+        :CWE-1316 .
+
+:CAPEC-457 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "USB Memory Attacks" ;
+    rdfs:subClassOf :CAPEC-456 ;
+    :capec-id "CAPEC-457" ;
+    :definition "An adversary loads malicious code onto a USB memory stick in order to infect any system which the device is plugged in to. USB drives present a significant security risk for business and government agencies. Given the ability to integrate wireless functionality into a USB stick, it is possible to design malware that not only steals confidential data, but sniffs the network, or monitor keystrokes, and then exfiltrates the stolen data off-site via a Wireless connection. Also, viruses can be transmitted via the USB interface without the specific use of a memory stick. The attacks from USB devices are often of such sophistication that experts conclude they are not the work of single individuals, but suggest state sponsorship. These attacks can be performed by an adversary with direct access to a target system or can be executed via means such as USB Drop Attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/457.html> ;
+    :related :CWE-1299,
+        :T1091,
+        :T1092 .
+
+:CAPEC-458 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Flash Memory Attacks" ;
+    rdfs:subClassOf :CAPEC-456 ;
+    :capec-id "CAPEC-458" ;
+    :definition "An adversary inserts malicious logic into a product or technology via flashing the on-board memory with a code-base that contains malicious logic. Various attacks exist against the integrity of flash memory, the most direct being rootkits coded into the BIOS or chipset of a device." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/458.html> ;
+    :related :CAPEC-665,
+        :CWE-1282 .
+
+:CAPEC-459 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Creating a Rogue Certification Authority Certificate" ;
+    rdfs:subClassOf :CAPEC-473 ;
+    :capec-id "CAPEC-459" ;
+    :definition "An adversary exploits a weakness resulting from using a hashing algorithm with weak collision resistance to generate certificate signing requests (CSR) that contain collision blocks in their \"to be signed\" parts. The adversary submits one CSR to be signed by a trusted certificate authority then uses the signed blob to make a second certificate appear signed by said certificate authority. Due to the hash collision, both certificates, though different, hash to the same value and so the signed blob works just as well in the second certificate. The net effect is that the adversary's second X.509 certificate, which the Certification Authority has never seen, is now signed and validated by that Certification Authority." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/459.html> ;
+    :related :CWE-290,
+        :CWE-295,
+        :CWE-327 .
+
+:CAPEC-460 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP Parameter Pollution (HPP)" ;
+    rdfs:subClassOf :CAPEC-15 ;
+    :capec-id "CAPEC-460" ;
+    :definition "An adversary adds duplicate HTTP GET/POST parameters by injecting query string delimiters. Via HPP it may be possible to override existing hardcoded HTTP parameters, modify the application behaviors, access and, potentially exploit, uncontrollable variables, and bypass input validation checkpoints and WAF rules." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/460.html> ;
+    :related :CWE-88,
+        :CWE-147,
+        :CWE-235 .
+
+:CAPEC-461 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Web Services API Signature Forgery Leveraging Hash Function Extension Weakness" ;
+    rdfs:subClassOf :CAPEC-115 ;
+    :capec-id "CAPEC-461" ;
+    :definition "An adversary utilizes a hash function extension/padding weakness, to modify the parameters passed to the web service requesting authentication by generating their own call in order to generate a legitimate signature hash (as described in the notes), without knowledge of the secret token sometimes provided by the web service." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/461.html> ;
+    :related :CWE-290,
+        :CWE-328 .
+
+:CAPEC-462 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross-Domain Search Timing" ;
+    rdfs:subClassOf :CAPEC-54 ;
+    :capec-id "CAPEC-462" ;
+    :definition "An attacker initiates cross domain HTTP / GET requests and times the server responses. The timing of these responses may leak important information on what is happening on the server. Browser's same origin policy prevents the attacker from directly reading the server responses (in the absence of any other weaknesses), but does not prevent the attacker from timing the responses to requests that the attacker issued cross domain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/462.html> ;
+    :related :CWE-208,
+        :CWE-352,
+        :CWE-385 .
+
+:CAPEC-463 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Padding Oracle Crypto Attack" ;
+    rdfs:subClassOf :CAPEC-97 ;
+    :capec-id "CAPEC-463" ;
+    :definition "An adversary is able to efficiently decrypt data without knowing the decryption key if a target system leaks data on whether or not a padding error happened while decrypting the ciphertext. A target system that leaks this type of information becomes the padding oracle and an adversary is able to make use of that oracle to efficiently decrypt data without knowing the decryption key by issuing on average 128*b calls to the padding oracle (where b is the number of bytes in the ciphertext block). In addition to performing decryption, an adversary is also able to produce valid ciphertexts (i.e., perform encryption) by using the padding oracle, all without knowing the encryption key." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/463.html> ;
+    :related :CWE-209,
+        :CWE-347,
+        :CWE-354,
+        :CWE-514,
+        :CWE-649,
+        :CWE-696 .
+
+:CAPEC-464 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Evercookie" ;
+    rdfs:subClassOf :CAPEC-554 ;
+    :capec-id "CAPEC-464" ;
+    :definition "An attacker creates a very persistent cookie that stays present even after the user thinks it has been removed. The cookie is stored on the victim's machine in over ten places. When the victim clears the cookie cache via traditional means inside the browser, that operation removes the cookie from certain places but not others. The malicious code then replicates the cookie from all of the places where it was not deleted to all of the possible storage locations once again. So the victim again has the cookie in all of the original storage locations. In other words, failure to delete the cookie in even one location will result in the cookie's resurrection everywhere. The evercookie will also persist across different browsers because certain stores (e.g., Local Shared Objects) are shared between different browsers." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/464.html> ;
+    :related :CWE-359,
+        :T1606.001 .
+
+:CAPEC-465 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Transparent Proxy Abuse" ;
+    rdfs:subClassOf :CAPEC-554 ;
+    :capec-id "CAPEC-465" ;
+    :definition "A transparent proxy serves as an intermediate between the client and the internet at large. It intercepts all requests originating from the client and forwards them to the correct location. The proxy also intercepts all responses to the client and forwards these to the client. All of this is done in a manner transparent to the client." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/465.html> ;
+    :related :CWE-441,
+        :T1090.001 .
+
+:CAPEC-466 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Leveraging Active Adversary in the Middle Attacks to Bypass Same Origin Policy" ;
+    rdfs:subClassOf :CAPEC-94 ;
+    :capec-id "CAPEC-466" ;
+    :definition "An attacker leverages an adversary in the middle attack (CAPEC-94) in order to bypass the same origin policy protection in the victim's browser. This active adversary in the middle attack could be launched, for instance, when the victim is connected to a public WIFI hot spot. An attacker is able to intercept requests and responses between the victim's browser and some non-sensitive website that does not use TLS." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/466.html> ;
+    :related :CWE-300 .
+
+:CAPEC-467 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross Site Identification" ;
+    rdfs:subClassOf :CAPEC-62 ;
+    :capec-id "CAPEC-467" ;
+    :definition "An attacker harvests identifying information about a victim via an active session that the victim's browser has with a social networking site. A victim may have the social networking site open in one tab or perhaps is simply using the \"remember me\" feature to keep their session with the social networking site active. An attacker induces a payload to execute in the victim's browser that transparently to the victim initiates a request to the social networking site (e.g., via available social network site APIs) to retrieve identifying information about a victim. While some of this information may be public, the attacker is able to harvest this information in context and may use it for further attacks on the user (e.g., spear phishing)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/467.html> ;
+    :related :CWE-352,
+        :CWE-359 .
+
+:CAPEC-468 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Generic Cross-Browser Cross-Domain Theft" ;
+    rdfs:subClassOf :CAPEC-242 ;
+    :capec-id "CAPEC-468" ;
+    :definition "An attacker makes use of Cascading Style Sheets (CSS) injection to steal data cross domain from the victim's browser. The attack works by abusing the standards relating to loading of CSS: 1. Send cookies on any load of CSS (including cross-domain) 2. When parsing returned CSS ignore all data that does not make sense before a valid CSS descriptor is found by the CSS parser." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/468.html> ;
+    :related :CWE-149,
+        :CWE-177,
+        :CWE-707,
+        :CWE-838 .
+
+:CAPEC-469 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP DoS" ;
+    rdfs:subClassOf :CAPEC-227 ;
+    :capec-id "CAPEC-469" ;
+    :definition "An attacker performs flooding at the HTTP level to bring down only a particular web application rather than anything listening on a TCP/IP connection. This denial of service attack requires substantially fewer packets to be sent which makes DoS harder to detect. This is an equivalent of SYN flood in HTTP. The idea is to keep the HTTP session alive indefinitely and then repeat that hundreds of times. This attack targets resource depletion weaknesses in web server software. The web server will wait to attacker's responses on the initiated HTTP sessions while the connection threads are being exhausted." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/469.html> ;
+    :related :CWE-770,
+        :CWE-772,
+        :T1499.002 .
+
+:CAPEC-470 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Expanding Control over the Operating System from the Database" ;
+    rdfs:subClassOf :CAPEC-66 ;
+    :capec-id "CAPEC-470" ;
+    :definition "An attacker is able to leverage access gained to the database to read / write data to the file system, compromise the operating system, create a tunnel for accessing the host machine, and use this access to potentially attack other machines on the same network as the database machine. Traditionally SQL injections attacks are viewed as a way to gain unauthorized read access to the data stored in the database, modify the data in the database, delete the data, etc. However, almost every data base management system (DBMS) system includes facilities that if compromised allow an attacker complete access to the file system, operating system, and full access to the host running the database. The attacker can then use this privileged access to launch subsequent attacks. These facilities include dropping into a command shell, creating user defined functions that can call system level libraries present on the host machine, stored procedures, etc." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/470.html> ;
+    :related :CWE-89,
+        :CWE-250 .
+
+:CAPEC-471 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Search Order Hijacking" ;
+    rdfs:subClassOf :CAPEC-159 ;
+    :capec-id "CAPEC-471" ;
+    :definition "An adversary exploits a weakness in an application's specification of external libraries to exploit the functionality of the loader where the process loading the library searches first in the same directory in which the process binary resides and then in other directories. Exploitation of this preferential search order can allow an attacker to make the loading process load the adversary's rogue library rather than the legitimate library. This attack can be leveraged with many different libraries and with many different loading processes. No forensic trails are left in the system's registry or file system that an incorrect library had been loaded." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/471.html> ;
+    :related :CWE-427,
+        :T1574.001,
+        :T1574.004,
+        :T1574.008 .
+
+:CAPEC-472 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Browser Fingerprinting" ;
+    rdfs:subClassOf :CAPEC-541 ;
+    :capec-id "CAPEC-472" ;
+    :definition "An attacker carefully crafts small snippets of Java Script to efficiently detect the type of browser the potential victim is using. Many web-based attacks need prior knowledge of the web browser including the version of browser to ensure successful exploitation of a vulnerability. Having this knowledge allows an attacker to target the victim with attacks that specifically exploit known or zero day weaknesses in the type and version of the browser used by the victim. Automating this process via Java Script as a part of the same delivery system used to exploit the browser is considered more efficient as the attacker can supply a browser fingerprinting method and integrate it with exploit code, all contained in Java Script and in response to the same web page request by the browser." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/472.html> ;
+    :related :CWE-200 .
+
+:CAPEC-473 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signature Spoof" ;
+    rdfs:subClassOf :CAPEC-151 ;
+    :capec-id "CAPEC-473" ;
+    :definition "An attacker generates a message or datablock that causes the recipient to believe that the message or datablock was generated and cryptographically signed by an authoritative or reputable source, misleading a victim or victim operating system into performing malicious actions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/473.html> ;
+    :related :CWE-20,
+        :CWE-290,
+        :CWE-327,
+        :T1036.001,
+        :T1553.002 .
+
+:CAPEC-474 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signature Spoofing by Key Theft" ;
+    rdfs:subClassOf :CAPEC-473 ;
+    :capec-id "CAPEC-474" ;
+    :definition "An attacker obtains an authoritative or reputable signer's private signature key by theft and then uses this key to forge signatures from the original signer to mislead a victim into performing actions that benefit the attacker." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/474.html> ;
+    :related :CWE-522,
+        :T1552.004 .
+
+:CAPEC-475 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signature Spoofing by Improper Validation" ;
+    rdfs:subClassOf :CAPEC-473 ;
+    :capec-id "CAPEC-475" ;
+    :definition "An adversary exploits a cryptographic weakness in the signature verification algorithm implementation to generate a valid signature without knowing the key." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/475.html> ;
+    :related :CWE-295,
+        :CWE-327,
+        :CWE-347 .
+
+:CAPEC-476 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signature Spoofing by Misrepresentation" ;
+    rdfs:subClassOf :CAPEC-473 ;
+    :capec-id "CAPEC-476" ;
+    :definition "An attacker exploits a weakness in the parsing or display code of the recipient software to generate a data blob containing a supposedly valid signature, but the signer's identity is falsely represented, which can lead to the attacker manipulating the recipient software or its victim user to perform compromising actions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/476.html> ;
+    :related :CWE-290 .
+
+:CAPEC-477 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signature Spoofing by Mixing Signed and Unsigned Content" ;
+    rdfs:subClassOf :CAPEC-473 ;
+    :capec-id "CAPEC-477" ;
+    :definition "An attacker exploits the underlying complexity of a data structure that allows for both signed and unsigned content, to cause unsigned data to be processed as though it were signed data." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/477.html> ;
+    :related :CWE-311,
+        :CWE-319,
+        :CWE-693 .
+
+:CAPEC-478 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Modification of Windows Service Configuration" ;
+    rdfs:subClassOf :CAPEC-203 ;
+    :capec-id "CAPEC-478" ;
+    :definition "An adversary exploits a weakness in access control to modify the execution parameters of a Windows service. The goal of this attack is to execute a malicious binary in place of an existing service." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/478.html> ;
+    :related :CWE-284,
+        :T1543.003,
+        :T1574.011 .
+
+:CAPEC-479 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Root Certificate" ;
+    rdfs:subClassOf :CAPEC-473 ;
+    :capec-id "CAPEC-479" ;
+    :definition "An adversary exploits a weakness in authorization and installs a new root certificate on a compromised system. Certificates are commonly used for establishing secure TLS/SSL communications within a web browser. When a user attempts to browse a website that presents a certificate that is not trusted an error message will be displayed to warn the user of the security risk. Depending on the security settings, the browser may not allow the user to establish a connection to the website. Adversaries have used this technique to avoid security warnings prompting users when compromised systems connect over HTTPS to adversary controlled web servers that spoof legitimate websites in order to collect login credentials." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/479.html> ;
+    :related :CWE-284,
+        :T1553.004 .
+
+:CAPEC-480 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Escaping Virtualization" ;
+    rdfs:subClassOf :CAPEC-115 ;
+    :capec-id "CAPEC-480" ;
+    :definition "An adversary gains access to an application, service, or device with the privileges of an authorized or privileged user by escaping the confines of a virtualized environment. The adversary is then able to access resources or execute unauthorized code within the host environment, generally with the privileges of the user running the virtualized process. Successfully executing an attack of this type is often the first step in executing more complex attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/480.html> ;
+    :related :CWE-693,
+        :T1611 .
+
+:CAPEC-481 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Contradictory Destinations in Traffic Routing Schemes" ;
+    rdfs:subClassOf :CAPEC-161 ;
+    :capec-id "CAPEC-481" ;
+    :definition "Adversaries can provide contradictory destinations when sending messages. Traffic is routed in networks using the domain names in various headers available at different levels of the OSI model. In a Content Delivery Network (CDN) multiple domains might be available, and if there are contradictory domain names provided it is possible to route traffic to an inappropriate destination. The technique, called Domain Fronting, involves using different domain names in the SNI field of the TLS header and the Host field of the HTTP header. An alternative technique, called Domainless Fronting, is similar, but the SNI field is left blank." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/481.html> ;
+    :related :CWE-923,
+        :T1090.004 .
+
+:CAPEC-482 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Flood" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-482" ;
+    :definition "An adversary may execute a flooding attack using the TCP protocol with the intent to deny legitimate users access to a service. These attacks exploit the weakness within the TCP protocol where there is some state information for the connection the server needs to maintain. This often involves the use of TCP SYN messages." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/482.html> ;
+    :related :CWE-770,
+        :T1498.001,
+        :T1499.001,
+        :T1499.002 .
+
+:CAPEC-484 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: XML Client-Side Attack" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-230: XML Nested Payloads and CAPEC-231: XML Oversized Payloads. Please refer to these CAPECs going forward." ;
+    :capec-id "CAPEC-484" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/484.html> .
+
+:CAPEC-485 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signature Spoofing by Key Recreation" ;
+    rdfs:subClassOf :CAPEC-473 ;
+    :capec-id "CAPEC-485" ;
+    :definition "An attacker obtains an authoritative or reputable signer's private signature key by exploiting a cryptographic weakness in the signature algorithm or pseudorandom number generation and then uses this key to forge signatures from the original signer to mislead a victim into performing actions that benefit the attacker." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/485.html> ;
+    :related :CWE-330,
+        :T1552.004 .
+
+:CAPEC-486 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "UDP Flood" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-486" ;
+    :definition "An adversary may execute a flooding attack using the UDP protocol with the intent to deny legitimate users access to a service by consuming the available network bandwidth. Additionally, firewalls often open a port for each UDP connection destined for a service with an open UDP port, meaning the firewalls in essence save the connection state thus the high packet nature of a UDP flood can also overwhelm resources allocated to the firewall. UDP attacks can also target services like DNS or VoIP which utilize these protocols. Additionally, due to the session-less nature of the UDP protocol, the source of a packet is easily spoofed making it difficult to find the source of the attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/486.html> ;
+    :related :CWE-770 .
+
+:CAPEC-487 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP Flood" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-487" ;
+    :definition "An adversary may execute a flooding attack using the ICMP protocol with the intent to deny legitimate users access to a service by consuming the available network bandwidth. A typical attack involves a victim server receiving ICMP packets at a high rate from a wide range of source addresses. Additionally, due to the session-less nature of the ICMP protocol, the source of a packet is easily spoofed making it difficult to find the source of the attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/487.html> ;
+    :related :CWE-770 .
+
+:CAPEC-488 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "HTTP Flood" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-488" ;
+    :definition "An adversary may execute a flooding attack using the HTTP protocol with the intent to deny legitimate users access to a service by consuming resources at the application layer such as web services and their infrastructure. These attacks use legitimate session-based HTTP GET requests designed to consume large amounts of a server's resources. Since these are legitimate sessions this attack is very difficult to detect." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/488.html> ;
+    :related :CWE-770,
+        :T1499.002 .
+
+:CAPEC-489 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SSL Flood" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-489" ;
+    :definition "An adversary may execute a flooding attack using the SSL protocol with the intent to deny legitimate users access to a service by consuming all the available resources on the server side. These attacks take advantage of the asymmetric relationship between the processing power used by the client and the processing power used by the server to create a secure connection. In this manner the attacker can make a large number of HTTPS requests on a low provisioned machine to tie up a disproportionately large number of resources on the server. The clients then continue to keep renegotiating the SSL connection. When multiplied by a large number of attacking machines, this attack can result in a crash or loss of service to legitimate users." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/489.html> ;
+    :related :CWE-770,
+        :T1499.002 .
+
+:CAPEC-490 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Amplification" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-490" ;
+    :definition "An adversary may execute an amplification where the size of a response is far greater than that of the request that generates it. The goal of this attack is to use a relatively few resources to create a large amount of traffic against a target server. To execute this attack, an adversary send a request to a 3rd party service, spoofing the source address to be that of the target server. The larger response that is generated by the 3rd party service is then sent to the target server. By sending a large number of initial requests, the adversary can generate a tremendous amount of traffic directed at the target. The greater the discrepancy in size between the initial request and the final payload delivered to the target increased the effectiveness of this attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/490.html> ;
+    :related :CWE-770,
+        :T1498.002 .
+
+:CAPEC-491 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Quadratic Data Expansion" ;
+    rdfs:subClassOf :CAPEC-230 ;
+    :capec-id "CAPEC-491" ;
+    :definition "An adversary exploits macro-like substitution to cause a denial of service situation due to excessive memory being allocated to fully expand the data. The result of this denial of service could cause the application to freeze or crash. This involves defining a very large entity and using it multiple times in a single entity substitution. CAPEC-197 is a similar attack pattern, but it is easier to discover and defend against. This attack pattern does not perform multi-level substitution and therefore does not obviously appear to consume extensive resources." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/491.html> ;
+    :related :CWE-770 .
+
+:CAPEC-492 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Regular Expression Exponential Blowup" ;
+    rdfs:subClassOf :CAPEC-130 ;
+    :capec-id "CAPEC-492" ;
+    :definition "An adversary may execute an attack on a program that uses a poor Regular Expression(Regex) implementation by choosing input that results in an extreme situation for the Regex. A typical extreme situation operates at exponential time compared to the input size. This is due to most implementations using a Nondeterministic Finite Automaton(NFA) state machine to be built by the Regex algorithm since NFA allows backtracking and thus more complex regular expressions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/492.html> ;
+    :related :CWE-400,
+        :CWE-1333 .
+
+:CAPEC-493 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SOAP Array Blowup" ;
+    rdfs:subClassOf :CAPEC-130 ;
+    :capec-id "CAPEC-493" ;
+    :definition "An adversary may execute an attack on a web service that uses SOAP messages in communication. By sending a very large SOAP array declaration to the web service, the attacker forces the web service to allocate space for the array elements before they are parsed by the XML parser. The attacker message is typically small in size containing a large array declaration of say 1,000,000 elements and a couple of array elements. This attack targets exhaustion of the memory resources of the web service." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/493.html> ;
+    :related :CWE-770 .
+
+:CAPEC-494 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP Fragmentation" ;
+    rdfs:subClassOf :CAPEC-130 ;
+    :capec-id "CAPEC-494" ;
+    :definition "An adversary may execute a TCP Fragmentation attack against a target with the intention of avoiding filtering rules of network controls, by attempting to fragment the TCP packet such that the headers flag field is pushed into the second fragment which typically is not filtered." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/494.html> ;
+    :related :CWE-404,
+        :CWE-770 .
+
+:CAPEC-495 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "UDP Fragmentation" ;
+    rdfs:subClassOf :CAPEC-130 ;
+    :capec-id "CAPEC-495" ;
+    :definition "An attacker may execute a UDP Fragmentation attack against a target server in an attempt to consume resources such as bandwidth and CPU. IP fragmentation occurs when an IP datagram is larger than the MTU of the route the datagram has to traverse. Typically the attacker will use large UDP packets over 1500 bytes of data which forces fragmentation as ethernet MTU is 1500 bytes. This attack is a variation on a typical UDP flood but it enables more network bandwidth to be consumed with fewer packets. Additionally it has the potential to consume server CPU resources and fill memory buffers associated with the processing and reassembling of fragmented packets." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/495.html> ;
+    :related :CWE-404,
+        :CWE-770 .
+
+:CAPEC-496 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ICMP Fragmentation" ;
+    rdfs:subClassOf :CAPEC-130 ;
+    :capec-id "CAPEC-496" ;
+    :definition "An attacker may execute a ICMP Fragmentation attack against a target with the intention of consuming resources or causing a crash. The attacker crafts a large number of identical fragmented IP packets containing a portion of a fragmented ICMP message. The attacker these sends these messages to a target host which causes the host to become non-responsive. Another vector may be sending a fragmented ICMP message to a target host with incorrect sizes in the header which causes the host to hang." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/496.html> ;
+    :related :CWE-404,
+        :CWE-770 .
+
+:CAPEC-497 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "File Discovery" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-497" ;
+    :definition "An adversary engages in probing and exploration activities to determine if common key files exists. Such files often contain configuration and security parameters of the targeted application, system or network. Using this knowledge may often pave the way for more damaging attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/497.html> ;
+    :related :CWE-200,
+        :T1083 .
+
+:CAPEC-498 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Probe iOS Screenshots" ;
+    rdfs:subClassOf :CAPEC-545 ;
+    :capec-id "CAPEC-498" ;
+    :definition "An adversary examines screenshot images created by iOS in an attempt to obtain sensitive information. This attack targets temporary screenshots created by the underlying OS while the application remains open in the background." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/498.html> ;
+    :related :CWE-359 .
+
+:CAPEC-499 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Android Intent Intercept" ;
+    rdfs:subClassOf :CAPEC-117 ;
+    :capec-id "CAPEC-499" ;
+    :definition "An adversary, through a previously installed malicious application, intercepts messages from a trusted Android-based application in an attempt to achieve a variety of different objectives including denial of service, information disclosure, and data injection. An implicit intent sent from a trusted application can be received by any application that has declared an appropriate intent filter. If the intent is not protected by a permission that the malicious application lacks, then the attacker can gain access to the data contained within the intent. Further, the intent can be either blocked from reaching the intended destination, or modified and potentially forwarded along." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/499.html> ;
+    :related :CWE-925 .
+
+:CAPEC-500 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "WebView Injection" ;
+    rdfs:subClassOf :CAPEC-253 ;
+    :capec-id "CAPEC-500" ;
+    :definition "An adversary, through a previously installed malicious application, injects code into the context of a web page displayed by a WebView component. Through the injected code, an adversary is able to manipulate the DOM tree and cookies of the page, expose sensitive information, and can launch attacks against the web application from within the web page." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/500.html> ;
+    :related :CWE-749,
+        :CWE-940 .
+
+:CAPEC-501 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Android Activity Hijack" ;
+    rdfs:subClassOf :CAPEC-173,
+        :CAPEC-499 ;
+    :capec-id "CAPEC-501" ;
+    :definition "An adversary intercepts an implicit intent sent to launch a Android-based trusted activity and instead launches a counterfeit activity in its place. The malicious activity is then used to mimic the trusted activity's user interface and prompt the target to enter sensitive data as if they were interacting with the trusted activity." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/501.html> ;
+    :related :CWE-923 .
+
+:CAPEC-502 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Intent Spoof" ;
+    rdfs:subClassOf :CAPEC-148 ;
+    :capec-id "CAPEC-502" ;
+    :definition "An adversary, through a previously installed malicious application, issues an intent directed toward a specific trusted application's component in an attempt to achieve a variety of different objectives including modification of data, information disclosure, and data injection. Components that have been unintentionally exported and made public are subject to this type of an attack. If the component trusts the intent's action without verififcation, then the target application performs the functionality at the adversary's request, helping the adversary achieve the desired negative technical impact." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/502.html> ;
+    :related :CWE-284 .
+
+:CAPEC-503 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "WebView Exposure" ;
+    rdfs:subClassOf :CAPEC-122 ;
+    :capec-id "CAPEC-503" ;
+    :definition "An adversary, through a malicious web page, accesses application specific functionality by leveraging interfaces registered through WebView's addJavascriptInterface API. Once an interface is registered to WebView through addJavascriptInterface, it becomes global and all pages loaded in the WebView can call this interface." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/503.html> ;
+    :related :CWE-284 .
+
+:CAPEC-504 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Task Impersonation" ;
+    rdfs:subClassOf :CAPEC-173 ;
+    :capec-id "CAPEC-504" ;
+    :definition "An adversary, through a previously installed malicious application, impersonates an expected or routine task in an attempt to steal sensitive information or leverage a user's privileges." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/504.html> ;
+    :related :CWE-1021,
+        :T1036.004 .
+
+:CAPEC-505 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Scheme Squatting" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-505" ;
+    :definition "An adversary, through a previously installed malicious application, registers for a URL scheme intended for a target application that has not been installed. Thereafter, messages intended for the target application are handled by the malicious application. Upon receiving a message, the malicious application displays a screen that mimics the target application, thereby convincing the user to enter sensitive information. This type of attack is most often used to obtain sensitive information (e.g., credentials) from the user as they think that they are interacting with the intended target application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/505.html> .
+
+:CAPEC-506 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Tapjacking" ;
+    rdfs:subClassOf :CAPEC-173 ;
+    :capec-id "CAPEC-506" ;
+    :definition "An adversary, through a previously installed malicious application, displays an interface that misleads the user and convinces them to tap on an attacker desired location on the screen. This is often accomplished by overlaying one screen on top of another while giving the appearance of a single interface. There are two main techniques used to accomplish this. The first is to leverage transparent properties that allow taps on the screen to pass through the visible application to an application running in the background. The second is to strategically place a small object (e.g., a button or text field) on top of the visible screen and make it appear to be a part of the underlying application. In both cases, the user is convinced to tap on the screen but does not realize the application that they are interacting with." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/506.html> ;
+    :related :CWE-1021 .
+
+:CAPEC-507 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Physical Theft" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-507" ;
+    :definition "An adversary gains physical access to a system or device through theft of the item. Possession of a system or device enables a number of unique attacks to be executed and often provides the adversary with an extended timeframe for which to perform an attack. Most protections put in place to secure sensitive information can be defeated when an adversary has physical access and enough time." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/507.html> .
+
+:CAPEC-508 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Shoulder Surfing" ;
+    rdfs:subClassOf :CAPEC-651 ;
+    :capec-id "CAPEC-508" ;
+    :definition "In a shoulder surfing attack, an adversary observes an unaware individual's keystrokes, screen content, or conversations with the goal of obtaining sensitive information. One motive for this attack is to obtain sensitive information about the target for financial, personal, political, or other gains. From an insider threat perspective, an additional motive could be to obtain system/application credentials or cryptographic keys. Shoulder surfing attacks are accomplished by observing the content \"over the victim's shoulder\", as implied by the name of this attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/508.html> ;
+    :related :CWE-200,
+        :CWE-359 .
+
+:CAPEC-509 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Kerberoasting" ;
+    rdfs:subClassOf :CAPEC-652 ;
+    :capec-id "CAPEC-509" ;
+    :definition "Through the exploitation of how service accounts leverage Kerberos authentication with Service Principal Names (SPNs), the adversary obtains and subsequently cracks the hashed credentials of a service account target to exploit its privileges. The Kerberos authentication protocol centers around a ticketing system which is used to request/grant access to services and to then access the requested services. As an authenticated user, the adversary may request Active Directory and obtain a service ticket with portions encrypted via RC4 with the private key of the authenticated account. By extracting the local ticket and saving it disk, the adversary can brute force the hashed value to reveal the target account credentials." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/509.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-294,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-522,
+        :T1558.003 .
+
+:CAPEC-510 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SaaS User Request Forgery" ;
+    rdfs:subClassOf :CAPEC-21 ;
+    :capec-id "CAPEC-510" ;
+    :definition "An adversary, through a previously installed malicious application, performs malicious actions against a third-party Software as a Service (SaaS) application (also known as a cloud based application) by leveraging the persistent and implicit trust placed on a trusted user's session. This attack is executed after a trusted user is authenticated into a cloud service, \"piggy-backing\" on the authenticated session, and exploiting the fact that the cloud service believes it is only interacting with the trusted user. If successful, the actions embedded in the malicious application will be processed and accepted by the targeted SaaS application and executed at the trusted user's privilege level." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/510.html> ;
+    :related :CWE-346 .
+
+:CAPEC-511 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Infiltration of Software Development Environment" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-511" ;
+    :definition "An attacker uses common delivery mechanisms such as email attachments or removable media to infiltrate the IDE (Integrated Development Environment) of a victim manufacturer with the intent of implanting malware allowing for attack control of the victim IDE environment. The attack then uses this access to exfiltrate sensitive data or information, manipulate said data or information, and conceal these actions. This will allow and aid the attack to meet the goal of future compromise of a recipient of the victim's manufactured product further down in the supply chain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/511.html> ;
+    :related :T1195.001 .
+
+:CAPEC-516 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardware Component Substitution During Baselining" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-516" ;
+    :definition "An adversary with access to system components during allocated baseline development can substitute a maliciously altered hardware component for a baseline component during the product development and research phases. This can lead to adjustments and calibrations being made in the product so that when the final product, now containing the modified component, is deployed it will not perform as designed and be advantageous to the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/516.html> ;
+    :related :T1195.003 .
+
+:CAPEC-517 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Documentation Alteration to Circumvent Dial-down" ;
+    rdfs:subClassOf :CAPEC-447 ;
+    :capec-id "CAPEC-517" ;
+    :definition "An attacker with access to a manufacturer's documentation, which include descriptions of advanced technology and/or specific components' criticality, alters the documents to circumvent dial-down functionality requirements. This alteration would change the interpretation of implementation and manufacturing techniques, allowing for advanced technologies to remain in place even though these technologies might be restricted to certain customers, such as nations on the terrorist watch list, giving the attacker on the receiving end of a shipped product access to an advanced technology that might otherwise be restricted." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/517.html> .
+
+:CAPEC-518 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Documentation Alteration to Produce Under-performing Systems" ;
+    rdfs:subClassOf :CAPEC-447 ;
+    :capec-id "CAPEC-518" ;
+    :definition "An attacker with access to a manufacturer's documentation alters the descriptions of system capabilities with the intent of causing errors in derived system requirements, impacting the overall effectiveness and capability of the system, allowing an attacker to take advantage of the introduced system capability flaw once the system is deployed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/518.html> .
+
+:CAPEC-519 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Documentation Alteration to Cause Errors in System Design" ;
+    rdfs:subClassOf :CAPEC-447 ;
+    :capec-id "CAPEC-519" ;
+    :definition "An attacker with access to a manufacturer's documentation containing requirements allocation and software design processes maliciously alters the documentation in order to cause errors in system design. This allows the attacker to take advantage of a weakness in a deployed system of the manufacturer for malicious purposes." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/519.html> .
+
+:CAPEC-520 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Counterfeit Hardware Component Inserted During Product Assembly" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-520" ;
+    :definition "An adversary with either direct access to the product assembly process or to the supply of subcomponents used in the product assembly process introduces counterfeit hardware components into product assembly. The assembly containing the counterfeit components results in a system specifically designed for malicious purposes." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/520.html> ;
+    :related :T1195.003 .
+
+:CAPEC-521 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardware Design Specifications Are Altered" ;
+    rdfs:subClassOf :CAPEC-447 ;
+    :capec-id "CAPEC-521" ;
+    :definition "An attacker with access to a manufacturer's hardware manufacturing process documentation alters the design specifications, which introduces flaws advantageous to the attacker once the system is deployed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/521.html> .
+
+:CAPEC-522 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Hardware Component Replacement" ;
+    rdfs:subClassOf :CAPEC-439 ;
+    :capec-id "CAPEC-522" ;
+    :definition "An adversary replaces legitimate hardware in the system with faulty counterfeit or tampered hardware in the supply chain distribution channel, with purpose of causing malicious disruption or allowing for additional compromise when the system is deployed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/522.html> ;
+    :related :T1195.003 .
+
+:CAPEC-523 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Software Implanted" ;
+    rdfs:subClassOf :CAPEC-439 ;
+    :capec-id "CAPEC-523" ;
+    :definition "An attacker implants malicious software into the system in the supply chain distribution channel, with purpose of causing malicious disruption or allowing for additional compromise when the system is deployed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/523.html> ;
+    :related :T1195.002 .
+
+:CAPEC-524 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Rogue Integration Procedures" ;
+    rdfs:subClassOf :CAPEC-439 ;
+    :capec-id "CAPEC-524" ;
+    :definition "An attacker alters or establishes rogue processes in an integration facility in order to insert maliciously altered components into the system. The attacker would then supply the malicious components. This would allow for malicious disruption or additional compromise when the system is deployed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/524.html> .
+
+:CAPEC-528 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "XML Flood" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-528" ;
+    :definition "An adversary may execute a flooding attack using XML messages with the intent to deny legitimate users access to a web service. These attacks are accomplished by sending a large number of XML based requests and letting the service attempt to parse each one. In many cases this type of an attack will result in a XML Denial of Service (XDoS) due to an application becoming unstable, freezing, or crashing." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/528.html> ;
+    :related :CWE-770,
+        :T1498.001,
+        :T1499.002 .
+
+:CAPEC-529 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malware-Directed Internal Reconnaissance" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-529" ;
+    :definition "Adversary uses malware or a similarly controlled application installed inside an organizational perimeter to gather information about the composition, configuration, and security mechanisms of a targeted application, system or network." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/529.html> .
+
+:CAPEC-530 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Provide Counterfeit Component" ;
+    rdfs:subClassOf :CAPEC-531 ;
+    :capec-id "CAPEC-530" ;
+    :definition "An attacker provides a counterfeit component during the procurement process of a lower-tier component supplier to a sub-system developer or integrator, which is then built into the system being upgraded or repaired by the victim, allowing the attacker to cause disruption or additional compromise." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/530.html> .
+
+:CAPEC-531 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardware Component Substitution" ;
+    rdfs:subClassOf :CAPEC-534 ;
+    :capec-id "CAPEC-531" ;
+    :definition "An attacker substitutes out a tested and approved hardware component for a maliciously-altered hardware component. This type of attack is carried out directly on the system, enabling the attacker to then cause disruption or additional compromise." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/531.html> ;
+    :related :T1195.003 .
+
+:CAPEC-532 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Altered Installed BIOS" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-532" ;
+    :definition "An attacker with access to download and update system software sends a maliciously altered BIOS to the victim or victim supplier/integrator, which when installed allows for future exploitation." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/532.html> ;
+    :related :T1495,
+        :T1542.001 .
+
+:CAPEC-533 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Manual Software Update" ;
+    rdfs:subClassOf :CAPEC-186 ;
+    :capec-id "CAPEC-533" ;
+    :definition "An attacker introduces malicious code to the victim's system by altering the payload of a software update, allowing for additional compromise or site disruption at the victim location. These manual, or user-assisted attacks, vary from requiring the user to download and run an executable, to as streamlined as tricking the user to click a URL. Attacks which aim at penetrating a specific network infrastructure often rely upon secondary attack methods to achieve the desired impact. Spamming, for example, is a common method employed as an secondary attack vector. Thus the attacker has in their arsenal a choice of initial attack vectors ranging from traditional SMTP/POP/IMAP spamming and its varieties, to web-application mechanisms which commonly implement both chat and rich HTML messaging within the user interface." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/533.html> ;
+    :related :CWE-494 .
+
+:CAPEC-534 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Hardware Update" ;
+    rdfs:subClassOf :CAPEC-440 ;
+    :capec-id "CAPEC-534" ;
+    :definition "An adversary introduces malicious hardware during an update or replacement procedure, allowing for additional compromise or site disruption at the victim location. After deployment, it is not uncommon for upgrades and replacements to occur involving hardware and various replaceable parts. These upgrades and replacements are intended to correct defects, provide additional features, and to replace broken or worn-out parts. However, by forcing or tricking the replacement of a good component with a defective or corrupted component, an adversary can leverage known defects to obtain a desired malicious impact." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/534.html> .
+
+:CAPEC-535 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Gray Market Hardware" ;
+    rdfs:subClassOf :CAPEC-531 ;
+    :capec-id "CAPEC-535" ;
+    :definition "An attacker maliciously alters hardware components that will be sold on the gray market, allowing for victim disruption and compromise when the victim needs replacement hardware components for systems where the parts are no longer in regular supply from original suppliers, or where the hardware components from the attacker seems to be a great benefit from a cost perspective." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/535.html> .
+
+:CAPEC-536 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Data Injected During Configuration" ;
+    rdfs:subClassOf :CAPEC-176 ;
+    :capec-id "CAPEC-536" ;
+    :definition "An attacker with access to data files and processes on a victim's system injects malicious data into critical operational data during configuration or recalibration, causing the victim's system to perform in a suboptimal manner that benefits the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/536.html> ;
+    :related :CWE-284 .
+
+:CAPEC-537 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Infiltration of Hardware Development Environment" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-537" ;
+    :definition "An adversary, leveraging the ability to manipulate components of primary support systems and tools within the development and production environments, inserts malicious software within the hardware and/or firmware development environment. The infiltration purpose is to alter developed hardware components in a system destined for deployment at the victim's organization, for the purpose of disruption or further compromise." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/537.html> ;
+    :related :T1195.003 .
+
+:CAPEC-538 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Open-Source Library Manipulation" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-538" ;
+    :definition "Adversaries implant malicious code in open source software (OSS) libraries to have it widely distributed, as OSS is commonly downloaded by developers and other users to incorporate into software development projects. The adversary can have a particular system in mind to target, or the implantation can be the first stage of follow-on attacks on many systems." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/538.html> ;
+    :related :CWE-494,
+        :CWE-829,
+        :T1195.001 .
+
+:CAPEC-539 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "ASIC With Malicious Functionality" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-539" ;
+    :definition "An attacker with access to the development environment process of an application-specific integrated circuit (ASIC) for a victim system being developed or maintained after initial deployment can insert malicious functionality into the system for the purpose of disruption or further compromise." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/539.html> ;
+    :related :T1195.003 .
+
+:CAPEC-540 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Overread Buffers" ;
+    rdfs:subClassOf :CAPEC-123 ;
+    :capec-id "CAPEC-540" ;
+    :definition "An adversary attacks a target by providing input that causes an application to read beyond the boundary of a defined buffer. This typically occurs when a value influencing where to start or stop reading is set to reflect positions outside of the valid memory location of the buffer. This type of attack may result in exposure of sensitive information, a system crash, or arbitrary code execution." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/540.html> ;
+    :related :CWE-125 .
+
+:CAPEC-541 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Application Fingerprinting" ;
+    rdfs:subClassOf :CAPEC-224 ;
+    :capec-id "CAPEC-541" ;
+    :definition "An adversary engages in fingerprinting activities to determine the type or version of an application installed on a remote target." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/541.html> ;
+    :related :CWE-204,
+        :CWE-205,
+        :CWE-208,
+        :T1592.002 .
+
+:CAPEC-542 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Targeted Malware" ;
+    rdfs:subClassOf :CAPEC-549 ;
+    :capec-id "CAPEC-542" ;
+    :definition "An adversary develops targeted malware that takes advantage of a known vulnerability in an organizational information technology environment. The malware crafted for these attacks is based specifically on information gathered about the technology environment. Successfully executing the malware enables an adversary to achieve a wide variety of negative technical impacts." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/542.html> ;
+    :related :T1027,
+        :T1587.001 .
+
+:CAPEC-543 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Counterfeit Websites" ;
+    rdfs:subClassOf :CAPEC-194 ;
+    :capec-id "CAPEC-543" ;
+    :definition "Adversary creates duplicates of legitimate websites. When users visit a counterfeit site, the site can gather information or upload malware." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/543.html> ;
+    :related :T1036.005 .
+
+:CAPEC-544 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Counterfeit Organizations" ;
+    rdfs:subClassOf :CAPEC-194 ;
+    :capec-id "CAPEC-544" ;
+    :definition "An adversary creates a false front organizations with the appearance of a legitimate supplier in the critical life cycle path that then injects corrupted/malicious information system components into the organizational supply chain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/544.html> .
+
+:CAPEC-545 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pull Data from System Resources" ;
+    rdfs:subClassOf :CAPEC-116 ;
+    :capec-id "CAPEC-545" ;
+    :definition "An adversary who is authorized or has the ability to search known system resources, does so with the intention of gathering useful information. System resources include files, memory, and other aspects of the target system. In this pattern of attack, the adversary does not necessarily know what they are going to find when they start pulling data. This is different than CAPEC-150 where the adversary knows what they are looking for due to the common location." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/545.html> ;
+    :related :CWE-1239,
+        :CWE-1243,
+        :CWE-1258,
+        :CWE-1266,
+        :CWE-1272,
+        :CWE-1278,
+        :CWE-1323,
+        :CWE-1330,
+        :T1005,
+        :T1555.001 .
+
+:CAPEC-546 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Incomplete Data Deletion in a Multi-Tenant Environment" ;
+    rdfs:subClassOf :CAPEC-545 ;
+    :capec-id "CAPEC-546" ;
+    :definition "An adversary obtains unauthorized information due to insecure or incomplete data deletion in a multi-tenant environment. If a cloud provider fails to completely delete storage and data from former cloud tenants' systems/resources, once these resources are allocated to new, potentially malicious tenants, the latter can probe the provided resources for sensitive information still there." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/546.html> ;
+    :related :CWE-284,
+        :CWE-1266,
+        :CWE-1272 .
+
+:CAPEC-547 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Physical Destruction of Device or Component" ;
+    rdfs:subClassOf :CAPEC-607 ;
+    :capec-id "CAPEC-547" ;
+    :definition "An adversary conducts a physical attack a device or component, destroying it such that it no longer functions as intended." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/547.html> .
+
+:CAPEC-548 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Contaminate Resource" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-548" ;
+    :definition "An adversary contaminates organizational information systems (including devices and networks) by causing them to handle information of a classification/sensitivity for which they have not been authorized. When this happens, the contaminated information system, device, or network must be brought offline to investigate and mitigate the data spill, which denies availability of the system until the investigation is complete." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/548.html> .
+
+:CAPEC-549 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Local Execution of Code" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-549" ;
+    :definition "An adversary installs and executes malicious code on the target system in an effort to achieve a negative technical impact. Examples include rootkits, ransomware, spyware, adware, and others." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/549.html> ;
+    :related :CWE-829 .
+
+:CAPEC-550 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Install New Service" ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-550" ;
+    :definition "When an operating system starts, it also starts programs called services or daemons. Adversaries may install a new service which will be executed at startup (on a Windows system, by modifying the registry). The service name may be disguised by using a name from a related operating system or benign software. Services are usually run with elevated privileges." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/550.html> ;
+    :related :CWE-284,
+        :T1543 .
+
+:CAPEC-551 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Modify Existing Service" ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-551" ;
+    :definition "When an operating system starts, it also starts programs called services or daemons. Modifying existing services may break existing services or may enable services that are disabled/not commonly used." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/551.html> ;
+    :related :CWE-284,
+        :CWE-522,
+        :T1543 .
+
+:CAPEC-552 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Install Rootkit " ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-552" ;
+    :definition "An adversary exploits a weakness in authentication to install malware that alters the functionality and information provide by targeted operating system API calls. Often referred to as rootkits, it is often used to hide the presence of programs, files, network connections, services, drivers, and other system components." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/552.html> ;
+    :related :CWE-284,
+        :T1014,
+        :T1542.003,
+        :T1547.006 .
+
+:CAPEC-554 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Functionality Bypass" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-554" ;
+    :definition "An adversary attacks a system by bypassing some or all functionality intended to protect it. Often, a system user will think that protection is in place, but the functionality behind those protections has been disabled by the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/554.html> ;
+    :related :CWE-424,
+        :CWE-1299 .
+
+:CAPEC-555 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Remote Services with Stolen Credentials" ;
+    rdfs:subClassOf :CAPEC-560 ;
+    :capec-id "CAPEC-555" ;
+    :definition "This pattern of attack involves an adversary that uses stolen credentials to leverage remote services such as RDP, telnet, SSH, and VNC to log into a system. Once access is gained, any number of malicious activities could be performed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/555.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-294,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-522,
+        :T1021,
+        :T1114.002,
+        :T1133 .
+
+:CAPEC-556 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Replace File Extension Handlers" ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-556" ;
+    :definition "When a file is opened, its file handler is checked to determine which program opens the file. File handlers are configuration properties of many operating systems. Applications can modify the file handler for a given file extension to call an arbitrary program when a file with the given extension is opened." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/556.html> ;
+    :related :CWE-284,
+        :T1546.001 .
+
+:CAPEC-557 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Schedule Software To Run" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This CAPEC has been deprecated because it is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
+    :capec-id "CAPEC-557" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/557.html> .
+
+:CAPEC-558 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Replace Trusted Executable" ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-558" ;
+    :definition "An adversary exploits weaknesses in privilege management or access control to replace a trusted executable with a malicious version and enable the execution of malware when that trusted executable is called." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/558.html> ;
+    :related :CWE-284,
+        :T1505.005,
+        :T1546.008 .
+
+:CAPEC-559 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Orbital Jamming" ;
+    rdfs:subClassOf :CAPEC-601 ;
+    :capec-id "CAPEC-559" ;
+    :definition "In this attack pattern, the adversary sends disruptive signals at a target satellite using a rogue uplink station to disrupt the intended transmission. Those within the satellite's footprint are prevented from reaching the satellite's targeted or neighboring channels. The satellite's footprint size depends upon its position in the sky; higher orbital satellites cover multiple continents." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/559.html> .
+
+:CAPEC-560 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Use of Known Domain Credentials" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-560" ;
+    :definition "An adversary guesses or obtains (i.e. steals or purchases) legitimate credentials (e.g. userID/password) to achieve authentication and to perform authorized actions under the guise of an authenticated user or service." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/560.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-307,
+        :CWE-308,
+        :CWE-309,
+        :CWE-522,
+        :CWE-654,
+        :CWE-1273,
+        :T1078 .
+
+:CAPEC-561 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Windows Admin Shares with Stolen Credentials" ;
+    rdfs:subClassOf :CAPEC-653 ;
+    :capec-id "CAPEC-561" ;
+    :definition "An adversary guesses or obtains (i.e. steals or purchases) legitimate Windows administrator credentials (e.g. userID/password) to access Windows Admin Shares on a local machine or within a Windows domain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/561.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-294,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-522,
+        :T1021.002 .
+
+:CAPEC-562 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Modify Shared File" ;
+    rdfs:subClassOf :CAPEC-17 ;
+    :capec-id "CAPEC-562" ;
+    :definition "An adversary manipulates the files in a shared location by adding malicious programs, scripts, or exploit code to valid content. Once a user opens the shared content, the tainted content is executed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/562.html> ;
+    :related :CWE-284,
+        :T1080 .
+
+:CAPEC-563 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Add Malicious File to Shared Webroot" ;
+    rdfs:subClassOf :CAPEC-17 ;
+    :capec-id "CAPEC-563" ;
+    :definition "An adversaries may add malicious content to a website through the open file share and then browse to that content with a web browser to cause the server to execute the content. The malicious content will typically run under the context and permissions of the web server process, often resulting in local system or administrative privileges depending on how the web server is configured." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/563.html> ;
+    :related :CWE-284 .
+
+:CAPEC-564 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Run Software at Logon" ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-564" ;
+    :definition "Operating system allows logon scripts to be run whenever a specific user or users logon to a system. If adversaries can access these scripts, they may insert additional code into the logon script. This code can allow them to maintain persistence or move laterally within an enclave because it is executed every time the affected user or users logon to a computer. Modifying logon scripts can effectively bypass workstation and enclave firewalls. Depending on the access configuration of the logon scripts, either local credentials or a remote administrative account may be necessary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/564.html> ;
+    :related :CWE-284,
+        :T1037,
+        :T1543.001,
+        :T1543.004,
+        :T1547 .
+
+:CAPEC-565 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Password Spraying" ;
+    rdfs:subClassOf :CAPEC-49 ;
+    :capec-id "CAPEC-565" ;
+    :definition "In a Password Spraying attack, an adversary tries a small list (e.g. 3-5) of common or expected passwords, often matching the target's complexity policy, against a known list of user accounts to gain valid credentials. The adversary tries a particular password for each user account, before moving onto the next password in the list. This approach assists the adversary in remaining undetected by avoiding rapid or frequent account lockouts. The adversary may then reattempt the process with additional passwords, once enough time has passed to prevent inducing a lockout." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/565.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-307,
+        :CWE-308,
+        :CWE-309,
+        :CWE-521,
+        :CWE-654,
+        :T1110.003 .
+
+:CAPEC-566 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Dump Password Hashes" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This CAPEC has been deprecated because of is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
+    :capec-id "CAPEC-566" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/566.html> .
+
+:CAPEC-567 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Obtain Data via Utilities" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This CAPEC has been deprecated because it is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
+    :capec-id "CAPEC-567" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/567.html> .
+
+:CAPEC-568 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Capture Credentials via Keylogger" ;
+    rdfs:subClassOf :CAPEC-569 ;
+    :capec-id "CAPEC-568" ;
+    :definition "An adversary deploys a keylogger in an effort to obtain credentials directly from a system's user. After capturing all the keystrokes made by a user, the adversary can analyze the data and determine which string are likely to be passwords or other credential related information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/568.html> ;
+    :related :T1056.001 .
+
+:CAPEC-569 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Collect Data as Provided by Users" ;
+    rdfs:subClassOf :CAPEC-116 ;
+    :capec-id "CAPEC-569" ;
+    :definition "An attacker leverages a tool, device, or program to obtain specific information as provided by a user of the target system. This information is often needed by the attacker to launch a follow-on attack. This attack is different than Social Engineering as the adversary is not tricking or deceiving the user. Instead the adversary is putting a mechanism in place that captures the information that a user legitimately enters into a system. Deploying a keylogger, performing a UAC prompt, or wrapping the Windows default credential provider are all examples of such interactions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/569.html> ;
+    :related :T1056 .
+
+:CAPEC-570 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Signature-Based Avoidance" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This CAPEC has been deprecated because it is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
+    :capec-id "CAPEC-570" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/570.html> .
+
+:CAPEC-571 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Block Logging to Central Repository" ;
+    rdfs:subClassOf :CAPEC-161 ;
+    :capec-id "CAPEC-571" ;
+    :definition "An adversary prevents host-generated logs being delivered to a central location in an attempt to hide indicators of compromise." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/571.html> ;
+    :related :T1562.002,
+        :T1562.006,
+        :T1562.008 .
+
+:CAPEC-572 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Artificially Inflate File Sizes" ;
+    rdfs:subClassOf :CAPEC-165 ;
+    :capec-id "CAPEC-572" ;
+    :definition "An adversary modifies file contents by adding data to files for several reasons. Many different attacks could “follow” this pattern resulting in numerous outcomes. Adding data to a file could also result in a Denial of Service condition for devices with limited storage capacity." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/572.html> ;
+    :related :T1027.001 .
+
+:CAPEC-573 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Process Footprinting" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-573" ;
+    :definition "An adversary exploits functionality meant to identify information about the currently running processes on the target system to an authorized user. By knowing what processes are running on the target system, the adversary can learn about the target environment as a means towards further malicious behavior." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/573.html> ;
+    :related :CWE-200,
+        :T1057 .
+
+:CAPEC-574 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Services Footprinting" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-574" ;
+    :definition "An adversary exploits functionality meant to identify information about the services on the target system to an authorized user. By knowing what services are registered on the target system, the adversary can learn about the target environment as a means towards further malicious behavior. Depending on the operating system, commands that can obtain services information include \"sc\" and \"tasklist/svc\" using Tasklist, and \"net start\" using Net." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/574.html> ;
+    :related :CWE-200,
+        :T1007 .
+
+:CAPEC-575 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Account Footprinting" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-575" ;
+    :definition "An adversary exploits functionality meant to identify information about the domain accounts and their permissions on the target system to an authorized user. By knowing what accounts are registered on the target system, the adversary can inform further and more targeted malicious behavior. Example Windows commands which can acquire this information are: \"net user\" and \"dsquery\"." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/575.html> ;
+    :related :CWE-200,
+        :T1087 .
+
+:CAPEC-576 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Group Permission Footprinting" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-576" ;
+    :definition "An adversary exploits functionality meant to identify information about user groups and their permissions on the target system to an authorized user. By knowing what users/permissions are registered on the target system, the adversary can inform further and more targeted malicious behavior. An example Windows command which can list local groups is \"net localgroup\"." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/576.html> ;
+    :related :CWE-200,
+        :T1069,
+        :T1615 .
+
+:CAPEC-577 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Owner Footprinting" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-577" ;
+    :definition "An adversary exploits functionality meant to identify information about the primary users on the target system to an authorized user. They may do this, for example, by reviewing logins or file modification times. By knowing what owners use the target system, the adversary can inform further and more targeted malicious behavior. An example Windows command that may accomplish this is \"dir /A ntuser.dat\". Which will display the last modified time of a user's ntuser.dat file when run within the root folder of a user. This time is synonymous with the last time that user was logged in." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/577.html> ;
+    :related :CWE-200,
+        :T1033 .
+
+:CAPEC-578 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Disable Security Software" ;
+    rdfs:subClassOf :CAPEC-176 ;
+    :capec-id "CAPEC-578" ;
+    :definition "An adversary exploits a weakness in access control to disable security tools so that detection does not occur. This can take the form of killing processes, deleting registry keys so that tools do not start at run time, deleting log files, or other methods." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/578.html> ;
+    :related :CWE-284,
+        :T1556.006,
+        :T1562.001,
+        :T1562.002,
+        :T1562.004,
+        :T1562.007,
+        :T1562.008,
+        :T1562.009 .
+
+:CAPEC-579 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Replace Winlogon Helper DLL" ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-579" ;
+    :definition "Winlogon is a part of Windows that performs logon actions. In Windows systems prior to Windows Vista, a registry key can be modified that causes Winlogon to load a DLL on startup. Adversaries may take advantage of this feature to load adversarial code at startup." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/579.html> ;
+    :related :CWE-15,
+        :T1547.004 .
+
+:CAPEC-580 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "System Footprinting" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-580" ;
+    :definition "An adversary engages in active probing and exploration activities to determine security information about a remote target system. Often times adversaries will rely on remote applications that can be probed for system configurations." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/580.html> ;
+    :related :CWE-204,
+        :CWE-205,
+        :CWE-208,
+        :T1082 .
+
+:CAPEC-581 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Security Software Footprinting" ;
+    rdfs:subClassOf :CAPEC-580 ;
+    :capec-id "CAPEC-581" ;
+    :definition "Adversaries may attempt to get a listing of security tools that are installed on the system and their configurations. This may include security related system features (such as a built-in firewall or anti-spyware) as well as third-party security software." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/581.html> ;
+    :related :T1518.001 .
+
+:CAPEC-582 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Route Disabling" ;
+    rdfs:subClassOf :CAPEC-607 ;
+    :capec-id "CAPEC-582" ;
+    :definition "An adversary disables the network route between two targets. The goal is to completely sever the communications channel between two entities. This is often the result of a major error or the use of an \"Internet kill switch\" by those in control of critical infrastructure. This attack pattern differs from most other obstruction patterns by targeting the route itself, as opposed to the data passed over the route." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/582.html> .
+
+:CAPEC-583 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Disabling Network Hardware" ;
+    rdfs:subClassOf :CAPEC-582 ;
+    :capec-id "CAPEC-583" ;
+    :definition "In this attack pattern, an adversary physically disables networking hardware by powering it down or disconnecting critical equipment. Disabling or shutting off critical system resources prevents them from performing their service as intended, which can have direct and indirect consequences on other systems. This attack pattern is considerably less technical than the selective blocking used in most obstruction attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/583.html> .
+
+:CAPEC-584 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "BGP Route Disabling" ;
+    rdfs:subClassOf :CAPEC-582 ;
+    :capec-id "CAPEC-584" ;
+    :definition "An adversary suppresses the Border Gateway Protocol (BGP) advertisement for a route so as to render the underlying network inaccessible. The BGP protocol helps traffic move throughout the Internet by selecting the most efficient route between Autonomous Systems (AS), or routing domains. BGP is the basis for interdomain routing infrastructure, providing connections between these ASs. By suppressing the intended AS routing advertisements and/or forcing less effective routes for traffic to ASs, the adversary can deny availability for the target network." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/584.html> .
+
+:CAPEC-585 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DNS Domain Seizure" ;
+    rdfs:subClassOf :CAPEC-582 ;
+    :capec-id "CAPEC-585" ;
+    :definition "In this attack pattern, an adversary influences a target's web-hosting company to disable a target domain. The goal is to prevent access to the targeted service provided by that domain. It usually occurs as the result of civil or criminal legal interventions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/585.html> .
+
+:CAPEC-586 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Object Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-586" ;
+    :definition "An adversary attempts to exploit an application by injecting additional, malicious content during its processing of serialized objects. Developers leverage serialization in order to convert data or state into a static, binary format for saving to disk or transferring over a network. These objects are then deserialized when needed to recover the data/state. By injecting a malformed object into a vulnerable application, an adversary can potentially compromise the application by manipulating the deserialization process. This can result in a number of unwanted outcomes, including remote code execution." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/586.html> ;
+    :related :CWE-502 .
+
+:CAPEC-587 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cross Frame Scripting (XFS)" ;
+    rdfs:subClassOf :CAPEC-103 ;
+    :capec-id "CAPEC-587" ;
+    :definition "This attack pattern combines malicious Javascript and a legitimate webpage loaded into a concealed iframe. The malicious Javascript is then able to interact with a legitimate webpage in a manner that is unknown to the user. This attack usually leverages some element of social engineering in that an attacker must convinces a user to visit a web page that the attacker controls." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/587.html> ;
+    :related :CWE-1021 .
+
+:CAPEC-588 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DOM-Based XSS" ;
+    rdfs:subClassOf :CAPEC-63 ;
+    :capec-id "CAPEC-588" ;
+    :definition "This type of attack is a form of Cross-Site Scripting (XSS) where a malicious script is inserted into the client-side HTML being parsed by a web browser. Content served by a vulnerable web application includes script code used to manipulate the Document Object Model (DOM). This script code either does not properly validate input, or does not perform proper output encoding, thus creating an opportunity for an adversary to inject a malicious script launch a XSS attack. A key distinction between other XSS attacks and DOM-based attacks is that in other XSS attacks, the malicious script runs when the vulnerable web page is initially loaded, while a DOM-based attack executes sometime after the page loads. Another distinction of DOM-based attacks is that in some cases, the malicious script is never sent to the vulnerable web server at all. An attack like this is guaranteed to bypass any server-side filtering attempts to protect users." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/588.html> ;
+    :related :CWE-20,
+        :CWE-79,
+        :CWE-83 .
+
+:CAPEC-589 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DNS Blocking" ;
+    rdfs:subClassOf :CAPEC-603 ;
+    :capec-id "CAPEC-589" ;
+    :definition "An adversary intercepts traffic and intentionally drops DNS requests based on content in the request. In this way, the adversary can deny the availability of specific services or content to the user even if the IP address is changed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/589.html> ;
+    :related :CWE-300 .
+
+:CAPEC-590 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "IP Address Blocking" ;
+    rdfs:subClassOf :CAPEC-603 ;
+    :capec-id "CAPEC-590" ;
+    :definition "An adversary performing this type of attack drops packets destined for a target IP address. The aim is to prevent access to the service hosted at the target IP address." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/590.html> ;
+    :related :CWE-300 .
+
+:CAPEC-591 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Reflected XSS" ;
+    rdfs:subClassOf :CAPEC-63 ;
+    :capec-id "CAPEC-591" ;
+    :definition "This type of attack is a form of Cross-Site Scripting (XSS) where a malicious script is \"reflected\" off a vulnerable web application and then executed by a victim's browser. The process starts with an adversary delivering a malicious script to a victim and convincing the victim to send the script to the vulnerable web application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/591.html> ;
+    :related :CWE-79 .
+
+:CAPEC-592 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Stored XSS" ;
+    rdfs:subClassOf :CAPEC-63 ;
+    :capec-id "CAPEC-592" ;
+    :definition "An adversary utilizes a form of Cross-site Scripting (XSS) where a malicious script is persistently \"stored\" within the data storage of a vulnerable web application as valid input." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/592.html> ;
+    :related :CWE-79 .
+
+:CAPEC-593 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Session Hijacking" ;
+    rdfs:subClassOf :CAPEC-21 ;
+    :capec-id "CAPEC-593" ;
+    :definition "This type of attack involves an adversary that exploits weaknesses in an application's use of sessions in performing authentication. The adversary is able to steal or manipulate an active session and use it to gain unathorized access to the application." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/593.html> ;
+    :related :CWE-287,
+        :T1185,
+        :T1550.001,
+        :T1563 .
+
+:CAPEC-594 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Traffic Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-594" ;
+    :definition "An adversary injects traffic into the target's network connection. The adversary is therefore able to degrade or disrupt the connection, and potentially modify the content. This is not a flooding attack, as the adversary is not focusing on exhausting resources. Instead, the adversary is crafting a specific input to affect the system in a particular way." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/594.html> ;
+    :related :CWE-940 .
+
+:CAPEC-595 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Connection Reset" ;
+    rdfs:subClassOf :CAPEC-594 ;
+    :capec-id "CAPEC-595" ;
+    :definition "In this attack pattern, an adversary injects a connection reset packet to one or both ends of a target's connection. The attacker is therefore able to have the target and/or the destination server sever the connection without having to directly filter the traffic between them." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/595.html> ;
+    :related :CWE-940 .
+
+:CAPEC-596 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TCP RST Injection" ;
+    rdfs:subClassOf :CAPEC-595 ;
+    :capec-id "CAPEC-596" ;
+    :definition "An adversary injects one or more TCP RST packets to a target after the target has made a HTTP GET request. The goal of this attack is to have the target and/or destination web server terminate the TCP connection." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/596.html> ;
+    :related :CWE-940 .
+
+:CAPEC-597 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Absolute Path Traversal" ;
+    rdfs:subClassOf :CAPEC-126 ;
+    :capec-id "CAPEC-597" ;
+    :definition "An adversary with access to file system resources, either directly or via application logic, will use various file absolute paths and navigation mechanisms such as \"..\" to extend their range of access to inappropriate areas of the file system. The goal of the adversary is to access directories and files that are intended to be restricted from their access." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/597.html> ;
+    :related :CWE-36 .
+
+:CAPEC-598 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DNS Spoofing" ;
+    rdfs:subClassOf :CAPEC-194 ;
+    :capec-id "CAPEC-598" ;
+    :definition "An adversary sends a malicious (\"NXDOMAIN\" (\"No such domain\") code, or DNS A record) response to a target's route request before a legitimate resolver can. This technique requires an On-path or In-path device that can monitor and respond to the target's DNS requests. This attack differs from BGP Tampering in that it directly responds to requests made by the target instead of polluting the routing the target's infrastructure uses." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/598.html> .
+
+:CAPEC-599 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Terrestrial Jamming" ;
+    rdfs:subClassOf :CAPEC-195 ;
+    :capec-id "CAPEC-599" ;
+    :definition "In this attack pattern, the adversary transmits disruptive signals in the direction of the target's consumer-level satellite dish (as opposed to the satellite itself). The transmission disruption occurs in a more targeted range. Portable terrestrial jammers have a range of 3-5 kilometers in urban areas and 20 kilometers in rural areas. This technique requires a terrestrial jammer that is more powerful than the frequencies sent from the satellite." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/599.html> .
+
+:CAPEC-600 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Credential Stuffing" ;
+    rdfs:subClassOf :CAPEC-560 ;
+    :capec-id "CAPEC-600" ;
+    :definition "An adversary tries known username/password combinations against different systems, applications, or services to gain additional authenticated access. Credential Stuffing attacks rely upon the fact that many users leverage the same username/password combination for multiple systems, applications, and services." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/600.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-307,
+        :CWE-308,
+        :CWE-309,
+        :CWE-522,
+        :CWE-654,
+        :T1110.004 .
+
+:CAPEC-601 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Jamming" ;
+    rdfs:subClassOf :CAPEC-607 ;
+    :capec-id "CAPEC-601" ;
+    :definition "An adversary uses radio noise or signals in an attempt to disrupt communications. By intentionally overwhelming system resources with illegitimate traffic, service is denied to the legitimate traffic of authorized users." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/601.html> .
+
+:CAPEC-602 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Degradation" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated." ;
+    :capec-id "CAPEC-602" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/602.html> .
+
+:CAPEC-603 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Blockage" ;
+    rdfs:subClassOf :CAPEC-607 ;
+    :capec-id "CAPEC-603" ;
+    :definition "An adversary blocks the delivery of an important system resource causing the system to fail or stop working." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/603.html> .
+
+:CAPEC-604 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Wi-Fi Jamming" ;
+    rdfs:subClassOf :CAPEC-601 ;
+    :capec-id "CAPEC-604" ;
+    :definition "In this attack scenario, the attacker actively transmits on the Wi-Fi channel to prevent users from transmitting or receiving data from the targeted Wi-Fi network. There are several known techniques to perform this attack – for example: the attacker may flood the Wi-Fi access point (e.g. the retransmission device) with deauthentication frames. Another method is to transmit high levels of noise on the RF band used by the Wi-Fi network." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/604.html> .
+
+:CAPEC-605 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cellular Jamming" ;
+    rdfs:subClassOf :CAPEC-601 ;
+    :capec-id "CAPEC-605" ;
+    :definition "In this attack scenario, the attacker actively transmits signals to overpower and disrupt the communication between a cellular user device and a cell tower. Several existing techniques are known in the open literature for this attack for 2G, 3G, and 4G LTE cellular technology. For example, some attacks target cell towers by overwhelming them with false status messages, while others introduce high levels of noise on signaling channels." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/605.html> .
+
+:CAPEC-606 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Weakening of Cellular Encryption" ;
+    rdfs:subClassOf :CAPEC-620 ;
+    :capec-id "CAPEC-606" ;
+    :definition "An attacker, with control of a Cellular Rogue Base Station or through cooperation with a Malicious Mobile Network Operator can force the mobile device (e.g., the retransmission device) to use no encryption (A5/0 mode) or to use easily breakable encryption (A5/1 or A5/2 mode)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/606.html> ;
+    :related :CWE-757 .
+
+:CAPEC-607 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Obstruction" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-607" ;
+    :definition "An attacker obstructs the interactions between system components. By interrupting or disabling these interactions, an adversary can often force the system into a degraded state or cause the system to stop working as intended. This can cause the system components to be unavailable until the obstruction mitigated." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/607.html> .
+
+:CAPEC-608 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cryptanalysis of Cellular Encryption" ;
+    rdfs:subClassOf :CAPEC-97 ;
+    :capec-id "CAPEC-608" ;
+    :definition "The use of cryptanalytic techniques to derive cryptographic keys or otherwise effectively defeat cellular encryption to reveal traffic content. Some cellular encryption algorithms such as A5/1 and A5/2 (specified for GSM use) are known to be vulnerable to such attacks and commercial tools are available to execute these attacks and decrypt mobile phone conversations in real-time. Newer encryption algorithms in use by UMTS and LTE are stronger and currently believed to be less vulnerable to these types of attacks. Note, however, that an attacker with a Cellular Rogue Base Station can force the use of weak cellular encryption even by newer mobile devices." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/608.html> ;
+    :related :CWE-327 .
+
+:CAPEC-609 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cellular Traffic Intercept" ;
+    rdfs:subClassOf :CAPEC-157 ;
+    :capec-id "CAPEC-609" ;
+    :definition "Cellular traffic for voice and data from mobile devices and retransmission devices can be intercepted via numerous methods. Malicious actors can deploy their own cellular tower equipment and intercept cellular traffic surreptitiously. Additionally, government agencies of adversaries and malicious actors can intercept cellular traffic via the telecommunications backbone over which mobile traffic is transmitted." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/609.html> ;
+    :related :CWE-311,
+        :T1111 .
+
+:CAPEC-610 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cellular Data Injection" ;
+    rdfs:subClassOf :CAPEC-240 ;
+    :capec-id "CAPEC-610" ;
+    :definition "Adversaries inject data into mobile technology traffic (data flows or signaling data) to disrupt communications or conduct additional surveillance operations." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/610.html> .
+
+:CAPEC-611 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "BitSquatting" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-611" ;
+    :definition "An adversary registers a domain name one bit different than a trusted domain. A BitSquatting attack leverages random errors in memory to direct Internet traffic to adversary-controlled destinations. BitSquatting requires no exploitation or complicated reverse engineering, and is operating system and architecture agnostic. Experimental observations show that BitSquatting popular websites could redirect non-trivial amounts of Internet traffic to a malicious entity." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/611.html> .
+
+:CAPEC-612 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "WiFi MAC Address Tracking" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-612" ;
+    :definition "In this attack scenario, the attacker passively listens for WiFi messages and logs the associated Media Access Control (MAC) addresses. These addresses are intended to be unique to each wireless device (although they can be configured and changed by software). Once the attacker is able to associate a MAC address with a particular user or set of users (for example, when attending a public event), the attacker can then scan for that MAC address to track that user in the future." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/612.html> ;
+    :related :CWE-201,
+        :CWE-300 .
+
+:CAPEC-613 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "WiFi SSID Tracking" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-613" ;
+    :definition "In this attack scenario, the attacker passively listens for WiFi management frame messages containing the Service Set Identifier (SSID) for the WiFi network. These messages are frequently transmitted by WiFi access points (e.g., the retransmission device) as well as by clients that are accessing the network (e.g., the handset/mobile device). Once the attacker is able to associate an SSID with a particular user or set of users (for example, when attending a public event), the attacker can then scan for this SSID to track that user in the future." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/613.html> ;
+    :related :CWE-201,
+        :CWE-300 .
+
+:CAPEC-614 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Rooting SIM Cards" ;
+    rdfs:subClassOf :CAPEC-186 ;
+    :capec-id "CAPEC-614" ;
+    :definition "SIM cards are the de facto trust anchor of mobile devices worldwide. The cards protect the mobile identity of subscribers, associate devices with phone numbers, and increasingly store payment credentials, for example in NFC-enabled phones with mobile wallets. This attack leverages over-the-air (OTA) updates deployed via cryptographically-secured SMS messages to deliver executable code to the SIM. By cracking the DES key, an attacker can send properly signed binary SMS messages to a device, which are treated as Java applets and are executed on the SIM. These applets are allowed to send SMS, change voicemail numbers, and query the phone location, among many other predefined functions. These capabilities alone provide plenty of potential for abuse." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/614.html> ;
+    :related :CWE-327 .
+
+:CAPEC-615 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Evil Twin Wi-Fi Attack" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-615" ;
+    :definition "Adversaries install Wi-Fi equipment that acts as a legitimate Wi-Fi network access point. When a device connects to this access point, Wi-Fi data traffic is intercepted, captured, and analyzed. This also allows the adversary to use \"adversary-in-the-middle\" (CAPEC-94) for all communications." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/615.html> ;
+    :related :CWE-300 .
+
+:CAPEC-616 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Establish Rogue Location" ;
+    rdfs:subClassOf :CAPEC-154 ;
+    :capec-id "CAPEC-616" ;
+    :definition "An adversary provides a malicious version of a resource at a location that is similar to the expected location of a legitimate resource. After establishing the rogue location, the adversary waits for a victim to visit the location and access the malicious resource." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/616.html> ;
+    :related :CWE-200,
+        :T1036.005 .
+
+:CAPEC-617 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cellular Rogue Base Station" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-617" ;
+    :definition "In this attack scenario, the attacker imitates a cellular base station with their own \"rogue\" base station equipment. Since cellular devices connect to whatever station has the strongest signal, the attacker can easily convince a targeted cellular device (e.g. the retransmission device) to talk to the rogue base station." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/617.html> .
+
+:CAPEC-618 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Cellular Broadcast Message Request" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-618" ;
+    :definition "In this attack scenario, the attacker uses knowledge of the target’s mobile phone number (i.e., the number associated with the SIM used in the retransmission device) to cause the cellular network to send broadcast messages to alert the mobile device. Since the network knows which cell tower the target’s mobile device is attached to, the broadcast messages are only sent in the Location Area Code (LAC) where the target is currently located. By triggering the cellular broadcast message and then listening for the presence or absence of that message, an attacker could verify that the target is in (or not in) a given location." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/618.html> ;
+    :related :CWE-201 .
+
+:CAPEC-619 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Signal Strength Tracking" ;
+    rdfs:subClassOf :CAPEC-292 ;
+    :capec-id "CAPEC-619" ;
+    :definition "In this attack scenario, the attacker passively monitors the signal strength of the target’s cellular RF signal or WiFi RF signal and uses the strength of the signal (with directional antennas and/or from multiple listening points at once) to identify the source location of the signal. Obtaining the signal of the target can be accomplished through multiple techniques such as through Cellular Broadcast Message Request or through the use of IMSI Tracking or WiFi MAC Address Tracking." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/619.html> ;
+    :related :CWE-201 .
+
+:CAPEC-620 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Drop Encryption Level" ;
+    rdfs:subClassOf :CAPEC-212 ;
+    :capec-id "CAPEC-620" ;
+    :definition "An attacker forces the encryption level to be lowered, thus enabling a successful attack against the encrypted data." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/620.html> ;
+    :related :CWE-757,
+        :T1600 .
+
+:CAPEC-621 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Analysis of Packet Timing and Sizes" ;
+    rdfs:subClassOf :CAPEC-189 ;
+    :capec-id "CAPEC-621" ;
+    :definition "An attacker may intercept and log encrypted transmissions for the purpose of analyzing metadata such as packet timing and sizes. Although the actual data may be encrypted, this metadata may reveal valuable information to an attacker. Note that this attack is applicable to VOIP data as well as application data, especially for interactive apps that require precise timing and low-latency (e.g. thin-clients)." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/621.html> ;
+    :related :CWE-201 .
+
+:CAPEC-622 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Electromagnetic Side-Channel Attack" ;
+    rdfs:subClassOf :CAPEC-189 ;
+    :capec-id "CAPEC-622" ;
+    :definition "In this attack scenario, the attacker passively monitors electromagnetic emanations that are produced by the targeted electronic device as an unintentional side-effect of its processing. From these emanations, the attacker derives information about the data that is being processed (e.g. the attacker can recover cryptographic keys by monitoring emanations associated with cryptographic processing). This style of attack requires proximal access to the device, however attacks have been demonstrated at public conferences that work at distances of up to 10-15 feet. There have not been any significant studies to determine the maximum practical distance for such attacks. Since the attack is passive, it is nearly impossible to detect and the targeted device will continue to operate as normal after a successful attack." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/622.html> ;
+    :related :CWE-201 .
+
+:CAPEC-623 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Compromising Emanations Attack" ;
+    rdfs:subClassOf :CAPEC-189 ;
+    :capec-id "CAPEC-623" ;
+    :definition "Compromising Emanations (CE) are defined as unintentional signals which an attacker may intercept and analyze to disclose the information processed by the targeted equipment. Commercial mobile devices and retransmission devices have displays, buttons, microchips, and radios that emit mechanical emissions in the form of sound or vibrations. Capturing these emissions can help an adversary understand what the device is doing." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/623.html> ;
+    :related :CWE-201 .
+
+:CAPEC-624 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardware Fault Injection" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    :capec-id "CAPEC-624" ;
+    :definition "The adversary uses disruptive signals or events, or alters the physical environment a device operates in, to cause faulty behavior in electronic devices. This can include electromagnetic pulses, laser pulses, clock glitches, ambient temperature extremes, and more. When performed in a controlled manner on devices performing cryptographic operations, this faulty behavior can be exploited to derive secret key information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/624.html> ;
+    :related :CWE-1247,
+        :CWE-1248,
+        :CWE-1256,
+        :CWE-1319,
+        :CWE-1332,
+        :CWE-1334,
+        :CWE-1338,
+        :CWE-1351 .
+
+:CAPEC-625 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Mobile Device Fault Injection" ;
+    rdfs:subClassOf :CAPEC-624 ;
+    :capec-id "CAPEC-625" ;
+    :definition "Fault injection attacks against mobile devices use disruptive signals or events (e.g. electromagnetic pulses, laser pulses, clock glitches, etc.) to cause faulty behavior. When performed in a controlled manner on devices performing cryptographic operations, this faulty behavior can be exploited to derive secret key information. Although this attack usually requires physical control of the mobile device, it is non-destructive, and the device can be used after the attack without any indication that secret keys were compromised." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/625.html> ;
+    :related :CWE-1247,
+        :CWE-1248,
+        :CWE-1256,
+        :CWE-1319,
+        :CWE-1332,
+        :CWE-1334,
+        :CWE-1338,
+        :CWE-1351 .
+
+:CAPEC-626 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Smudge Attack" ;
+    rdfs:subClassOf :CAPEC-395 ;
+    :capec-id "CAPEC-626" ;
+    :definition "Attacks that reveal the password/passcode pattern on a touchscreen device by detecting oil smudges left behind by the user’s fingers." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/626.html> .
+
+:CAPEC-627 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Counterfeit GPS Signals" ;
+    rdfs:subClassOf :CAPEC-148 ;
+    :capec-id "CAPEC-627" ;
+    :definition "An adversary attempts to deceive a GPS receiver by broadcasting counterfeit GPS signals, structured to resemble a set of normal GPS signals. These spoofed signals may be structured in such a way as to cause the receiver to estimate its position to be somewhere other than where it actually is, or to be located where it is but at a different time, as determined by the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/627.html> .
+
+:CAPEC-628 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Carry-Off GPS Attack" ;
+    rdfs:subClassOf :CAPEC-627 ;
+    :capec-id "CAPEC-628" ;
+    :definition "A common form of a GPS spoofing attack, commonly termed a carry-off attack begins with an adversary broadcasting signals synchronized with the genuine signals observed by the target receiver. The power of the counterfeit signals is then gradually increased and drawn away from the genuine signals. Over time, the adversary can carry the target away from their intended destination and toward a location chosen by the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/628.html> .
+
+:CAPEC-629 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    owl:deprecated true ;
+    rdfs:label "DEPRECATED: Unauthorized Use of Device Resources" ;
+    rdfs:subClassOf :CommonAttackPattern ;
+    rdfs:comment "This attack pattern has been deprecated." ;
+    :capec-id "CAPEC-629" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/629.html> .
+
+:CAPEC-630 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "TypoSquatting" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-630" ;
+    :definition "An adversary registers a domain name with at least one character different than a trusted domain. A TypoSquatting attack takes advantage of instances where a user mistypes a URL (e.g. www.goggle.com) or not does visually verify a URL before clicking on it (e.g. phishing attack). As a result, the user is directed to an adversary-controlled destination. TypoSquatting does not require an attack against the trusted domain or complicated reverse engineering." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/630.html> ;
+    :related :CAPEC-691 .
+
+:CAPEC-631 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "SoundSquatting" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-631" ;
+    :definition "An adversary registers a domain name that sounds the same as a trusted domain, but has a different spelling. A SoundSquatting attack takes advantage of a user's confusion of the two words to direct Internet traffic to adversary-controlled destinations. SoundSquatting does not require an attack against the trusted domain or complicated reverse engineering." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/631.html> .
+
+:CAPEC-632 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Homograph Attack via Homoglyphs" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-632" ;
+    :definition "An adversary registers a domain name containing a homoglyph, leading the registered domain to appear the same as a trusted domain. A homograph attack leverages the fact that different characters among various character sets look the same to the user. Homograph attacks must generally be combined with other attacks, such as phishing attacks, in order to direct Internet traffic to the adversary-controlled destinations." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/632.html> ;
+    :related :CWE-1007 .
+
+:CAPEC-633 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Token Impersonation" ;
+    rdfs:subClassOf :CAPEC-194 ;
+    :capec-id "CAPEC-633" ;
+    :definition "An adversary exploits a weakness in authentication to create an access token (or equivalent) that impersonates a different entity, and then associates a process/thread to that that impersonated token. This action causes a downstream user to make a decision or take action that is based on the assumed identity, and not the response that blocks the adversary." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/633.html> ;
+    :related :CWE-287,
+        :CWE-1270,
+        :T1134 .
+
+:CAPEC-634 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Probe Audio and Video Peripherals" ;
+    rdfs:subClassOf :CAPEC-545,
+        :CAPEC-651 ;
+    :capec-id "CAPEC-634" ;
+    :definition "The adversary exploits the target system's audio and video functionalities through malware or scheduled tasks. The goal is to capture sensitive information about the target for financial, personal, political, or other gains which is accomplished by collecting communication data between two parties via the use of peripheral devices (e.g. microphones and webcams) or applications with audio and video capabilities (e.g. Skype) on a system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/634.html> ;
+    :related :CWE-267,
+        :T1123,
+        :T1125 .
+
+:CAPEC-635 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Alternative Execution Due to Deceptive Filenames" ;
+    rdfs:subClassOf :CAPEC-165 ;
+    :capec-id "CAPEC-635" ;
+    :definition "The extension of a file name is often used in various contexts to determine the application that is used to open and use it. If an attacker can cause an alternative application to be used, it may be able to execute malicious code, cause a denial of service or expose sensitive information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/635.html> ;
+    :related :CWE-162,
+        :T1036.007 .
+
+:CAPEC-636 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hiding Malicious Data or Code within Files" ;
+    rdfs:subClassOf :CAPEC-165 ;
+    :capec-id "CAPEC-636" ;
+    :definition "Files on various operating systems can have a complex format which allows for the storage of other data, in addition to its contents. Often this is metadata about the file, such as a cached thumbnail for an image file. Unless utilities are invoked in a particular way, this data is not visible during the normal use of the file. It is possible for an attacker to store malicious data or code using these facilities, which would be difficult to discover." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/636.html> ;
+    :related :CWE-506,
+        :T1001.002,
+        :T1027.003,
+        :T1027.004,
+        :T1218.001,
+        :T1221 .
+
+:CAPEC-637 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Collect Data from Clipboard" ;
+    rdfs:subClassOf :CAPEC-150 ;
+    :capec-id "CAPEC-637" ;
+    :definition "The adversary exploits an application that allows for the copying of sensitive data or information by collecting information copied to the clipboard. Data copied to the clipboard can be accessed by other applications, such as malware built to exfiltrate or log clipboard contents on a periodic basis. In this way, the adversary aims to garner information to which they are unauthorized." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/637.html> ;
+    :related :CWE-267,
+        :T1115 .
+
+:CAPEC-638 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Altered Component Firmware" ;
+    rdfs:subClassOf :CAPEC-452 ;
+    :capec-id "CAPEC-638" ;
+    :definition "An adversary exploits systems features and/or improperly protected firmware of hardware components, such as Hard Disk Drives (HDD), with the goal of executing malicious code from within the component's Master Boot Record (MBR). Conducting this type of attack entails the adversary infecting the target with firmware altering malware, using known tools, and a payload. Once this malware is executed, the MBR is modified to include instructions to execute the payload at desired intervals and when the system is booted up. A successful attack will obtain persistence within the victim system even if the operating system is reinstalled and/or if the component is formatted or has its data erased." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/638.html> ;
+    :related :T1542.002 .
+
+:CAPEC-639 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Probe System Files" ;
+    rdfs:subClassOf :CAPEC-545 ;
+    :capec-id "CAPEC-639" ;
+    :definition "An adversary obtains unauthorized information due to improperly protected files. If an application stores sensitive information in a file that is not protected by proper access control, then an adversary can access the file and search for sensitive information." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/639.html> ;
+    :related :CWE-552,
+        :T1039,
+        :T1552.001,
+        :T1552.003,
+        :T1552.004,
+        :T1552.006 .
+
+:CAPEC-640 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Inclusion of Code in Existing Process" ;
+    rdfs:subClassOf :CAPEC-251 ;
+    :capec-id "CAPEC-640" ;
+    :definition "The adversary takes advantage of a bug in an application failing to verify the integrity of the running process to execute arbitrary code in the address space of a separate live process. The adversary could use running code in the context of another process to try to access process's memory, system/network resources, etc. The goal of this attack is to evade detection defenses and escalate privileges by masking the malicious code under an existing legitimate process. Examples of approaches include but not limited to: dynamic-link library (DLL) injection, portable executable injection, thread execution hijacking, ptrace system calls, VDSO hijacking, function hooking, reflective code loading, and more." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/640.html> ;
+    :related :CWE-114,
+        :CWE-829,
+        :T1505.005,
+        :T1574.006,
+        :T1574.013,
+        :T1620 .
+
+:CAPEC-641 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DLL Side-Loading" ;
+    rdfs:subClassOf :CAPEC-159 ;
+    :capec-id "CAPEC-641" ;
+    :definition "An adversary places a malicious version of a Dynamic-Link Library (DLL) in the Windows Side-by-Side (WinSxS) directory to trick the operating system into loading this malicious DLL instead of a legitimate DLL. Programs specify the location of the DLLs to load via the use of WinSxS manifests or DLL redirection and if they aren't used then Windows searches in a predefined set of directories to locate the file. If the applications improperly specify a required DLL or WinSxS manifests aren't explicit about the characteristics of the DLL to be loaded, they can be vulnerable to side-loading." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/641.html> ;
+    :related :CWE-706,
+        :T1574.002 .
+
+:CAPEC-642 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Replace Binaries" ;
+    rdfs:subClassOf :CAPEC-17 ;
+    :capec-id "CAPEC-642" ;
+    :definition "Adversaries know that certain binaries will be regularly executed as part of normal processing. If these binaries are not protected with the appropriate file system permissions, it could be possible to replace them with malware. This malware might be executed at higher system permission levels. A variation of this pattern is to discover self-extracting installation packages that unpack binaries to directories with weak file permissions which it does not clean up appropriately. These binaries can be replaced by malware, which can then be executed." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/642.html> ;
+    :related :CWE-732,
+        :T1505.005,
+        :T1554,
+        :T1574.005 .
+
+:CAPEC-643 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Identify Shared Files/Directories on System" ;
+    rdfs:subClassOf :CAPEC-309 ;
+    :capec-id "CAPEC-643" ;
+    :definition "An adversary discovers connections between systems by exploiting the target system's standard practice of revealing them in searchable, common areas. Through the identification of shared folders/drives between systems, the adversary may further their goals of locating and collecting sensitive information/files, or map potential routes for lateral movement within the network." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/643.html> ;
+    :related :CWE-200,
+        :CWE-267,
+        :T1135 .
+
+:CAPEC-644 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Use of Captured Hashes (Pass The Hash)" ;
+    rdfs:subClassOf :CAPEC-653 ;
+    :capec-id "CAPEC-644" ;
+    :definition "An adversary obtains (i.e. steals or purchases) legitimate Windows domain credential hash values to access systems within the domain that leverage the Lan Man (LM) and/or NT Lan Man (NTLM) authentication protocols." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/644.html> ;
+    :related :CWE-294,
+        :CWE-308,
+        :CWE-522,
+        :CWE-836,
+        :T1550.002 .
+
+:CAPEC-645 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Use of Captured Tickets (Pass The Ticket)" ;
+    rdfs:subClassOf :CAPEC-652 ;
+    :capec-id "CAPEC-645" ;
+    :definition "An adversary uses stolen Kerberos tickets to access systems/resources that leverage the Kerberos authentication protocol. The Kerberos authentication protocol centers around a ticketing system which is used to request/grant access to services and to then access the requested services. An adversary can obtain any one of these tickets (e.g. Service Ticket, Ticket Granting Ticket, Silver Ticket, or Golden Ticket) to authenticate to a system/resource without needing the account's credentials. Depending on the ticket obtained, the adversary may be able to access a particular resource or generate TGTs for any account within an Active Directory Domain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/645.html> ;
+    :related :CWE-294,
+        :CWE-308,
+        :CWE-522,
+        :T1550.003 .
+
+:CAPEC-646 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Peripheral Footprinting" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-646" ;
+    :definition "Adversaries may attempt to obtain information about attached peripheral devices and components connected to a computer system. Examples may include discovering the presence of iOS devices by searching for backups, analyzing the Windows registry to determine what USB devices have been connected, or infecting a victim system with malware to report when a USB device has been connected. This may allow the adversary to gain additional insight about the system or network environment, which may be useful in constructing further attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/646.html> ;
+    :related :CWE-200,
+        :T1120 .
+
+:CAPEC-647 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Collect Data from Registries" ;
+    rdfs:subClassOf :CAPEC-150 ;
+    :capec-id "CAPEC-647" ;
+    :definition "An adversary exploits a weakness in authorization to gather system-specific data and sensitive information within a registry (e.g., Windows Registry, Mac plist). These contain information about the system configuration, software, operating system, and security. The adversary can leverage information gathered in order to carry out further attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/647.html> ;
+    :related :CWE-285,
+        :T1005,
+        :T1012,
+        :T1552.002 .
+
+:CAPEC-648 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Collect Data from Screen Capture" ;
+    rdfs:subClassOf :CAPEC-150 ;
+    :capec-id "CAPEC-648" ;
+    :definition "An adversary gathers sensitive information by exploiting the system's screen capture functionality. Through screenshots, the adversary aims to see what happens on the screen over the course of an operation. The adversary can leverage information gathered in order to carry out further attacks." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/648.html> ;
+    :related :CWE-267,
+        :T1113,
+        :T1513 .
+
+:CAPEC-649 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Adding a Space to a File Extension" ;
+    rdfs:subClassOf :CAPEC-635 ;
+    :capec-id "CAPEC-649" ;
+    :definition "An adversary adds a space character to the end of a file extension and takes advantage of an application that does not properly neutralize trailing special elements in file names. This extra space, which can be difficult for a user to notice, affects which default application is used to operate on the file and can be leveraged by the adversary to control execution." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/649.html> ;
+    :related :CWE-46,
+        :T1036.006 .
+
+:CAPEC-650 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Upload a Web Shell to a Web Server" ;
+    rdfs:subClassOf :CAPEC-17 ;
+    :capec-id "CAPEC-650" ;
+    :definition "By exploiting insufficient permissions, it is possible to upload a web shell to a web server in such a way that it can be executed remotely. This shell can have various capabilities, thereby acting as a \"gateway\" to the underlying web server. The shell might execute at the higher permission level of the web server, providing the ability the execute malicious code at elevated levels." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/650.html> ;
+    :related :CWE-287,
+        :CWE-553,
+        :T1505.003 .
+
+:CAPEC-651 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Eavesdropping" ;
+    rdfs:subClassOf :CAPEC-117 ;
+    :capec-id "CAPEC-651" ;
+    :definition "An adversary intercepts a form of communication (e.g. text, audio, video) by way of software (e.g., microphone and audio recording application), hardware (e.g., recording equipment), or physical means (e.g., physical proximity). The goal of eavesdropping is typically to gain unauthorized access to sensitive information about the target for financial, personal, political, or other gains. Eavesdropping is different from a sniffing attack as it does not take place on a network-based communication channel (e.g., IP traffic). Instead, it entails listening in on the raw audio source of a conversation between two or more parties." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/651.html> ;
+    :related :CWE-200,
+        :T1111 .
+
+:CAPEC-652 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Use of Known Kerberos Credentials" ;
+    rdfs:subClassOf :CAPEC-560 ;
+    :capec-id "CAPEC-652" ;
+    :definition "An adversary obtains (i.e. steals or purchases) legitimate Kerberos credentials (e.g. Kerberos service account userID/password or Kerberos Tickets) with the goal of achieving authenticated access to additional systems, applications, or services within the domain." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/652.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-294,
+        :CWE-307,
+        :CWE-308,
+        :CWE-309,
+        :CWE-522,
+        :CWE-654,
+        :CWE-836,
+        :T1558 .
+
+:CAPEC-653 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Use of Known Operating System Credentials" ;
+    rdfs:subClassOf :CAPEC-560 ;
+    :capec-id "CAPEC-653" ;
+    :definition "An adversary guesses or obtains (i.e. steals or purchases) legitimate operating system credentials (e.g. userID/password) to achieve authentication and to perform authorized actions on the system, under the guise of an authenticated user or service. This applies to any Operating System." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/653.html> ;
+    :related :CWE-262,
+        :CWE-263,
+        :CWE-307,
+        :CWE-308,
+        :CWE-309,
+        :CWE-522,
+        :CWE-654 .
+
+:CAPEC-654 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Credential Prompt Impersonation" ;
+    rdfs:subClassOf :CAPEC-504 ;
+    :capec-id "CAPEC-654" ;
+    :definition "An adversary, through a previously installed malicious application, impersonates a credential prompt in an attempt to steal a user's credentials." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/654.html> ;
+    :related :CWE-1021,
+        :T1056,
+        :T1548.004 .
+
+:CAPEC-655 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Avoid Security Tool Identification by Adding Data" ;
+    rdfs:subClassOf :CAPEC-572 ;
+    :capec-id "CAPEC-655" ;
+    :definition "An adversary adds data to a file to increase the file size beyond what security tools are capable of handling in an attempt to mask their actions." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/655.html> ;
+    :related :T1027.001 .
+
+:CAPEC-656 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Voice Phishing" ;
+    rdfs:subClassOf :CAPEC-98 ;
+    :capec-id "CAPEC-656" ;
+    :definition "An adversary targets users with a phishing attack for the purpose of soliciting account passwords or sensitive information from the user. Voice Phishing is a variation of the Phishing social engineering technique where the attack is initiated via a voice call, rather than email. The user is enticed to provide sensitive information by the adversary, who masquerades as a legitimate employee of the alleged organization. Voice Phishing attacks deviate from standard Phishing attacks, in that a user doesn't typically interact with a compromised website to provide sensitive information and instead provides this information verbally. Voice Phishing attacks can also be initiated by either the adversary in the form of a \"cold call\" or by the victim if calling an illegitimate telephone number." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/656.html> .
+
+:CAPEC-657 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Automated Software Update via Spoofing" ;
+    rdfs:subClassOf :CAPEC-186 ;
+    :capec-id "CAPEC-657" ;
+    :definition "An attackers uses identify or content spoofing to trick a client into performing an automated software update from a malicious source. A malicious automated software update that leverages spoofing can include content or identity spoofing as well as protocol spoofing. Content or identity spoofing attacks can trigger updates in software by embedding scripted mechanisms within a malicious web page, which masquerades as a legitimate update source. Scripting mechanisms communicate with software components and trigger updates from locations specified by the attackers' server. The result is the client believing there is a legitimate software update available but instead downloading a malicious update from the attacker." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/657.html> ;
+    :related :CWE-494,
+        :T1072 .
+
+:CAPEC-660 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Root/Jailbreak Detection Evasion via Hooking" ;
+    rdfs:subClassOf :CAPEC-251 ;
+    :capec-id "CAPEC-660" ;
+    :definition "An adversary forces a non-restricted mobile application to load arbitrary code or code files, via Hooking, with the goal of evading Root/Jailbreak detection. Mobile device users often Root/Jailbreak their devices in order to gain administrative control over the mobile operating system and/or to install third-party mobile applications that are not provided by authorized application stores (e.g. Google Play Store and Apple App Store). Adversaries may further leverage these capabilities to escalate privileges or bypass access control on legitimate applications. Although many mobile applications check if a mobile device is Rooted/Jailbroken prior to authorized use of the application, adversaries may be able to \"hook\" code in order to circumvent these checks. Successfully evading Root/Jailbreak detection allows an adversary to execute administrative commands, obtain confidential data, impersonate legitimate users of the application, and more." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/660.html> ;
+    :related :CWE-829,
+        :T1055 .
+
+:CAPEC-661 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Root/Jailbreak Detection Evasion via Debugging" ;
+    rdfs:subClassOf :CAPEC-121 ;
+    :capec-id "CAPEC-661" ;
+    :definition "An adversary inserts a debugger into the program entry point of a mobile application to modify the application binary, with the goal of evading Root/Jailbreak detection. Mobile device users often Root/Jailbreak their devices in order to gain administrative control over the mobile operating system and/or to install third-party mobile applications that are not provided by authorized application stores (e.g. Google Play Store and Apple App Store). Rooting/Jailbreaking a mobile device also provides users with access to system debuggers and disassemblers, which can be leveraged to exploit applications by dumping the application's memory at runtime in order to remove or bypass signature verification methods. This further allows the adversary to evade Root/Jailbreak detection mechanisms, which can result in execution of administrative commands, obtaining confidential data, impersonating legitimate users of the application, and more." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/661.html> ;
+    :related :CWE-489 .
+
+:CAPEC-662 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Adversary in the Browser (AiTB)" ;
+    rdfs:subClassOf :CAPEC-94 ;
+    :capec-id "CAPEC-662" ;
+    :definition "An adversary exploits security vulnerabilities or inherent functionalities of a web browser, in order to manipulate traffic between two endpoints." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/662.html> ;
+    :related :CWE-300,
+        :CWE-494,
+        :T1185 .
+
 :CAPEC-663 a :CommonAttackPattern,
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Exploitation of Transient Instruction Execution" ;
+    rdfs:subClassOf :CAPEC-74,
+        :CAPEC-184 ;
+    :capec-id "CAPEC-663" ;
+    :definition "An adversary exploits a hardware design flaw in a CPU implementation of transient instruction execution to expose sensitive data and bypass/subvert access control over restricted resources. Typically, the adversary conducts a covert channel attack to target non-discarded microarchitectural changes caused by transient executions such as speculative execution, branch prediction, instruction pipelining, and/or out-of-order execution. The transient execution results in a series of instructions (gadgets) which construct covert channel and access/transfer the secret data." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/663.html> ;
+    :related :CAPEC-124,
+        :CAPEC-180,
+        :CAPEC-212,
+        :CWE-1037,
+        :CWE-1264,
+        :CWE-1303 .
+
+:CAPEC-664 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Server Side Request Forgery" ;
+    rdfs:subClassOf :CAPEC-115 ;
+    :capec-id "CAPEC-664" ;
+    :definition "An adversary exploits improper input validation by submitting maliciously crafted input to a target application running on a server, with the goal of forcing the server to make a request either to itself, to web services running in the server’s internal network, or to external third parties. If successful, the adversary’s request will be made with the server’s privilege level, bypassing its authentication controls. This ultimately allows the adversary to access sensitive data, execute commands on the server’s network, and make external requests with the stolen identity of the server. Server Side Request Forgery attacks differ from Cross Site Request Forgery attacks in that they target the server itself, whereas CSRF attacks exploit an insecure user authentication mechanism to perform unauthorized actions on the user's behalf." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/664.html> ;
+    :related :CWE-20,
+        :CWE-918 .
+
+:CAPEC-665 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploitation of Thunderbolt Protection Flaws" ;
+    rdfs:subClassOf :CAPEC-276 ;
+    :capec-id "CAPEC-665" ;
+    :definition "An adversary leverages a firmware weakness within the Thunderbolt protocol, on a computing device to manipulate Thunderbolt controller firmware in order to exploit vulnerabilities in the implementation of authorization and verification schemes within Thunderbolt protection mechanisms. Upon gaining physical access to a target device, the adversary conducts high-level firmware manipulation of the victim Thunderbolt controller SPI (Serial Peripheral Interface) flash, through the use of a SPI Programing device and an external Thunderbolt device, typically as the target device is booting up. If successful, this allows the adversary to modify memory, subvert authentication mechanisms, spoof identities and content, and extract data and memory from the target device. Currently 7 major vulnerabilities exist within Thunderbolt protocol with 9 attack vectors as noted in the Execution Flow." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/665.html> ;
+    :related :CAPEC-148,
+        :CAPEC-151,
+        :CAPEC-458,
+        :CWE-288,
+        :CWE-345,
+        :CWE-353,
+        :CWE-862,
+        :CWE-1188,
+        :T1211,
+        :T1542.002,
+        :T1556 .
+
+:CAPEC-666 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "BlueSmacking" ;
+    rdfs:subClassOf :CAPEC-125 ;
+    :capec-id "CAPEC-666" ;
+    :definition "An adversary uses Bluetooth flooding to transfer large packets to Bluetooth enabled devices over the L2CAP protocol with the goal of creating a DoS. This attack must be carried out within close proximity to a Bluetooth enabled device." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/666.html> ;
+    :related :CWE-404,
+        :T1498.001,
+        :T1499.001 .
+
+:CAPEC-667 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bluetooth Impersonation AttackS (BIAS)" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-667" ;
+    :definition "An adversary disguises the MAC address of their Bluetooth enabled device to one for which there exists an active and trusted connection and authenticates successfully. The adversary can then perform malicious actions on the target Bluetooth device depending on the target’s capabilities." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/667.html> ;
+    :related :CWE-290 .
+
+:CAPEC-668 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Key Negotiation of Bluetooth Attack (KNOB)" ;
+    rdfs:subClassOf :CAPEC-115 ;
+    :capec-id "CAPEC-668" ;
+    :definition "An adversary can exploit a flaw in Bluetooth key negotiation allowing them to decrypt information sent between two devices communicating via Bluetooth. The adversary uses an Adversary in the Middle setup to modify packets sent between the two devices during the authentication process, specifically the entropy bits. Knowledge of the number of entropy bits will allow the attacker to easily decrypt information passing over the line of communication." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/668.html> ;
+    :related :CWE-285,
+        :CWE-425,
+        :CWE-693,
+        :T1565.002 .
+
+:CAPEC-669 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Alteration of a Software Update" ;
+    rdfs:subClassOf :CAPEC-184 ;
+    :capec-id "CAPEC-669" ;
+    :definition "An adversary with access to an organization’s software update infrastructure inserts malware into the content of an outgoing update to fielded systems where a wide range of malicious effects are possible. With the same level of access, the adversary can alter a software update to perform specific malicious acts including granting the adversary control over the software’s normal functionality." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/669.html> ;
+    :related :T1195.002 .
+
+:CAPEC-670 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Software Development Tools Maliciously Altered" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-670" ;
+    :definition "An adversary with the ability to alter tools used in a development environment causes software to be developed with maliciously modified tools. Such tools include requirements management and database tools, software design tools, configuration management tools, compilers, system build tools, and software performance testing and load testing tools. The adversary then carries out malicious acts once the software is deployed including malware infection of other systems to support further compromises." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/670.html> ;
+    :related :T1127,
+        :T1195.001 .
+
+:CAPEC-671 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Requirements for ASIC Functionality Maliciously Altered" ;
+    rdfs:subClassOf :CAPEC-447 ;
+    :capec-id "CAPEC-671" ;
+    :definition "An adversary with access to functional requirements for an application specific integrated circuit (ASIC), a chip designed/customized for a singular particular use, maliciously alters requirements derived from originating capability needs. In the chip manufacturing process, requirements drive the chip design which, when the chip is fully manufactured, could result in an ASIC which may not meet the user’s needs, contain malicious functionality, or exhibit other anomalous behaviors thereby affecting the intended use of the ASIC." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/671.html> ;
+    :related :T1195.003 .
+
+:CAPEC-672 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Malicious Code Implanted During Chip Programming" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-672" ;
+    :definition "During the programming step of chip manufacture, an adversary with access and necessary technical skills maliciously alters a chip’s intended program logic to produce an effect intended by the adversary when the fully manufactured chip is deployed and in operational use. Intended effects can include the ability of the adversary to remotely control a host system to carry out malicious acts." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/672.html> ;
+    :related :T1195.003 .
+
+:CAPEC-673 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Developer Signing Maliciously Altered Software" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-673" ;
+    :definition "Software produced by a reputable developer is clandestinely infected with malicious code and then digitally signed by the unsuspecting developer, where the software has been altered via a compromised software development or build process prior to being signed. The receiver or user of the software has no reason to believe that it is anything but legitimate and proceeds to deploy it to organizational systems." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/673.html> ;
+    :related :T1195.002 .
+
+:CAPEC-674 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Design for FPGA Maliciously Altered" ;
+    rdfs:subClassOf :CAPEC-447 ;
+    :capec-id "CAPEC-674" ;
+    :definition "An adversary alters the functionality of a field-programmable gate array (FPGA) by causing an FPGA configuration memory chip reload in order to introduce a malicious function that could result in the FPGA performing or enabling malicious functions on a host system. Prior to the memory chip reload, the adversary alters the program for the FPGA by adding a function to impact system operation." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/674.html> ;
+    :related :T1195.003 .
+
+:CAPEC-675 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Retrieve Data from Decommissioned Devices" ;
+    rdfs:subClassOf :CAPEC-116 ;
+    :capec-id "CAPEC-675" ;
+    :definition "An adversary obtains decommissioned, recycled, or discarded systems and devices that can include an organization’s intellectual property, employee data, and other types of controlled information. Systems and devices that have reached the end of their lifecycles may be subject to recycle or disposal where they can be exposed to adversarial attempts to retrieve information from internal memory chips and storage devices that are part of the system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/675.html> ;
+    :related :CWE-1266,
+        :T1052 .
+
+:CAPEC-676 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "NoSQL Injection" ;
+    rdfs:subClassOf :CAPEC-248 ;
+    :capec-id "CAPEC-676" ;
+    :definition "An adversary targets software that constructs NoSQL statements based on user input or with parameters vulnerable to operator replacement in order to achieve a variety of technical impacts such as escalating privileges, bypassing authentication, and/or executing code." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/676.html> ;
+    :related :CWE-943,
+        :CWE-1286 .
+
+:CAPEC-677 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Server Motherboard Compromise" ;
+    rdfs:subClassOf :CAPEC-534 ;
+    :capec-id "CAPEC-677" ;
+    :definition "Malware is inserted in a server motherboard (e.g., in the flash memory) in order to alter server functionality from that intended. The development environment or hardware/software support activity environment is susceptible to an adversary inserting malicious software into hardware components during development or update." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/677.html> ;
+    :related :T1195.003 .
+
+:CAPEC-678 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "System Build Data Maliciously Altered" ;
+    rdfs:subClassOf :CAPEC-444 ;
+    :capec-id "CAPEC-678" ;
+    :definition "During the system build process, the system is deliberately misconfigured by the alteration of the build data. Access to system configuration data files and build processes is susceptible to deliberate misconfiguration of the system." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/678.html> ;
+    :related :T1195.002 .
+
+:CAPEC-679 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploitation of Improperly Configured or Implemented Memory Protections" ;
+    rdfs:subClassOf :CAPEC-1,
+        :CAPEC-180 ;
+    :capec-id "CAPEC-679" ;
+    :definition "An adversary takes advantage of missing or incorrectly configured access control within memory to read/write data or inject malicious code into said memory." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/679.html> ;
+    :related :CWE-1222,
+        :CWE-1252,
+        :CWE-1257,
+        :CWE-1260,
+        :CWE-1274,
+        :CWE-1282,
+        :CWE-1312,
+        :CWE-1316,
+        :CWE-1326 .
+
+:CAPEC-680 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploitation of Improperly Controlled Registers" ;
+    rdfs:subClassOf :CAPEC-1,
+        :CAPEC-180 ;
+    :capec-id "CAPEC-680" ;
+    :definition "An adversary exploits missing or incorrectly configured access control within registers to read/write data that is not meant to be obtained or modified by a user." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/680.html> ;
+    :related :CWE-1224,
+        :CWE-1231,
+        :CWE-1233,
+        :CWE-1262,
+        :CWE-1283 .
+
+:CAPEC-681 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploitation of Improperly Controlled Hardware Security Identifiers" ;
+    rdfs:subClassOf :CAPEC-1,
+        :CAPEC-180 ;
+    :capec-id "CAPEC-681" ;
+    :definition "An adversary takes advantage of missing or incorrectly configured security identifiers (e.g., tokens), which are used for access control within a System-on-Chip (SoC), to read/write data or execute a given action." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/681.html> ;
+    :related :CWE-1259,
+        :CWE-1267,
+        :CWE-1270,
+        :CWE-1294,
+        :CWE-1302 .
+
+:CAPEC-682 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploitation of Firmware or ROM Code with Unpatchable Vulnerabilities" ;
+    rdfs:subClassOf :CAPEC-212 ;
+    :capec-id "CAPEC-682" ;
+    :definition "An adversary may exploit vulnerable code (i.e., firmware or ROM) that is unpatchable. Unpatchable devices exist due to manufacturers intentionally or inadvertently designing devices incapable of updating their software. Additionally, with updatable devices, the manufacturer may decide not to support the device and stop making updates to their software." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/682.html> ;
+    :related :CWE-1277,
+        :CWE-1310 .
+
+:CAPEC-690 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Metadata Spoofing" ;
     rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:isDefinedBy "https://capec.mitre.org/data/definitions/663.html" ;
-    :capec-id "CAPEC-553" .
+    :capec-id "CAPEC-690" ;
+    :definition "An adversary alters the metadata of a resource (e.g., file, directory, repository, etc.) to present a malicious resource as legitimate/credible." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/690.html> .
+
+:CAPEC-691 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Spoof Open-Source Software Metadata" ;
+    rdfs:subClassOf :CAPEC-690 ;
+    :capec-id "CAPEC-691" ;
+    :definition "An adversary spoofs open-source software metadata in an attempt to masquerade malicious software as popular, maintained, and trusted." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/691.html> ;
+    :related :CAPEC-630,
+        :CWE-494,
+        :T1195.001,
+        :T1195.002 .
+
+:CAPEC-692 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Spoof Version Control System Commit Metadata" ;
+    rdfs:subClassOf :CAPEC-691 ;
+    :capec-id "CAPEC-692" ;
+    :definition "An adversary spoofs metadata pertaining to a Version Control System (VCS) (e.g., Git) repository's commits to deceive users into believing that the maliciously provided software is frequently maintained and originates from a trusted source." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/692.html> ;
+    :related :CWE-494 .
+
+:CAPEC-693 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "StarJacking" ;
+    rdfs:subClassOf :CAPEC-691 ;
+    :capec-id "CAPEC-693" ;
+    :definition "An adversary spoofs software popularity metadata to deceive users into believing that a maliciously provided package is widely used and originates from a trusted source." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/693.html> ;
+    :related :CWE-494 .
+
+:CAPEC-694 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "System Location Discovery" ;
+    rdfs:subClassOf :CAPEC-169 ;
+    :capec-id "CAPEC-694" ;
+    :definition "An adversary collects information about the target system in an attempt to identify the system's geographical location." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/694.html> ;
+    :related :CWE-497,
+        :T1614 .
+
+:CAPEC-695 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Repo Jacking" ;
+    rdfs:subClassOf :CAPEC-616 ;
+    :capec-id "CAPEC-695" ;
+    :definition "An adversary takes advantage of the redirect property of directly linked Version Control System (VCS) repositories to trick users into incorporating malicious code into their applications." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/695.html> ;
+    :related :CWE-494,
+        :CWE-829,
+        :T1195.001 .
+
+:CAPEC-696 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Load Value Injection" ;
+    rdfs:subClassOf :CAPEC-663 ;
+    :capec-id "CAPEC-696" ;
+    :definition "An adversary exploits a hardware design flaw in a CPU implementation of transient instruction execution in which a faulting or assisted load instruction transiently forwards adversary-controlled data from microarchitectural buffers. By inducing a page fault or microcode assist during victim execution, an adversary can force legitimate victim execution to operate on the adversary-controlled data which is stored in the microarchitectural buffers. The adversary can then use existing code gadgets and side channel analysis to discover victim secrets that have not yet been flushed from microarchitectural state or hijack the system control flow." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/696.html> ;
+    :related :CWE-1342 .
+
+:CAPEC-697 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DHCP Spoofing" ;
+    rdfs:subClassOf :CAPEC-194 ;
+    :capec-id "CAPEC-697" ;
+    :definition "An adversary masquerades as a legitimate Dynamic Host Configuration Protocol (DHCP) server by spoofing DHCP traffic, with the goal of redirecting network traffic or denying service to DHCP." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/697.html> ;
+    :related :CWE-923,
+        :T1557.003 .
+
+:CAPEC-698 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Install Malicious Extension" ;
+    rdfs:subClassOf :CAPEC-542 ;
+    :capec-id "CAPEC-698" ;
+    :definition "An adversary directly installs or tricks a user into installing a malicious extension into existing trusted software, with the goal of achieving a variety of negative technical impacts." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/698.html> ;
+    :related :CWE-507,
+        :CWE-829,
+        :T1176,
+        :T1505.004 .
+
+:CAPEC-699 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Eavesdropping on a Monitor" ;
+    rdfs:subClassOf :CAPEC-651 ;
+    :capec-id "CAPEC-699" ;
+    :definition "An Adversary can eavesdrop on the content of an external monitor through the air without modifying any cable or installing software, just capturing this signal emitted by the cable or video port, with this the attacker will be able to impact the confidentiality of the data without being detected by traditional security tools" ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/699.html> ;
+    :related :CWE-1300 .
+
+:CAPEC-700 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Network Boundary Bridging" ;
+    rdfs:subClassOf :CAPEC-161 ;
+    :capec-id "CAPEC-700" ;
+    :definition "An adversary which has gained elevated access to network boundary devices may use these devices to create a channel to bridge trusted and untrusted networks. Boundary devices do not necessarily have to be on the network’s edge, but rather must serve to segment portions of the target network the adversary wishes to cross into." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/700.html> ;
+    :related :T1599 .
+
+:CAPEC-701 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Browser in the Middle (BiTM)" ;
+    rdfs:subClassOf :CAPEC-94 ;
+    :capec-id "CAPEC-701" ;
+    :definition "An adversary exploits the inherent functionalities of a web browser, in order to establish an unnoticed remote desktop connection in the victim's browser to the adversary's system. The adversary must deploy a web client with a remote desktop session that the victim can access." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/701.html> ;
+    :related :CWE-294,
+        :CWE-345 .
+
+:CAPEC-702 a :CommonAttackPattern,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Exploiting Incorrect Chaining or Granularity of Hardware Debug Components" ;
+    rdfs:subClassOf :CAPEC-180 ;
+    :capec-id "CAPEC-702" ;
+    :definition "An adversary exploits incorrect chaining or granularity of hardware debug components in order to gain unauthorized access to debug functionality on a chip. This happens when authorization is not checked on a per function basis and is assumed for a chain or group of debug functionality." ;
+    rdfs:seeAlso <https://capec.mitre.org/data/definitions/702.html> ;
+    :related :CWE-1296 .
 
 :CAPECThing a owl:Class ;
     rdfs:label "CAPEC Thing" ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -23,6 +23,7 @@
     :definition "x abuses y: The entity x applies an artifact y to a wrong thing or person; x applies y badly or incorrectly." .
 
 :access-mediated-by a owl:ObjectProperty ;
+    rdfs:label "access mediated by" ;
     rdfs:subPropertyOf :associated-with ;
     owl:inverseOf :mediates-access-to .
 
@@ -36,7 +37,6 @@
     rdfs:label "accesses" ;
     rdfs:subPropertyOf :associated-with,
         :may-access ;
-    rdfs:range :NetworkResource ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02673854-n> ;
     :definition "x accesses y: An subject x takes the action of reading from, writing into, or executing the stored information in the object y. Reads, writes, and executes are specific cases of accesses." .
 
@@ -94,7 +94,7 @@
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01980375-s> ;
     :definition "x attached-to y: A subject x is joined in close association to an object y." ;
-    rdfs:seeAlso "d3f:connects" .
+    rdfs:seeAlso :connects .
 
 :attack-may-be-countered-by a owl:ObjectProperty ;
     rdfs:label "attack-may-be-countered-by" ;
@@ -135,6 +135,19 @@
     rdfs:label "broader-transitive" ;
     rdfs:subPropertyOf :semantic-relation .
 
+:caused-by a owl:ObjectProperty ;
+    rdfs:label "caused-by" ;
+    rdfs:subPropertyOf :associated-with ;
+    owl:inverseOf :causes ;
+    rdfs:isDefinedBy <https://www.commoncoreontologies.org/ont00001819> ;
+    :definition "x caused-by y: The event or action x occurs as a consequence of event or action y." .
+
+:causes a owl:ObjectProperty ;
+    rdfs:label "causes" ;
+    rdfs:subPropertyOf :associated-with ;
+    rdfs:isDefinedBy <https://www.commoncoreontologies.org/ont00001803> ;
+    :definition "x causes y: The event or action x brings about event or action y as a consequence." .
+
 :cited-by a owl:ObjectProperty ;
     rdfs:label "cited-by" ;
     rdfs:subPropertyOf :d3fend-catalog-object-property ;
@@ -154,6 +167,11 @@
 :claims a owl:ObjectProperty ;
     rdfs:label "claims" ;
     rdfs:subPropertyOf :d3fend-catalog-object-property .
+
+:communicates-with a owl:ObjectProperty ;
+    rdfs:label "communicates with" ;
+    rdfs:subPropertyOf :associated-with ;
+    :definition "x communicates with y: An entity x sends and receives data by any means of data transferance to an entity y." .
 
 :configures a owl:ObjectProperty ;
     rdfs:label "configures" ;
@@ -186,8 +204,14 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     :definition "x contains y: A core relation that holds between a whole x and its part y.  Equivalent to relational concept 'has part' and thus transitive." .
 
 :contributor a owl:ObjectProperty ;
+    rdfs:label "contributor" ;
     rdfs:subPropertyOf :d3fend-catalog-object-property ;
     rdfs:range owl:Thing .
+
+:controls a owl:ObjectProperty ;
+    rdfs:label "controls" ;
+    rdfs:subPropertyOf :associated-with ;
+    :definition "x controls y: An entity x that regulate, guide, or manage the behavior of an entity y." .
 
 :copies a owl:ObjectProperty ;
     rdfs:label "copies" ;
@@ -217,7 +241,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
         :may-create ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01630392-v> ;
     :definition "x creates y: The subject x bring into existence an object y.  Some technique or agent x creates a persistent digital artifact y (as opposed to production of a consumable or transient object.); i.e., bring forth or generate" ;
-    rdfs:seeAlso "produces" .
+    rdfs:seeAlso :produces .
 
 :creator a owl:ObjectProperty ;
     rdfs:label "creator" ;
@@ -239,6 +263,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     :definition "x d3fend-kb-object-property y: The object y is a d3fend knowledge base object property. These properties allow the linkage of knowledge and information supporting and illustrating the d3fend model." .
 
 :d3fend-object-property a owl:ObjectProperty ;
+    rdfs:label "d3fend-object-property" ;
     rdfs:subPropertyOf owl:topObjectProperty .
 
 :d3fend-process-object-property a owl:ObjectProperty ;
@@ -247,9 +272,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 
 :d3fend-tactical-verb-property a owl:ObjectProperty ;
     rdfs:label "d3fend-tactical-verb-property" ;
-    rdfs:subPropertyOf :d3fend-object-property ;
-    rdfs:domain :DefensiveTechnique ;
-    rdfs:range :Artifact .
+    rdfs:subPropertyOf :d3fend-object-property .
 
 :d3fend-use-case-object-property a owl:ObjectProperty ;
     rdfs:subPropertyOf :d3fend-object-property .
@@ -272,16 +295,16 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :dependent a owl:ObjectProperty ;
     rdfs:label "dependent" ;
     rdfs:subPropertyOf :associated-with ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/00729216-a" ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00729216-a> ;
     :definition "x dependent y: A dependent y is an entity that requires the fulfillment of the requirements specified in dependency x." .
 
 :dependsOn a owl:ObjectProperty ;
     rdfs:label "depends-on" ;
     rdfs:subPropertyOf :associated-with ;
     owl:inverseOf :has-dependent ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/00729216-a",
-        "x depends-on y: The entity x is contingent on y being available; x relies on y." ;
-    rdfs:seeAlso "https://www.cisa.gov/what-are-dependencies" .
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00729216-a> ;
+    :definition "x depends-on y: The entity x is contingent on y being available; x relies on y." ;
+    rdfs:seeAlso <https://www.cisa.gov/what-are-dependencies> .
 
 :detects a owl:ObjectProperty ;
     rdfs:label "detects" ;
@@ -341,7 +364,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :enumerates a owl:ObjectProperty ;
     rdfs:label "enumerates" ;
     rdfs:subPropertyOf :reads ;
-    :definition "definition \"x enumerates y: The subject x takes the action of reading from a digital source y to acquire data and create a list of its contents." .
+    :definition "x enumerates y: The subject x takes the action of reading from a digital source y to acquire data and create a list of its contents." .
+
+:erases a owl:ObjectProperty ;
+    rdfs:label "erases" ;
+    rdfs:subPropertyOf :associated-with ;
+    :description "x erases y: A technique x removes recorded data from storage device y creating space for new data." .
 
 :evaluated-by a owl:ObjectProperty ;
     rdfs:label "evaluated-by" ;
@@ -379,13 +407,6 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
         :runs ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02569242-v> ;
     :definition "x executes y: The subject x takes the action of carrying out (executing) y, which is a single software module, function, or instruction." .
-
-:expected-latency a owl:ObjectProperty ;
-    rdfs:label "expected-latency" ;
-    rdfs:subPropertyOf :latency ;
-    rdfs:range [ a owl:Restriction ;
-            owl:onProperty :latency ;
-            owl:someValuesFrom :Latency ] .
 
 :extends a owl:ObjectProperty ;
     rdfs:label "extends" ;
@@ -434,6 +455,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :has-participant .
 
 :has-audience a owl:ObjectProperty ;
+    rdfs:label "has-audience" ;
     rdfs:subPropertyOf :d3fend-use-case-object-property .
 
 :has-contribution a owl:ObjectProperty ;
@@ -457,6 +479,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :d3fend-catalog-object-property .
 
 :has-goal a owl:ObjectProperty ;
+    rdfs:label "has-goal" ;
     rdfs:subPropertyOf :d3fend-use-case-object-property .
 
 :has-implementation a owl:ObjectProperty ;
@@ -482,9 +505,13 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 
 :has-participant a owl:ObjectProperty ;
     rdfs:label "has-participant" ;
-    rdfs:subPropertyOf :associated-with .
+    rdfs:subPropertyOf :associated-with ;
+    owl:inverseOf :participates-in ;
+    rdfs:isDefinedBy <http://purl.obolibrary.org/obo/BFO_0000057> ;
+    :definition "x has-participant y: The event x involves an object y as a participant, indicating that y plays some role in the event, whether actively, passively, or otherwise." .
 
 :has-prerequisite a owl:ObjectProperty ;
+    rdfs:label "has-prerequisite" ;
     rdfs:subPropertyOf :d3fend-use-case-object-property .
 
 :has-procedure a owl:ObjectProperty ;
@@ -562,12 +589,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :instructed-by a owl:ObjectProperty ;
     rdfs:label "instructed-by" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "definition \"x instructed-by y: A subject x takes machine instructions from object y.\"" .
+    :definition "x instructed-by y: A subject x takes machine instructions from object y." .
 
 :instructs a owl:ObjectProperty ;
     rdfs:label "instructs" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "definition \"x instructs y: A subject x delivers machine instructions to object y.\"" .
+    :definition "x instructs y: A subject x delivers machine instructions to object y." .
 
 :interprets a owl:ObjectProperty ;
     rdfs:label "interprets" ;
@@ -618,17 +645,8 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "kb-reference-of" ;
     skos:altLabel "kb-is-example-of" ;
     rdfs:subPropertyOf :d3fend-kb-object-property ;
-    rdfs:domain :Reference ;
-    rdfs:range :Technique ;
+    rdfs:range :CyberTechnique ;
     :definition "x kb-is-example-of y: The reference x is an example of technique y." .
-
-:latency a owl:ObjectProperty ;
-    rdfs:label "latency" ;
-    rdfs:subPropertyOf :d3fend-catalog-object-property ;
-    rdfs:range [ a owl:Restriction ;
-            owl:onProperty :latency ;
-            owl:someValuesFrom :Latency ] ;
-    :todo "Consider if want to keep this as is or distinguish with property name variation rather than type at end of property.  Could do both.  If just one, drop analytic in enumeration of value options and just have 'real-time', 'non-real-time', etc.  Do we need to distinguish between the individuals is real-time-eviction different from real-time-analytic?" .
 
 :license a owl:ObjectProperty ;
     rdfs:label "license" ;
@@ -749,10 +767,8 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-be-tactically-associated-with a owl:ObjectProperty ;
     rdfs:label "may-be-tactically-associated-with" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    rdfs:domain :DefensiveTechnique ;
-    rdfs:range :OffensiveTechnique ;
     :comment "Most/all of these properties are (will be) realized via inference over chain property path axioms and atomic assertions. Promote this to regular comment once definitions no longer in comments." ;
-    :definition "x may-be-tactically-associated-with y: the defensive technique x may be a tactic that counters offensive technique y." ;
+    :definition "x may-be-tactically-associated-with y: the defensive action x may be a tactic that counters offensive action y." ;
     :todo "Needs name change... With the right name change to better capture definition can keep this definition" .
 
 :may-be-weakness-of a owl:ObjectProperty ;
@@ -867,6 +883,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     :definition "x may-transfer y: They entity x might send the thing y; that is, 'x transfers y' may be true." .
 
 :mediates-access-to a owl:ObjectProperty ;
+    rdfs:label "mediates-access-to" ;
     rdfs:subPropertyOf :associated-with .
 
 :member-of a owl:ObjectProperty ;
@@ -944,6 +961,30 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     :definition "x owns y: The subject x has ownership or possession of some object y." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Ownership> .
 
+:participates-in a owl:ObjectProperty ;
+    rdfs:label "participates-in" ;
+    rdfs:subPropertyOf :associated-with ;
+    rdfs:isDefinedBy <http://purl.obolibrary.org/obo/BFO_0000056> ;
+    :definition "x participates-in y: The object x takes part in the event y, signifying that x contributes to or is affected by the event’s occurrence in some way." .
+
+:powered-by a owl:ObjectProperty ;
+    rdfs:label "powered by" ;
+    rdfs:subPropertyOf :associated-with ;
+    :definition "x is powered by y: An entity x is charged, or given energy or force by an entity y." .
+
+:preceded-by a owl:ObjectProperty ;
+    rdfs:label "preceded-by" ;
+    rdfs:subPropertyOf :associated-with ;
+    owl:inverseOf :precedes ;
+    rdfs:isDefinedBy <http://purl.obolibrary.org/obo/BFO_0000062> ;
+    :definition "x preceded-by y: The event or action x occurs after event or action y in time." .
+
+:precedes a owl:ObjectProperty ;
+    rdfs:label "precedes" ;
+    rdfs:subPropertyOf :associated-with ;
+    rdfs:isDefinedBy <http://purl.obolibrary.org/obo/BFO_0000063> ;
+    :definition "x precedes y: The event or action x occurs before event or action y in time." .
+
 :process-ancestor a owl:ObjectProperty,
         owl:TransitiveProperty ;
     rdfs:label "process-ancestor" ;
@@ -991,15 +1032,15 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
         :may-produce ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01625832-v> ;
     :definition "x produces y: The subject entity x or process produces a data object y, which may be discrete digital object or a stream (e.g., a stream such as network traffic.)" ;
-    rdfs:seeAlso "creates" ;
+    rdfs:seeAlso :creates ;
     :todo "Make definition of produces more generic to match sense of Product Developer produces Product (so generalize to any object really, not just computery digital stuff.)" .
 
 :provider a owl:ObjectProperty ;
     rdfs:label "provider" ;
     rdfs:subPropertyOf :associated-with ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/05901034-n" ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/05901034-n> ;
     :definition "x provider y: A provider y is an entity that supplies a service, system, or data resources to a dependent entity x." ;
-    rdfs:seeAlso "http://wordnet-rdf.princeton.edu/id/10696710-n" .
+    rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/10696710-n> .
 
 :provides a owl:ObjectProperty ;
     rdfs:label "provides" ;
@@ -1042,7 +1083,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "regenerates" ;
     rdfs:subPropertyOf :associated-with,
         :hardens ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/00167632-v" ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00167632-v> ;
     :definition "x regenerates y: The entity x discards the current digital artifact y and creates a new version that serves the same function." .
 
 :related a owl:ObjectProperty ;
@@ -1069,13 +1110,13 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :resume a owl:ObjectProperty ;
     rdfs:label "resume" ;
     rdfs:subPropertyOf :d3fend-process-object-property ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/00350758-v" ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00350758-v> ;
     :definition "The agent or technique x continues a previous action on entity y. Usually occurs after suspension on y." .
 
 :resumes a owl:ObjectProperty ;
     rdfs:label "resumes" ;
     rdfs:subPropertyOf :associated-with ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/00350758-v" ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00350758-v> ;
     :definition "The agent or technique x continues a previous action on entity y. Usually occurs after suspension on y." .
 
 :runs a owl:ObjectProperty ;
@@ -1130,7 +1171,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :suspends a owl:ObjectProperty ;
     rdfs:label "suspends" ;
     rdfs:subPropertyOf :evicts ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/00543748-v" ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00543748-v> ;
     :definition "x suspends y: The agent or technique x pauses entity y." .
 
 :terminates a owl:ObjectProperty ;
@@ -1260,7 +1301,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :d3fend-kb-reference-annotation a owl:AnnotationProperty ;
     rdfs:label "d3fend-kb-reference-annotation" ;
     rdfs:subPropertyOf :d3fend-kb-annotation-property ;
-    rdfs:domain :Reference ;
+    rdfs:domain :TechniqueReference ;
     rdfs:range xsd:string ;
     :definition "x d3fend-kb-data-property y: The reference x has the data property y." ;
     :todo "Move subproperties under d3fend-kb-data-property and rename this d3fend-kb-reference-property definition." .
@@ -1287,7 +1328,7 @@ dcterms:title a owl:AnnotationProperty .
 :description a owl:AnnotationProperty ;
     rdfs:label "description"@en ;
     rdfs:subPropertyOf :d3fend-catalog-annotation-property ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/06737512-n"^^xsd:anyURI ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/06737512-n> ;
     :definition "A statement that represents something in words." .
 
 :display-baseurl a owl:AnnotationProperty ;
@@ -1312,7 +1353,7 @@ dcterms:title a owl:AnnotationProperty .
 :kb-abstract a owl:AnnotationProperty ;
     rdfs:label "kb-abstract" ;
     rdfs:subPropertyOf :d3fend-kb-reference-annotation ;
-    rdfs:domain :Reference ;
+    rdfs:domain :TechniqueReference ;
     rdfs:range xsd:string ;
     :definition "x kb-abstract y: The reference x has the abstract y." .
 
@@ -1327,7 +1368,7 @@ dcterms:title a owl:AnnotationProperty .
 :kb-author a owl:AnnotationProperty ;
     rdfs:label "kb-author" ;
     rdfs:subPropertyOf :d3fend-kb-reference-annotation ;
-    rdfs:domain :Reference ;
+    rdfs:domain :TechniqueReference ;
     rdfs:range xsd:string ;
     :definition "x kb-author y: The reference x has some author y." ;
     :todo "Eventually would be best to resolve these to Person instances in KB.  This might be kept as kb-author-string.  Also, we might choose to drop kb- prefix on many of these.",
@@ -1336,7 +1377,7 @@ dcterms:title a owl:AnnotationProperty .
 :kb-mitre-analysis a owl:AnnotationProperty ;
     rdfs:label "kb-mitre-analysis" ;
     rdfs:subPropertyOf :d3fend-kb-annotation-property ;
-    rdfs:domain :Reference ;
+    rdfs:domain :TechniqueReference ;
     rdfs:range xsd:string ;
     :definition "x kb-mitre-analysis y: The reference x has the mitre d3fend analysis y." ;
     :todo "make a d3fend-kb-data-property" .
@@ -1478,9 +1519,10 @@ skos:altLabel a owl:AnnotationProperty .
     rdfs:range xsd:dateTime ;
     :comment "d3f:date casts the dcterms:date rdf Property as a DatatypeProperty." ;
     :definition "A point or period of time associated with an event in the lifecycle of the resource." ;
-    rdfs:seeAlso "https://www.w3.org/wiki/Good_Ontologies#The_Dublin_Core_.28DC.29_ontology"^^xsd:anyURI .
+    rdfs:seeAlso <https://www.w3.org/wiki/Good_Ontologies#The_Dublin_Core_.28DC.29_ontology> .
 
 :expectation-rating a owl:DatatypeProperty ;
+    rdfs:label "expectation-rating" ;
     rdfs:subPropertyOf :d3fend-catalog-data-property .
 
 :has-link a owl:DatatypeProperty ;
@@ -1504,7 +1546,6 @@ skos:altLabel a owl:AnnotationProperty .
 :kb-reference-title a owl:DatatypeProperty ;
     rdfs:label "kb-reference-title" ;
     rdfs:subPropertyOf :d3fend-kb-data-property ;
-    rdfs:domain :Reference ;
     rdfs:range xsd:string ;
     :definition "x kb-reference-title y: The d3fend knowledge base reference x has the reference title string y." .
 
@@ -1633,7 +1674,7 @@ skos:altLabel a owl:AnnotationProperty .
 
 :Access a owl:Class ;
     rdfs:label "Access" ;
-    rdfs:subClassOf :Action,
+    rdfs:subClassOf :Event,
         [ a owl:Restriction ;
             owl:onProperty :accesses ;
             owl:someValuesFrom :Resource ],
@@ -1641,11 +1682,26 @@ skos:altLabel a owl:AnnotationProperty .
             owl:onProperty :has-mediator ;
             owl:someValuesFrom :AccessMediator ] .
 
+:AccessControlAdministrationEvent a owl:Class ;
+    rdfs:label "Access Control Administration Event" ;
+    skos:altLabel "Permission Administration Event",
+        "Permission Provisioning Event" ;
+    rdfs:subClassOf :AccessControlEvent ;
+    :definition "An event concerning the administrative actions of setting, modifying, or abolishing permissions, configuring access control settings, and managing user access rights to ensure alignment with access control policies." .
+
 :AccessControlConfiguration a owl:Class ;
     rdfs:label "Access Control Configuration" ;
     rdfs:subClassOf :ConfigurationResource ;
     :definition "Information about what access permissions are granted to particular users for particular objects" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Access-control_list> .
+
+:AccessControlEvent a owl:Class ;
+    rdfs:label "Access Control Event" ;
+    rdfs:subClassOf :AuthorizationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :AccessControlConfiguration ] ;
+    :definition "An event that captures the implementation or evaluation of access control measures, including the application of rules and policies to govern the accessibility of resources by agents within a digital system." .
 
 :AccessControlGroup a owl:Class ;
     rdfs:label "Access Control Group" ;
@@ -1654,7 +1710,7 @@ skos:altLabel a owl:AnnotationProperty .
             owl:onProperty :restricted-by ;
             owl:someValuesFrom :AccessControlList ] ;
     :definition "A collection of objects that can have access controls placed on them." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/group" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/group> .
 
 :AccessControlList a owl:Class ;
     rdfs:label "Access Control List" ;
@@ -1664,6 +1720,25 @@ skos:altLabel a owl:AnnotationProperty .
             owl:someValuesFrom :UserGroup ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Access-control_list> ;
     :definition "A list of permissions attached to an object." .
+
+:AccessDeniedEvent a owl:Class ;
+    rdfs:label "Access Denied Event" ;
+    rdfs:subClassOf :AccessMediationEvent ;
+    :definition "An event indicating the refusal of access to a resource, where an access request has been evaluated and denied based on current authorization policies, preventing operations by the requesting agent." .
+
+:AccessGrantedEvent a owl:Class ;
+    rdfs:label "Access Granted Event" ;
+    rdfs:subClassOf :AccessMediationEvent ;
+    :definition "An event signifying that access to a resource has been authorized and successfully enforced, allowing the requesting agent to perform specified operations based on the access control policies." .
+
+:AccessMediationEvent a owl:Class ;
+    rdfs:label "Access Mediation Event" ;
+    skos:altLabel "Access Enforcement Event" ;
+    rdfs:subClassOf :AccessControlEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :AccessMediator ] ;
+    :definition "An event involving the intermediary control mechanism that evaluates access requests and enforces access control decisions, ensuring that subjects' resource interactions comply with the established access policies." .
 
 :AccessMediator a owl:Class ;
     rdfs:label "Access Mediator" ;
@@ -1740,7 +1815,7 @@ Management servers with enterprise policies for account management provide the a
 
 :Action a owl:Class ;
     rdfs:label "Action" ;
-    rdfs:subClassOf :D3FENDCore,
+    rdfs:subClassOf :Event,
         [ a owl:Restriction ;
             owl:onProperty :has-agent ;
             owl:someValuesFrom :Agent ] .
@@ -1826,21 +1901,12 @@ Another means of establishing network connectivity is by means of sendingn traff
         [ a owl:Restriction ;
             owl:onProperty :may-query ;
             owl:someValuesFrom :CollectorAgent ] ;
-    owl:disjointWith :PassivePhysicalLinkMapping ;
+    owl:disjointWith :DirectPhysicalLinkMapping ;
     :d3fend-id "D3-APLM" ;
     :definition "Active physical link mapping sends and receives network traffic as a means to map the physical layer." ;
     :kb-reference :Reference-IdentificationOfTracerouteNodesAndAssociatedDevices,
         :Reference-UsingSpanningTreeProtocolSTPToEnhanceLayer2NetworkTopologyMaps ;
     :synonym "Active Physical Layer Mapping" .
-
-:Activity a owl:Class ;
-    rdfs:label "Activity" ;
-    rdfs:subClassOf :D3FENDThing ;
-    :definition "An activity is a specific behavior representing a set of actions that may be accomplished by an agent." ;
-    rdfs:seeAlso "http://wordnet-rdf.princeton.edu/id/00408356-n",
-        "https://en.wikipedia.org/wiki/Business_Process_Model_and_Notation",
-        "https://en.wikipedia.org/wiki/IDEF0",
-        "https://enterpriseintegrationlab.github.io/icity/Activity/doc/index-en.html" .
 
 :ActivityDependency a owl:Class ;
     rdfs:label "Activity Dependency" ;
@@ -1870,8 +1936,13 @@ GeeksforGeeks. (n.d.). Adaptive Resonance Theory (ART). [Link](https://www.geeks
 :AddressSpace a owl:Class ;
     rdfs:label "Address Space" ;
     rdfs:subClassOf :DigitalInformationBearer ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Address_space" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Address_space> ;
     :definition "An address space defines a range of discrete addresses, each of which may correspond to a network host, peripheral device, disk sector, a memory cell or other logical or physical entity. For software programs to save and retrieve stored data, each unit of data must have an address where it can be located. The number of address spaces available depends on the underlying address structure, which is usually limited by the computer architecture being used." .
+
+:AddUserToGroupEvent a owl:Class ;
+    rdfs:label "Add User to Group Event" ;
+    rdfs:subClassOf :GroupManagementEvent ;
+    :definition "An event where a user is added to a group, granting the user the permissions and privileges associated with the group." .
 
 :AdminFeatureAssessment a owl:Class ;
     rdfs:label "Admin Feature Assessment" ;
@@ -1927,8 +1998,14 @@ Network protocols such as RDP, IPMI, SSH, SNMP, VNC, MOSH, NX, TeamViewer, SPICE
 
 :Agent a owl:Class ;
     rdfs:label "Agent" ;
-    rdfs:subClassOf :D3FENDCatalogThing,
-        :D3FENDCore .
+    rdfs:subClassOf :D3FENDCore .
+
+:AgentGroup a owl:Class ;
+    rdfs:label "Agent Group" ;
+    rdfs:subClassOf :Group,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :Agent ] .
 
 :AgglomerativeClustering a owl:Class,
         owl:NamedIndividual ;
@@ -2042,16 +2119,12 @@ Agglomerative clustering starts with each data point as its own cluster. The alg
 
 :AnalyticalPurpose a owl:Class ;
     rdfs:label "Analytical Purpose" ;
-    rdfs:subClassOf :D3FENDThing .
-
-:AnalyticLatency a owl:Class ;
-    rdfs:label "Analytic Latency" ;
-    rdfs:subClassOf :Latency .
+    rdfs:subClassOf :Goal .
 
 :AnalyticTechnique a owl:Class ;
     rdfs:label "Analytic Technique" ;
-    rdfs:subClassOf :D3FENDThing ;
-    rdfs:isDefinedBy "https://dictionary.cambridge.org/us/dictionary/english/analytics" ;
+    rdfs:subClassOf :Technique ;
+    rdfs:isDefinedBy <https://dictionary.cambridge.org/us/dictionary/english/analytics> ;
     :definition "A process in which a computer examines information using mathematical methods in order to find useful patterns." .
 
 :ANN-basedClustering a owl:Class,
@@ -2064,6 +2137,12 @@ Agglomerative clustering starts with each data point as its own cluster. The alg
 Wikipedia. (n.d.). Artificial neural network. [Link](https://en.wikipedia.org/wiki/Artificial_neural_network)""" ;
     :todo """have a gander at this paper for more clustering techniques ?
 https://www.sciencedirect.com/science/article/pii/S089360800900207X?viewFullText=true#sec19""" .
+
+:AnonymousPipe a owl:Class ;
+    rdfs:label "Anonymous Pipe" ;
+    rdfs:subClassOf :Pipe ;
+    rdfs:isDefinedBy <https://en.wikipedia.org/wiki/Anonymous_pipe> ;
+    :definition "In computer science, an anonymous pipe is a simplex FIFO communication channel that may be used for one-way interprocess communication (IPC). An implementation is often integrated into the operating system's file IO subsystem. Typically a parent program opens anonymous pipes, and creates a new process that inherits the other ends of the pipes, or creates several new processes and arranges them in a pipeline." .
 
 :AnswerSetProgramming a owl:Class,
         owl:NamedIndividual ;
@@ -2093,6 +2172,45 @@ In a more general sense, ASP includes all applications of answer sets to knowled
     :definition "A program that gives a computer instructions that provide the user with tools to accomplish a task; \"he has tried several different word processing applications\".  Distinct from system software that is intrinsically part of the operating system.  An application can be made up of executable files, configuration files, shared libraries, etc." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Application_software>,
         <http://wordnet-rdf.princeton.edu/id/06582286-n> .
+
+:Application-basedProcessIsolation a :Application-basedProcessIsolation,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Application-based Process Isolation" ;
+    rdfs:subClassOf :ExecutionIsolation,
+        [ a owl:Restriction ;
+            owl:onProperty :isolates ;
+            owl:someValuesFrom :Process ],
+        [ a owl:Restriction ;
+            owl:onProperty :restricts ;
+            owl:someValuesFrom :Subroutine ] ;
+    :d3fend-id "D3-ABPI" ;
+    :definition "Application code which prevents its own subroutines from accessing intra-process / internal memory space." ;
+    :kb-article """## How it works
+Some applications implement logic to permit or deny a particular subroutine access to other data within the same applicaition process. This is intended to prevent critical application process data from being tampered with.
+
+### Application-based Process Isolation in web browsers.
+
+Isolation in browsers usually is designed with the following architectural mindset:
+* Sandboxes and web resources should not be allowed to access each other because compromise of one should not effect the other.
+* The principle of least-privilege should be followed when browsing.
+The following aspects help make browser-based process isolation possible:
+* Same Origin Policy
+* Separate tabs and iframes use their own DOMs (cross-site document object models always run as a different process)
+* CORS ensures cross-site data is not delivered to a process unless the server allows it
+* Cookie and local data storage is separated by domain/site
+* Separate execution environments (threads)
+
+## Considerations
+- Using isolation in browsers does mitigate and protect by default some types of attacks (e.g. renderer attacks and access to the filesystem) but it depends on correct configuration of CORS, use of valid/appropriate certificates.
+-  Application-based Process Isolation may increase memory footprint.
+-  Application-based Process Isolation may decrease application performance.""" ;
+    :kb-reference :Reference-PrivateApplicationAccessWithBrowserIsolation,
+        :Reference-ProtectingWebApplicationsFromUntrustedEndpointsUsingRemoteBrowserIsolation,
+        :Reference-SiteIsolationDesignDocument ;
+    :synonym "Browser-based Process Isolation",
+        "Remote Browser Isolation",
+        "Sandbox" .
 
 :ApplicationConfiguration a owl:Class ;
     rdfs:label "Application Configuration" ;
@@ -2139,6 +2257,30 @@ Hardening an application's configuration involves analyzing not only the applica
     :kb-reference :Reference-RedHatEnterpriseLinux8SecurityTechnicalImplementationGuide,
         :Reference-Windows10STIG .
 
+:ApplicationDeletionEvent a owl:Class ;
+    rdfs:label "Application Deletion Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event capturing the removal of an application from a system, ensuring its binaries, configuration files, and registry entries are deleted or deactivated." .
+
+:ApplicationDisableEvent a owl:Class ;
+    rdfs:label "Application Disable Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event capturing the disabling of an application, preventing it from being operational or accessed until re-enabled." .
+
+:ApplicationEnableEvent a owl:Class ;
+    rdfs:label "Application Enable Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event representing the enabling of an application, allowing it to be started or accessed when required." .
+
+:ApplicationEvent a owl:Class ;
+    rdfs:label "Application Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Application ] ;
+    :definition "An event that captures the behavior, state, or interactions of software applications or services operating within a system. Application events encompass lifecycle changes, configuration updates, and operational anomalies, providing insight into the health and performance of software components." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/application_lifecycle> .
+
 :ApplicationHardening a :ApplicationHardening,
         owl:Class,
         owl:NamedIndividual ;
@@ -2155,6 +2297,11 @@ Hardening an application's configuration involves analyzing not only the applica
 Exploits may, for example, rely on knowledge of addresses in a process's memory, they may alter memory contents, and they may cause a program to use instructions in a way that they were not intended.  By, for example, including code that dynamically changes the memory address of data or code on each run, introducing logic to validating the memory contents before certain potentially dangerous flows are executed, or monitoring a program for unusual sequence of instructions, this makes it harder for an attacker to craft a working exploit.""" ;
     :synonym "Process Hardening" .
 
+:ApplicationInstallationEvent a owl:Class ;
+    rdfs:label "Application Installation Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event representing the installation of an application onto a system, making it available for use and interaction." .
+
 :ApplicationInstaller a owl:Class ;
     rdfs:label "Application Installer" ;
     rdfs:subClassOf :UserApplication .
@@ -2166,6 +2313,11 @@ Exploits may, for example, rely on knowledge of addresses in a process's memory,
             owl:onProperty :monitors ;
             owl:someValuesFrom :Application ] ;
     :definition "Collects information on applications on an endpoint." .
+
+:ApplicationLayerEvent a owl:Class ;
+    rdfs:label "Application Layer Event" ;
+    rdfs:subClassOf :NetworkEvent ;
+    :definition "An event occurring at the application layer, involving protocols that support application-specific communication." .
 
 :ApplicationLayerFirewall a owl:Class ;
     rdfs:label "Application Layer Firewall" ;
@@ -2192,6 +2344,11 @@ Exploits may, for example, rely on knowledge of addresses in a process's memory,
     rdfs:subClassOf :ApplicationConfiguration ;
     :definition "The current configuration of an application process, stored in memory. It may have been sourced from other types of application configurations, e.g. Application Configuration Files or Application Configuration Database Records." .
 
+:ApplicationRestartEvent a owl:Class ;
+    rdfs:label "Application Restart Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event where an application is sequentially stopped and started, typically to refresh its state, apply updates, or resolve issues while preserving its availability." .
+
 :ApplicationRule a owl:Class ;
     rdfs:label "Application Rule" ;
     rdfs:subClassOf :ApplicationConfiguration ;
@@ -2201,8 +2358,23 @@ Exploits may, for example, rely on knowledge of addresses in a process's memory,
     rdfs:label "Application Shim" ;
     rdfs:subClassOf :Shim ;
     :definition "An application shim adapts an application program to run on a version of a platform for which they were not originally created. Most commonly \"Application Shimming\" refers to use of The Windows Application Compatibility Toolkit (ACT) provides backward compatibility by simulating the behavior of older version of Windows." ;
-    rdfs:seeAlso "d3f:Shim",
-        <http://dbpedia.org/resource/Shim_(computing)#Examples> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Shim_(computing)#Examples>,
+        :Shim .
+
+:ApplicationStartEvent a owl:Class ;
+    rdfs:label "Application Start Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event where an application transitions from an inactive state to an active state, initializing its resources and becoming operational for user interaction or automated processes." .
+
+:ApplicationStopEvent a owl:Class ;
+    rdfs:label "Application Stop Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event capturing the cessation of an application’s operations, transitioning it to an inactive state and releasing any allocated resources." .
+
+:ApplicationUpdateEvent a owl:Class ;
+    rdfs:label "Application Update Event" ;
+    rdfs:subClassOf :ApplicationEvent ;
+    :definition "An event describing changes made to an application, such as updates, reconfigurations, or patch installations, while maintaining its presence on the system." .
 
 :ApproximateStringMatching a owl:Class,
         owl:NamedIndividual ;
@@ -2246,11 +2418,10 @@ Wikipedia. (n.d.). Autoregressive-moving-average model. [Link](https://en.wikipe
 
 :Artifact a owl:Class ;
     rdfs:label "Artifact" ;
-    rdfs:subClassOf :D3FENDThing ;
+    rdfs:subClassOf :D3FENDCore ;
     :definition "A man-made object taken as a whole.",
         <http://www.ontologyrepository.com/CommonCoreOntologies/Artifact> ;
-    rdfs:seeAlso "Asset",
-        <http://d3fend.mitre.org/ontologies/d3fend.owl>,
+    rdfs:seeAlso <http://d3fend.mitre.org/ontologies/d3fend.owl>,
         <http://wordnet-rdf.princeton.edu/id/00022119-n> .
 
 :ArtifactServer a owl:Class ;
@@ -2300,6 +2471,13 @@ ANN Classification. [Link](http://uc-r.github.io/ann_classification).""" .
     :synonym "Asset Discovery",
         "Asset Inventorying" .
 
+:AssetInventoryAgent a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Asset Inventory Agent" ;
+    rdfs:subClassOf :CollectorAgent ;
+    :definition "An asset inventory agent is a software tool which captures and transmits information about the devices on a network, including their hostnames, MAC addresses, software they may be running, etc." ;
+    rdfs:seeAlso <https://www.ninjaone.com/blog/how-to-do-an-it-asset-inventory> .
+
 :AssetVulnerabilityEnumeration a :AssetVulnerabilityEnumeration,
         owl:Class,
         owl:NamedIndividual ;
@@ -2319,6 +2497,11 @@ ANN Classification. [Link](http://uc-r.github.io/ann_classification).""" .
     :kb-reference :Reference-AutomatedComputerVulnerabilityResolutionSystem,
         :Reference-SecurityVulnerabilityInformationAggregation,
         :Reference-SystemAndMethodForVulnerabilityRiskAssessment .
+
+:AssignPrivilegesToGroupEvent a owl:Class ;
+    rdfs:label "Assign Privileges to Group Event" ;
+    rdfs:subClassOf :GroupManagementEvent ;
+    :definition "An event where specific privileges or rights are granted to a group, enabling its members to perform actions or access resources as defined by the privileges." .
 
 :AssociationRuleLearning a owl:Class,
         owl:NamedIndividual ;
@@ -2344,6 +2527,10 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
     rdfs:subClassOf :CryptographicKey ;
     :definition "Asymmetric keys are public and private keys, paired such that asymmetric (public-key) cryptography algorithms can be implemented using them. Public-key cryptography, or asymmetric cryptography, is any cryptographic system that uses pairs of keys: public keys that may be disseminated widely paired with private keys which are known only to the owner. There are two functions that can be achieved: using a public key to authenticate that a message originated with a holder of the paired private key; or encrypting a message with a public key to ensure that only the holder of the paired private key can decrypt it." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Public-key_cryptography> .
+
+:ATTACKEnterpriseDataSource a owl:Class ;
+    rdfs:label "ATTACK Enterprise Data Source" ;
+    rdfs:subClassOf :ATTACKEnterpriseThing .
 
 :ATTACKEnterpriseMitigation a owl:Class ;
     rdfs:label "ATTACK Enterprise Mitigation" ;
@@ -2389,11 +2576,9 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
             owl:onProperty :authenticates ;
             owl:someValuesFrom :UserAccount ] .
 
-:Authentication a owl:Class,
-        owl:NamedIndividual,
-        :UserAction ;
+:Authentication a owl:Class ;
     rdfs:label "Authentication" ;
-    rdfs:subClassOf :UserAction,
+    rdfs:subClassOf :DefensiveAction,
         [ a owl:Restriction ;
             owl:onProperty :authenticates ;
             owl:someValuesFrom :User ],
@@ -2428,6 +2613,22 @@ Are these cached credentials only on the local host? Can they be persisted to th
 Windows Credential Management API""" ;
     :kb-reference :Reference-SecureCachingOfServerCredentials_DellProductsLP,
         :Reference-SystemAndMethodForProvidingAnActivelyInvalidatedClient-sideNetworkResourceCache_IMVU .
+
+:AuthenticationEvent a owl:Class ;
+    rdfs:label "Authentication Event" ;
+    skos:altLabel "Agent Authentication Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :caused-by ;
+            owl:someValuesFrom :Authentication ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Agent ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Credential ] ;
+    :definition "An event capturing the systematic process of verifying an agent's identity within a system, involving credential validation and identity confirmation." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/authentication> .
 
 :AuthenticationEventThresholding a :AuthenticationEventThresholding,
         owl:Class,
@@ -2477,7 +2678,7 @@ This technique covers statistical outliers. Though depending on the complexity o
 
 :AuthenticationLog a owl:Class ;
     rdfs:label "Authentication Log" ;
-    rdfs:subClassOf :Log,
+    rdfs:subClassOf :EventLog,
         [ a owl:Restriction ;
             owl:onProperty :records ;
             owl:someValuesFrom :Authentication ] ;
@@ -2500,12 +2701,23 @@ This technique covers statistical outliers. Though depending on the complexity o
 
 :Authorization a owl:Class ;
     rdfs:label "Authorization" ;
-    rdfs:subClassOf :UserAction,
+    rdfs:subClassOf :DefensiveAction,
         [ a owl:Restriction ;
             owl:onProperty :authorizes ;
-            owl:someValuesFrom :NetworkResourceAccess ] ;
+            owl:someValuesFrom :Access ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Authorization> ;
     :definition "Authorization is the function of specifying access rights to resources related to information security and computer security in general and to access control in particular. More formally, \"to authorize\" is to define an access policy. For example, human resources staff is normally authorized to access employee records and this policy is usually formalized as access control rules in a computer system. During operation, the system uses the access control rules to decide whether access requests from (authenticated) consumers shall be approved (granted) or disapproved (rejected). Resources include individual files or an item's data, computer programs, computer devices and functionality provided by computer applications. Examples of consumers are computer users, computer program" .
+
+:AuthorizationEvent a owl:Class ;
+    rdfs:label "Authorization Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :caused-by ;
+            owl:someValuesFrom :Authorization ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Agent ] ;
+    :definition "An event reflecting the decision-making process and actions concerning access control, recording whether agents are permitted or denied access to resources based on pre-defined access control policies." .
 
 :AuthorizationEventThresholding a :AuthorizationEventThresholding,
         owl:Class,
@@ -2532,7 +2744,7 @@ Depending on the complexity of the data considered, outliers may not be obvious 
 
 :AuthorizationLog a owl:Class ;
     rdfs:label "Authorization Log" ;
-    rdfs:subClassOf :Log,
+    rdfs:subClassOf :EventLog,
         [ a owl:Restriction ;
             owl:onProperty :records ;
             owl:someValuesFrom :NetworkResourceAccess ] ;
@@ -2621,7 +2833,7 @@ Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/w
     :definition "A supervised learning method that builds a Bayesian linear regression model using training data." ;
     :kb-article """## References
 Wikipedia. (n.d.). Bayesian linear regression. [Link](https://en.wikipedia.org/wiki/Bayesian_linear_regression)""" ;
-    rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#BayesianLinearRegression" .
+    rdfs:seeAlso :BayesianLinearRegression .
 
 :BayesianMethod a owl:Class,
         owl:NamedIndividual ;
@@ -2949,9 +3161,9 @@ C4.5 algorithm. Wikipedia. [Link](https://en.wikipedia.org/wiki/C4.5_algorithm).
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
             owl:someValuesFrom :CacheMemory ] ;
-    rdfs:isDefinedBy "https://whatis.techtarget.com/definition/memory" ;
+    rdfs:isDefinedBy <https://whatis.techtarget.com/definition/memory> ;
     :definition "Cache memory is temporary storage that is more readily available to the processor than the computer's main memory source, located between the main memory and the processor.  It is typically either integrated directly into the CPU chip (level 1 cache) or placed on a separate chip with a bus interconnect with the CPU (level 2 cache)." ;
-    rdfs:seeAlso "https://dbpedia.org/page/CPU_cache" .
+    rdfs:seeAlso <https://dbpedia.org/page/CPU_cache> .
 
 :CallStack a owl:Class ;
     rdfs:label "Call Stack" ;
@@ -2973,7 +3185,7 @@ Wikipedia. (n.d.). Canopy clustering algorithm. [Link](https://en.wikipedia.org/
 
 :Capability a owl:Class ;
     rdfs:label "Capability" ;
-    rdfs:subClassOf :D3FENDThing,
+    rdfs:subClassOf :ExternalThing,
         [ a owl:Restriction ;
             owl:onProperty :assessed-by ;
             owl:someValuesFrom :CapabilityAssessment ],
@@ -3052,11 +3264,11 @@ DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
     rdfs:label "Capability Implementation" ;
     rdfs:subClassOf :D3FENDCatalogThing,
         [ a owl:Restriction ;
-            owl:onProperty :features ;
-            owl:someValuesFrom :AdministrativeFeature ],
+            owl:onProperty :assessed-by ;
+            owl:someValuesFrom :CapabilityAssessment ],
         [ a owl:Restriction ;
-            owl:onProperty :latency ;
-            owl:someValuesFrom :D3FENDCatalogThing ],
+            owl:onProperty :features ;
+            owl:someValuesFrom :CapabilityFeature ],
         [ a owl:Restriction ;
             owl:onProperty :operating-system ;
             owl:someValuesFrom xsd:string ],
@@ -3064,7146 +3276,13 @@ DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
             owl:onProperty :version ;
             owl:someValuesFrom xsd:string ] .
 
-:CAPEC-1 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Accessing Functionality Not Properly Constrained by ACLs" ;
-    rdfs:subClassOf :CAPEC-122 ;
-    :capec-id "CAPEC-1" ;
-    :definition "In applications, particularly web applications, access to functionality is mitigated by an authorization framework. This framework maps Access Control Lists (ACLs) to elements of the application's functionality; particularly URL's for web apps. In the case that the administrator failed to specify an ACL for a particular element, an attacker may be able to access it with impunity. An attacker with the ability to access functionality not properly constrained by ACLs can obtain sensitive information and possibly compromise the entire application. Such an attacker can access resources that must be available only to users at a higher privilege level, can access management sections of the application, or can run queries for data that they otherwise not supposed to." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/1.html> ;
-    :related :CWE-276,
-        :CWE-285,
-        :CWE-434,
-        :CWE-693,
-        :CWE-732,
-        :CWE-1191,
-        :CWE-1193,
-        :CWE-1220,
-        :CWE-1297,
-        :CWE-1311,
-        :CWE-1314,
-        :CWE-1315,
-        :CWE-1318,
-        :CWE-1320,
-        :CWE-1321,
-        :CWE-1327,
-        :T1574.010 .
-
-:CAPEC-2 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Inducing Account Lockout" ;
-    rdfs:subClassOf :CAPEC-212 ;
-    :capec-id "CAPEC-2" ;
-    :definition "An attacker leverages the security functionality of the system aimed at thwarting potential attacks to launch a denial of service attack against a legitimate system user. Many systems, for instance, implement a password throttling mechanism that locks an account after a certain number of incorrect log in attempts. An attacker can leverage this throttling mechanism to lock a legitimate user out of their own account. The weakness that is being leveraged by an attacker is the very security feature that has been put in place to counteract attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/2.html> ;
-    :related :CWE-645,
-        :T1531 .
-
-:CAPEC-3 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Leading 'Ghost' Character Sequences to Bypass Input Filters" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-3" ;
-    :definition "Some APIs will strip certain leading characters from a string of parameters. An adversary can intentionally introduce leading \"ghost\" characters (extra characters that don't affect the validity of the request at the API layer) that enable the input to pass the filters and therefore process the adversary's input. This occurs when the targeted API will accept input data in several syntactic forms and interpret it in the equivalent semantic way, while the filter does not take into account the full spectrum of the syntactic forms acceptable to the targeted API." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/3.html> ;
-    :related :CWE-20,
-        :CWE-41,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-179,
-        :CWE-180,
-        :CWE-181,
-        :CWE-183,
-        :CWE-184,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-4 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Alternative IP Address Encodings" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-4" ;
-    :definition "This attack relies on the adversary using unexpected formats for representing IP addresses. Networked applications may expect network location information in a specific format, such as fully qualified domains names (FQDNs), URL, IP address, or IP Address ranges. If the location information is not validated against a variety of different possible encodings and formats, the adversary can use an alternate format to bypass application access control." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/4.html> ;
-    :related :CWE-173,
-        :CWE-291 .
-
-:CAPEC-5 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "Blue Boxing" ;
-    rdfs:subClassOf :CAPEC-220 ;
-    rdfs:comment "This type of attack against older telephone switches and trunks has been around for decades. A tone is sent by an adversary to impersonate a supervisor signal which has the effect of rerouting or usurping command of the line. While the US infrastructure proper may not contain widespread vulnerabilities to this type of attack, many companies are connected globally through call centers and business process outsourcing. These international systems may be operated in countries which have not upgraded Telco infrastructure and so are vulnerable to Blue boxing. Blue boxing is a result of failure on the part of the system to enforce strong authorization for administrative functions. While the infrastructure is different than standard current applications like web applications, there are historical lessons to be learned to upgrade the access control for administrative functions." ;
-    :capec-id "CAPEC-5" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/5.html> ;
-    :related :CWE-285 .
-
-:CAPEC-6 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Argument Injection" ;
-    rdfs:subClassOf :CAPEC-137 ;
-    :capec-id "CAPEC-6" ;
-    :definition "An attacker changes the behavior or state of a targeted application through injecting data or command syntax through the targets use of non-validated and non-filtered arguments of exposed services or methods." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/6.html> ;
-    :related :CWE-74,
-        :CWE-78,
-        :CWE-146,
-        :CWE-184,
-        :CWE-185,
-        :CWE-697 .
-
-:CAPEC-7 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Blind SQL Injection" ;
-    rdfs:subClassOf :CAPEC-66 ;
-    :capec-id "CAPEC-7" ;
-    :definition "Blind SQL Injection results from an insufficient mitigation for SQL Injection. Although suppressing database error messages are considered best practice, the suppression alone is not sufficient to prevent SQL Injection. Blind SQL Injection is a form of SQL Injection that overcomes the lack of error messages. Without the error messages that facilitate SQL Injection, the adversary constructs input strings that probe the target through simple Boolean SQL expressions. The adversary can determine if the syntax and structure of the injection was successful based on whether the query was executed or not. Applied iteratively, the adversary determines how and where the target is vulnerable to SQL Injection." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/7.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-89,
-        :CWE-209,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-8 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Buffer Overflow in an API Call" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-8" ;
-    :definition "This attack targets libraries or shared code modules which are vulnerable to buffer overflow attacks. An adversary who has knowledge of known vulnerable libraries or shared code can easily target software that makes use of these libraries. All clients that make use of the code library thus become vulnerable by association. This has a very broad effect on security across a system, usually affecting more than one software process." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/8.html> ;
-    :related :CAPEC-46,
-        :CWE-20,
-        :CWE-74,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-680,
-        :CWE-697,
-        :CWE-733 .
-
-:CAPEC-9 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Buffer Overflow in Local Command-Line Utilities" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-9" ;
-    :definition "This attack targets command-line utilities available in a number of shells. An adversary can leverage a vulnerability found in a command-line utility to escalate privilege to root." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/9.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-680,
-        :CWE-697,
-        :CWE-733 .
-
-:CAPEC-10 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Buffer Overflow via Environment Variables" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-10" ;
-    :definition "This attack pattern involves causing a buffer overflow through manipulation of environment variables. Once the adversary finds that they can modify an environment variable, they may try to overflow associated buffers. This attack leverages implicit trust often placed in environment variables." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/10.html> ;
-    :related :CAPEC-13,
-        :CAPEC-46,
-        :CWE-20,
-        :CWE-74,
-        :CWE-99,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-302,
-        :CWE-680,
-        :CWE-697,
-        :CWE-733 .
-
-:CAPEC-11 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cause Web Server Misclassification" ;
-    rdfs:subClassOf :CAPEC-635 ;
-    :capec-id "CAPEC-11" ;
-    :definition "An attack of this type exploits a Web server's decision to take action based on filename or file extension. Because different file types are handled by different server processes, misclassification may force the Web server to take unexpected action, or expected actions in an unexpected sequence. This may cause the server to exhaust resources, supply debug or system data to the attacker, or bind an attacker to a remote process." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/11.html> ;
-    :related :CWE-430,
-        :T1036.006 .
-
-:CAPEC-12 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Choosing Message Identifier" ;
-    rdfs:subClassOf :CAPEC-216 ;
-    :capec-id "CAPEC-12" ;
-    :definition "This pattern of attack is defined by the selection of messages distributed via multicast or public information channels that are intended for another client by determining the parameter value assigned to that client. This attack allows the adversary to gain access to potentially privileged information, and to possibly perpetrate other attacks through the distribution means by impersonation. If the channel/message being manipulated is an input rather than output mechanism for the system, (such as a command bus), this style of attack could be used to change the adversary's identifier to more a privileged one." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/12.html> ;
-    :related :CAPEC-21,
-        :CWE-201,
-        :CWE-306 .
-
-:CAPEC-13 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Subverting Environment Variable Values" ;
-    rdfs:subClassOf :CAPEC-77 ;
-    :capec-id "CAPEC-13" ;
-    :definition "The adversary directly or indirectly modifies environment variables used by or controlling the target software. The adversary's goal is to cause the target software to deviate from its expected operation in a manner that benefits the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/13.html> ;
-    :related :CAPEC-10,
-        :CWE-15,
-        :CWE-20,
-        :CWE-73,
-        :CWE-74,
-        :CWE-200,
-        :CWE-285,
-        :CWE-302,
-        :CWE-353,
-        :T1562.003,
-        :T1574.006,
-        :T1574.007 .
-
-:CAPEC-14 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Client-side Injection-induced Buffer Overflow" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-14" ;
-    :definition "This type of attack exploits a buffer overflow vulnerability in targeted client software through injection of malicious content from a custom-built hostile service. This hostile service is created to deliver the correct content to the client software. For example, if the client-side application is a browser, the service will host a webpage that the browser loads." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/14.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-353,
-        :CWE-680,
-        :CWE-697 .
-
-:CAPEC-15 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Command Delimiters" ;
-    rdfs:subClassOf :CAPEC-137 ;
-    :capec-id "CAPEC-15" ;
-    :definition "An attack of this type exploits a programs' vulnerabilities that allows an attacker's commands to be concatenated onto a legitimate command with the intent of targeting other resources such as the file system or database. The system that uses a filter or denylist input validation, as opposed to allowlist validation is vulnerable to an attacker who predicts delimiters (or combinations of delimiters) not present in the filter or denylist. As with other injection attacks, the attacker uses the command delimiter payload as an entry point to tunnel through the application and activate additional attacks through SQL queries, shell commands, network scanning, and so on." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/15.html> ;
-    :related :CWE-77,
-        :CWE-78,
-        :CWE-93,
-        :CWE-138,
-        :CWE-140,
-        :CWE-146,
-        :CWE-154,
-        :CWE-157,
-        :CWE-184,
-        :CWE-185,
-        :CWE-697 .
-
-:CAPEC-16 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Dictionary-based Password Attack" ;
-    rdfs:subClassOf :CAPEC-49 ;
-    :capec-id "CAPEC-16" ;
-    :definition "An attacker tries each of the words in a dictionary as passwords to gain access to the system via some user's account. If the password chosen by the user was a word within the dictionary, this attack will be successful (in the absence of other mitigations). This is a specific instance of the password brute forcing attack pattern." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/16.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-307,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-654 .
-
-:CAPEC-17 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Malicious Files" ;
-    rdfs:subClassOf :CAPEC-122 ;
-    :capec-id "CAPEC-17" ;
-    :definition "An attack of this type exploits a system's configuration that allows an adversary to either directly access an executable file, for example through shell access; or in a possible worst case allows an adversary to upload a file and then execute it. Web servers, ftp servers, and message oriented middleware systems which have many integration points are particularly vulnerable, because both the programmers and the administrators must be in synch regarding the interfaces and the correct privileges for each interface." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/17.html> ;
-    :related :CWE-59,
-        :CWE-270,
-        :CWE-272,
-        :CWE-282,
-        :CWE-285,
-        :CWE-693,
-        :CWE-732,
-        :T1574.005,
-        :T1574.010 .
-
-:CAPEC-18 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Targeting Non-Script Elements" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-18" ;
-    :definition "This attack is a form of Cross-Site Scripting (XSS) where malicious scripts are embedded in elements that are not expected to host scripts such as image tags (<img>), comments in XML documents (< !-CDATA->), etc. These tags may not be subject to the same input validation, output validation, and other content filtering and checking routines, so this can create an opportunity for an adversary to tunnel through the application's elements and launch a XSS attack through other elements. As with all remote attacks, it is important to differentiate the ability to launch an attack (such as probing an internal network for unpatched servers) and the ability of the remote adversary to collect and interpret the output of said attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/18.html> ;
-    :related :CWE-80 .
-
-:CAPEC-19 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Embedding Scripts within Scripts" ;
-    rdfs:subClassOf :CAPEC-242 ;
-    :capec-id "CAPEC-19" ;
-    :definition "An adversary leverages the capability to execute their own script by embedding it within other scripts that the target software is likely to execute due to programs' vulnerabilities that are brought on by allowing remote hosts to execute scripts." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/19.html> ;
-    :related :CWE-284,
-        :T1027.009,
-        :T1546.004,
-        :T1546.016 .
-
-:CAPEC-20 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Encryption Brute Forcing" ;
-    rdfs:subClassOf :CAPEC-112 ;
-    :capec-id "CAPEC-20" ;
-    :definition "An attacker, armed with the cipher text and the encryption algorithm used, performs an exhaustive (brute force) search on the key space to determine the key that decrypts the cipher text to obtain the plaintext." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/20.html> ;
-    :related :CWE-326,
-        :CWE-327,
-        :CWE-693,
-        :CWE-1204 .
-
-:CAPEC-21 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploitation of Trusted Identifiers" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-21" ;
-    :definition "An adversary guesses, obtains, or \"rides\" a trusted identifier (e.g. session ID, resource ID, cookie, etc.) to perform authorized actions under the guise of an authenticated user or service." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/21.html> ;
-    :related :CAPEC-12,
-        :CWE-6,
-        :CWE-290,
-        :CWE-302,
-        :CWE-346,
-        :CWE-384,
-        :CWE-539,
-        :CWE-602,
-        :CWE-642,
-        :CWE-664,
-        :T1134,
-        :T1528,
-        :T1539 .
-
-:CAPEC-22 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploiting Trust in Client" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-22" ;
-    :definition "An attack of this type exploits vulnerabilities in client/server communication channel authentication and data integrity. It leverages the implicit trust a server places in the client, or more importantly, that which the server believes is the client. An attacker executes this type of attack by communicating directly with the server where the server believes it is communicating only with a valid client. There are numerous variations of this type of attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/22.html> ;
-    :related :CWE-20,
-        :CWE-200,
-        :CWE-287,
-        :CWE-290,
-        :CWE-693 .
-
-:CAPEC-23 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "File Content Injection" ;
-    rdfs:subClassOf :CAPEC-242 ;
-    :capec-id "CAPEC-23" ;
-    :definition "An adversary poisons files with a malicious payload (targeting the file systems accessible by the target software), which may be passed through by standard channels such as via email, and standard web content like PDF and multimedia files. The adversary exploits known vulnerabilities or handling routines in the target processes, in order to exploit the host's trust in executing remote content, including binary files." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/23.html> ;
-    :related :CAPEC-35,
-        :CWE-20 .
-
-:CAPEC-24 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Filter Failure through Buffer Overflow" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-24" ;
-    :definition "In this attack, the idea is to cause an active filter to fail by causing an oversized transaction. An attacker may try to feed overly long input strings to the program in an attempt to overwhelm the filter (by causing a buffer overflow) and hoping that the filter does not fail securely (i.e. the user input is let into the system unfiltered)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/24.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-680,
-        :CWE-697,
-        :CWE-733 .
-
-:CAPEC-25 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Forced Deadlock" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-25" ;
-    :definition "The adversary triggers and exploits a deadlock condition in the target software to cause a denial of service. A deadlock can occur when two or more competing actions are waiting for each other to finish, and thus neither ever does. Deadlock conditions can be difficult to detect." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/25.html> ;
-    :related :CWE-412,
-        :CWE-567,
-        :CWE-662,
-        :CWE-667,
-        :CWE-833,
-        :CWE-1322,
-        :T1499.004 .
-
-:CAPEC-26 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Leveraging Race Conditions" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-26" ;
-    :definition "The adversary targets a race condition occurring when multiple processes access and manipulate the same resource concurrently, and the outcome of the execution depends on the particular order in which the access takes place. The adversary can leverage a race condition by \"running the race\", modifying the resource and modifying the normal execution flow. For instance, a race condition can occur while accessing a file: the adversary can trick the system by replacing the original file with their version and cause the system to read the malicious file." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/26.html> ;
-    :related :CWE-362,
-        :CWE-363,
-        :CWE-366,
-        :CWE-368,
-        :CWE-370,
-        :CWE-662,
-        :CWE-665,
-        :CWE-667,
-        :CWE-689,
-        :CWE-1223,
-        :CWE-1254,
-        :CWE-1298 .
-
-:CAPEC-27 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Leveraging Race Conditions via Symbolic Links" ;
-    rdfs:subClassOf :CAPEC-29 ;
-    :capec-id "CAPEC-27" ;
-    :definition "This attack leverages the use of symbolic links (Symlinks) in order to write to sensitive files. An attacker can create a Symlink link to a target file not otherwise accessible to them. When the privileged program tries to create a temporary file with the same name as the Symlink link, it will actually write to the target file pointed to by the attackers' Symlink link. If the attacker can insert malicious content in the temporary file they will be writing to the sensitive file by using the Symlink. The race occurs because the system checks if the temporary file exists, then creates the file. The attacker would typically create the Symlink during the interval between the check and the creation of the temporary file." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/27.html> ;
-    :related :CWE-61,
-        :CWE-367,
-        :CWE-662,
-        :CWE-667,
-        :CWE-689 .
-
-:CAPEC-28 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Fuzzing" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-28" ;
-    :definition "In this attack pattern, the adversary leverages fuzzing to try to identify weaknesses in the system. Fuzzing is a software security and functionality testing method that feeds randomly constructed input to the system and looks for an indication that a failure in response to that input has occurred. Fuzzing treats the system as a black box and is totally free from any preconceptions or assumptions about the system. Fuzzing can help an attacker discover certain assumptions made about user input in the system. Fuzzing gives an attacker a quick way of potentially uncovering some of these assumptions despite not necessarily knowing anything about the internals of the system. These assumptions can then be turned against the system by specially crafting user input that may allow an attacker to achieve their goals." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/28.html> ;
-    :related :CWE-20,
-        :CWE-74 .
-
-:CAPEC-29 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Leveraging Time-of-Check and Time-of-Use (TOCTOU) Race Conditions" ;
-    rdfs:subClassOf :CAPEC-26 ;
-    :capec-id "CAPEC-29" ;
-    :definition "This attack targets a race condition occurring between the time of check (state) for a resource and the time of use of a resource. A typical example is file access. The adversary can leverage a file access race condition by \"running the race\", meaning that they would modify the resource between the first time the target program accesses the file and the time the target program uses the file. During that period of time, the adversary could replace or modify the file, causing the application to behave unexpectedly." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/29.html> ;
-    :related :CWE-362,
-        :CWE-366,
-        :CWE-367,
-        :CWE-368,
-        :CWE-370,
-        :CWE-662,
-        :CWE-663,
-        :CWE-665,
-        :CWE-691 .
-
-:CAPEC-30 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hijacking a Privileged Thread of Execution" ;
-    rdfs:subClassOf :CAPEC-233 ;
-    :capec-id "CAPEC-30" ;
-    :definition "An adversary hijacks a privileged thread of execution by injecting malicious code into a running process. By using a privleged thread to do their bidding, adversaries can evade process-based detection that would stop an attack that creates a new process. This can lead to an adversary gaining access to the process's memory and can also enable elevated privileges. The most common way to perform this attack is by suspending an existing thread and manipulating its memory." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/30.html> ;
-    :related :CWE-270,
-        :T1055.003 .
-
-:CAPEC-31 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Accessing/Intercepting/Modifying HTTP Cookies" ;
-    rdfs:subClassOf :CAPEC-39,
-        :CAPEC-157 ;
-    :capec-id "CAPEC-31" ;
-    :definition "This attack relies on the use of HTTP Cookies to store credentials, state information and other critical data on client systems. There are several different forms of this attack. The first form of this attack involves accessing HTTP Cookies to mine for potentially sensitive data contained therein. The second form involves intercepting this data as it is transmitted from client to server. This intercepted information is then used by the adversary to impersonate the remote user/session. The third form is when the cookie's content is modified by the adversary before it is sent back to the server. Here the adversary seeks to convince the target server to operate on this falsified information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/31.html> ;
-    :related :CWE-20,
-        :CWE-113,
-        :CWE-302,
-        :CWE-311,
-        :CWE-315,
-        :CWE-384,
-        :CWE-472,
-        :CWE-539,
-        :CWE-565,
-        :CWE-602,
-        :CWE-642,
-        :T1539 .
-
-:CAPEC-32 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Through HTTP Query Strings" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-32" ;
-    :definition "An adversary embeds malicious script code in the parameters of an HTTP query string and convinces a victim to submit the HTTP request that contains the query string to a vulnerable web application. The web application then procedes to use the values parameters without properly validation them first and generates the HTML code that will be executed by the victim's browser." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/32.html> ;
-    :related :CWE-80 .
-
-:CAPEC-33 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP Request Smuggling" ;
-    rdfs:subClassOf :CAPEC-220 ;
-    :capec-id "CAPEC-33" ;
-    :definition "An adversary abuses the flexibility and discrepancies in the parsing and interpretation of HTTP Request messages using various HTTP headers, request-line and body parameters as well as message sizes (denoted by the end of message signaled by a given HTTP header) by different intermediary HTTP agents (e.g., load balancer, reverse proxy, web caching proxies, application firewalls, etc.) to secretly send unauthorized and malicious HTTP requests to a back-end HTTP agent (e.g., web server)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/33.html> ;
-    :related :CAPEC-273,
-        :CWE-444 .
-
-:CAPEC-34 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP Response Splitting" ;
-    rdfs:subClassOf :CAPEC-220 ;
-    :capec-id "CAPEC-34" ;
-    :definition "An adversary manipulates and injects malicious content, in the form of secret unauthorized HTTP responses, into a single HTTP response from a vulnerable or compromised back-end HTTP agent (e.g., web server) or into an already spoofed HTTP response from an adversary controlled domain/site." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/34.html> ;
-    :related :CAPEC-105,
-        :CWE-74,
-        :CWE-113,
-        :CWE-138,
-        :CWE-436 .
-
-:CAPEC-35 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Leverage Executable Code in Non-Executable Files" ;
-    rdfs:subClassOf :CAPEC-636 ;
-    :capec-id "CAPEC-35" ;
-    :definition "An attack of this type exploits a system's trust in configuration and resource files. When the executable loads the resource (such as an image file or configuration file) the attacker has modified the file to either execute malicious code directly or manipulate the target process (e.g. application server) to execute based on the malicious configuration parameters. Since systems are increasingly interrelated mashing up resources from local and remote sources the possibility of this attack occurring is high." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/35.html> ;
-    :related :CAPEC-23,
-        :CAPEC-75,
-        :CWE-59,
-        :CWE-94,
-        :CWE-95,
-        :CWE-96,
-        :CWE-97,
-        :CWE-270,
-        :CWE-272,
-        :CWE-282,
-        :T1027.006,
-        :T1027.009,
-        :T1564.009 .
-
-:CAPEC-36 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Unpublished Interfaces or Functionality" ;
-    rdfs:subClassOf :CAPEC-113 ;
-    :capec-id "CAPEC-36" ;
-    :definition "An adversary searches for and invokes interfaces or functionality that the target system designers did not intend to be publicly available. If interfaces fail to authenticate requests, the attacker may be able to invoke functionality they are not authorized for." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/36.html> ;
-    :related :CWE-306,
-        :CWE-693,
-        :CWE-695,
-        :CWE-1242 .
-
-:CAPEC-37 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Retrieve Embedded Sensitive Data" ;
-    rdfs:subClassOf :CAPEC-167 ;
-    :capec-id "CAPEC-37" ;
-    :definition "An attacker examines a target system to find sensitive data that has been embedded within it. This information can reveal confidential contents, such as account numbers or individual keys/credentials that can be used as an intermediate step in a larger attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/37.html> ;
-    :related :CWE-226,
-        :CWE-311,
-        :CWE-312,
-        :CWE-314,
-        :CWE-315,
-        :CWE-318,
-        :CWE-525,
-        :CWE-1239,
-        :CWE-1258,
-        :CWE-1266,
-        :CWE-1272,
-        :CWE-1278,
-        :CWE-1301,
-        :CWE-1330,
-        :T1005,
-        :T1552.004 .
-
-:CAPEC-38 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Leveraging/Manipulating Configuration File Search Paths" ;
-    rdfs:subClassOf :CAPEC-159 ;
-    :capec-id "CAPEC-38" ;
-    :definition "This pattern of attack sees an adversary load a malicious resource into a program's standard path so that when a known command is executed then the system instead executes the malicious component. The adversary can either modify the search path a program uses, like a PATH variable or classpath, or they can manipulate resources on the path to point to their malicious components. J2EE applications and other component based applications that are built from multiple binaries can have very long list of dependencies to execute. If one of these libraries and/or references is controllable by the attacker then application controls can be circumvented by the attacker." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/38.html> ;
-    :related :CWE-426,
-        :CWE-427,
-        :T1574.007,
-        :T1574.009 .
-
-:CAPEC-39 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulating Opaque Client-based Data Tokens" ;
-    rdfs:subClassOf :CAPEC-22 ;
-    :capec-id "CAPEC-39" ;
-    :definition "In circumstances where an application holds important data client-side in tokens (cookies, URLs, data files, and so forth) that data can be manipulated. If client or server-side application components reinterpret that data as authentication tokens or data (such as store item pricing or wallet information) then even opaquely manipulating that data may bear fruit for an Attacker. In this pattern an attacker undermines the assumption that client side tokens have been adequately protected from tampering through use of encryption or obfuscation." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/39.html> ;
-    :related :CWE-233,
-        :CWE-285,
-        :CWE-302,
-        :CWE-315,
-        :CWE-353,
-        :CWE-384,
-        :CWE-472,
-        :CWE-539,
-        :CWE-565 .
-
-:CAPEC-40 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulating Writeable Terminal Devices" ;
-    rdfs:subClassOf :CAPEC-248 ;
-    :capec-id "CAPEC-40" ;
-    :definition "This attack exploits terminal devices that allow themselves to be written to by other users. The attacker sends command strings to the target terminal device hoping that the target user will hit enter and thereby execute the malicious command with their privileges. The attacker can send the results (such as copying /etc/passwd) to a known directory and collect once the attack has succeeded." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/40.html> ;
-    :related :CWE-77 .
-
-:CAPEC-41 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Meta-characters in E-mail Headers to Inject Malicious Payloads" ;
-    rdfs:subClassOf :CAPEC-134,
-        :CAPEC-242 ;
-    :capec-id "CAPEC-41" ;
-    :definition "This type of attack involves an attacker leveraging meta-characters in email headers to inject improper behavior into email programs. Email software has become increasingly sophisticated and feature-rich. In addition, email applications are ubiquitous and connected directly to the Web making them ideal targets to launch and propagate attacks. As the user demand for new functionality in email applications grows, they become more like browsers with complex rendering and plug in routines. As more email functionality is included and abstracted from the user, this creates opportunities for attackers. Virtually all email applications do not list email header information by default, however the email header contains valuable attacker vectors for the attacker to exploit particularly if the behavior of the email client application is known. Meta-characters are hidden from the user, but can contain scripts, enumerations, probes, and other attacks against the user's system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/41.html> ;
-    :related :CWE-88,
-        :CWE-150,
-        :CWE-697 .
-
-:CAPEC-42 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "MIME Conversion" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-42" ;
-    :definition "An attacker exploits a weakness in the MIME conversion routine to cause a buffer overflow and gain control over the mail server machine. The MIME system is designed to allow various different information formats to be interpreted and sent via e-mail. Attack points exist when data are converted to MIME compatible format and back." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/42.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-119,
-        :CWE-120 .
-
-:CAPEC-43 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploiting Multiple Input Interpretation Layers" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-43" ;
-    :definition "An attacker supplies the target software with input data that contains sequences of special characters designed to bypass input validation logic. This exploit relies on the target making multiples passes over the input data and processing a \"layer\" of special characters with each pass. In this manner, the attacker can disguise input that would otherwise be rejected as invalid by concealing it with layers of special/escape characters that are stripped off by subsequent processing steps. The goal is to first discover cases where the input validation layer executes before one or more parsing layers. That is, user input may go through the following logic in an application: <parser1> --> <input validator> --> <parser2>. In such cases, the attacker will need to provide input that will pass through the input validator, but after passing through parser2, will be converted into something that the input validator was supposed to stop." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/43.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-77,
-        :CWE-78,
-        :CWE-179,
-        :CWE-181,
-        :CWE-183,
-        :CWE-184,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-44 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Overflow Binary Resource File" ;
-    rdfs:subClassOf :CAPEC-23,
-        :CAPEC-100 ;
-    :capec-id "CAPEC-44" ;
-    :definition "An attack of this type exploits a buffer overflow vulnerability in the handling of binary resources. Binary resources may include music files like MP3, image files like JPEG files, and any other binary file. These attacks may pass unnoticed to the client machine through normal usage of files, such as a browser loading a seemingly innocent JPEG file. This can allow the adversary access to the execution stack and execute arbitrary code in the target process." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/44.html> ;
-    :related :CWE-119,
-        :CWE-120,
-        :CWE-697 .
-
-:CAPEC-45 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Buffer Overflow via Symbolic Links" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-45" ;
-    :definition "This type of attack leverages the use of symbolic links to cause buffer overflows. An adversary can try to create or manipulate a symbolic link file such that its contents result in out of bounds data. When the target software processes the symbolic link file, it could potentially overflow internal buffers with insufficient bounds checking." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/45.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-285,
-        :CWE-302,
-        :CWE-680,
-        :CWE-697 .
-
-:CAPEC-46 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Overflow Variables and Tags" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-46" ;
-    :definition "This type of attack leverages the use of tags or variables from a formatted configuration data to cause buffer overflow. The adversary crafts a malicious HTML page or configuration file that includes oversized strings, thus causing an overflow." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/46.html> ;
-    :related :CAPEC-8,
-        :CAPEC-10,
-        :CWE-20,
-        :CWE-74,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-680,
-        :CWE-697,
-        :CWE-733 .
-
-:CAPEC-47 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Buffer Overflow via Parameter Expansion" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-47" ;
-    :definition "In this attack, the target software is given input that the adversary knows will be modified and expanded in size during processing. This attack relies on the target software failing to anticipate that the expanded data may exceed some internal limit, thereby creating a buffer overflow." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/47.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-118,
-        :CWE-119,
-        :CWE-120,
-        :CWE-130,
-        :CWE-131,
-        :CWE-680,
-        :CWE-697 .
-
-:CAPEC-48 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Passing Local Filenames to Functions That Expect a URL" ;
-    rdfs:subClassOf :CAPEC-212 ;
-    :capec-id "CAPEC-48" ;
-    :definition "This attack relies on client side code to access local files and resources instead of URLs. When the client browser is expecting a URL string, but instead receives a request for a local file, that execution is likely to occur in the browser process space with the browser's authority to local files. The attacker can send the results of this request to the local files out to a site that they control. This attack may be used to steal sensitive authentication data (either local or remote), or to gain system profile information to launch further attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/48.html> ;
-    :related :CWE-241,
-        :CWE-706 .
-
-:CAPEC-49 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Password Brute Forcing" ;
-    rdfs:subClassOf :CAPEC-112 ;
-    :capec-id "CAPEC-49" ;
-    :definition "An adversary tries every possible value for a password until they succeed. A brute force attack, if feasible computationally, will always be successful because it will essentially go through all possible passwords given the alphabet used (lower case letters, upper case letters, numbers, symbols, etc.) and the maximum length of the password." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/49.html> ;
-    :related :CWE-257,
-        :CWE-262,
-        :CWE-263,
-        :CWE-307,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-654,
-        :T1110.001 .
-
-:CAPEC-50 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Password Recovery Exploitation" ;
-    rdfs:subClassOf :CAPEC-212 ;
-    :capec-id "CAPEC-50" ;
-    :definition "An attacker may take advantage of the application feature to help users recover their forgotten passwords in order to gain access into the system with the same privileges as the original user. Generally password recovery schemes tend to be weak and insecure." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/50.html> ;
-    :related :CWE-522,
-        :CWE-640 .
-
-:CAPEC-51 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Poison Web Service Registry" ;
-    rdfs:subClassOf :CAPEC-203 ;
-    :capec-id "CAPEC-51" ;
-    :definition "SOA and Web Services often use a registry to perform look up, get schema information, and metadata about services. A poisoned registry can redirect (think phishing for servers) the service requester to a malicious service provider, provide incorrect information in schema or metadata, and delete information about service provider interfaces." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/51.html> ;
-    :related :CWE-74,
-        :CWE-285,
-        :CWE-693 .
-
-:CAPEC-52 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Embedding NULL Bytes" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-52" ;
-    :definition "An adversary embeds one or more null bytes in input to the target software. This attack relies on the usage of a null-valued byte as a string terminator in many environments. The goal is for certain components of the target software to stop processing the input when it encounters the null byte(s)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/52.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-158,
-        :CWE-172,
-        :CWE-173,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-53 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Postfix, Null Terminate, and Backslash" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-53" ;
-    :definition "If a string is passed through a filter of some kind, then a terminal NULL may not be valid. Using alternate representation of NULL allows an adversary to embed the NULL mid-string while postfixing the proper data so that the filter is avoided. One example is a filter that looks for a trailing slash character. If a string insertion is possible, but the slash must exist, an alternate encoding of NULL in mid-string may be used." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/53.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-158,
-        :CWE-172,
-        :CWE-173,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-54 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Query System for Information" ;
-    rdfs:subClassOf :CAPEC-116 ;
-    :capec-id "CAPEC-54" ;
-    :definition "An adversary, aware of an application's location (and possibly authorized to use the application), probes an application's structure and evaluates its robustness by submitting requests and examining responses. Often, this is accomplished by sending variants of expected queries in the hope that these modified queries might return information beyond what the expected set of queries would provide." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/54.html> ;
-    :related :CWE-209 .
-
-:CAPEC-55 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Rainbow Table Password Cracking" ;
-    rdfs:subClassOf :CAPEC-49 ;
-    :capec-id "CAPEC-55" ;
-    :definition "An attacker gets access to the database table where hashes of passwords are stored. They then use a rainbow table of pre-computed hash chains to attempt to look up the original password. Once the original password corresponding to the hash is obtained, the attacker uses the original password to gain access to the system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/55.html> ;
-    :related :CWE-261,
-        :CWE-262,
-        :CWE-263,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-654,
-        :CWE-916,
-        :T1110.002 .
-
-:CAPEC-56 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Removing/short-circuiting 'guard logic'" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-207 : Removing Important Client Functionality. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-56" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/56.html> .
-
-:CAPEC-57 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Utilizing REST's Trust in the System Resource to Obtain Sensitive Data" ;
-    rdfs:subClassOf :CAPEC-157 ;
-    :capec-id "CAPEC-57" ;
-    :definition "This attack utilizes a REST(REpresentational State Transfer)-style applications' trust in the system resources and environment to obtain sensitive data once SSL is terminated." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/57.html> ;
-    :related :CWE-287,
-        :CWE-300,
-        :CWE-693,
-        :T1040 .
-
-:CAPEC-58 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Restful Privilege Elevation" ;
-    rdfs:subClassOf :CAPEC-1,
-        :CAPEC-180 ;
-    :capec-id "CAPEC-58" ;
-    :definition "An adversary identifies a Rest HTTP (Get, Put, Delete) style permission method allowing them to perform various malicious actions upon server data due to lack of access control mechanisms implemented within the application service accepting HTTP messages." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/58.html> ;
-    :related :CWE-267,
-        :CWE-269 .
-
-:CAPEC-59 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Session Credential Falsification through Prediction" ;
-    rdfs:subClassOf :CAPEC-196 ;
-    :capec-id "CAPEC-59" ;
-    :definition "This attack targets predictable session ID in order to gain privileges. The attacker can predict the session ID used during a transaction to perform spoofing and session hijacking." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/59.html> ;
-    :related :CWE-6,
-        :CWE-200,
-        :CWE-285,
-        :CWE-290,
-        :CWE-330,
-        :CWE-331,
-        :CWE-346,
-        :CWE-384,
-        :CWE-488,
-        :CWE-539,
-        :CWE-693 .
-
-:CAPEC-60 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Reusing Session IDs (aka Session Replay)" ;
-    rdfs:subClassOf :CAPEC-593 ;
-    :capec-id "CAPEC-60" ;
-    :definition "This attack targets the reuse of valid session ID to spoof the target system in order to gain privileges. The attacker tries to reuse a stolen session ID used previously during a transaction to perform spoofing and session hijacking. Another name for this type of attack is Session Replay." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/60.html> ;
-    :related :CWE-200,
-        :CWE-285,
-        :CWE-290,
-        :CWE-294,
-        :CWE-346,
-        :CWE-384,
-        :CWE-488,
-        :CWE-539,
-        :CWE-664,
-        :CWE-732,
-        :T1134.001,
-        :T1550.004 .
-
-:CAPEC-61 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Session Fixation" ;
-    rdfs:subClassOf :CAPEC-593 ;
-    :capec-id "CAPEC-61" ;
-    :definition "The attacker induces a client to establish a session with the target software using a session identifier provided by the attacker. Once the user successfully authenticates to the target software, the attacker uses the (now privileged) session identifier in their own transactions. This attack leverages the fact that the target software either relies on client-generated session identifiers or maintains the same session identifiers after privilege elevation." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/61.html> ;
-    :related :CWE-384,
-        :CWE-664,
-        :CWE-732 .
-
-:CAPEC-62 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross Site Request Forgery" ;
-    rdfs:subClassOf :CAPEC-21 ;
-    :capec-id "CAPEC-62" ;
-    :definition "An attacker crafts malicious web links and distributes them (via web pages, email, etc.), typically in a targeted manner, hoping to induce users to click on the link and execute the malicious action against some third-party application. If successful, the action embedded in the malicious link will be processed and accepted by the targeted application with the users' privilege level. This type of attack leverages the persistence and implicit trust placed in user session cookies by many web applications today. In such an architecture, once the user authenticates to an application and a session cookie is created on the user's system, all following transactions for that session are authenticated using that cookie including potential actions initiated by an attacker and simply \"riding\" the existing session cookie." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/62.html> ;
-    :related :CWE-306,
-        :CWE-352,
-        :CWE-664,
-        :CWE-732,
-        :CWE-1275 .
-
-:CAPEC-63 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross-Site Scripting (XSS)" ;
-    rdfs:subClassOf :CAPEC-242 ;
-    :capec-id "CAPEC-63" ;
-    :definition "An adversary embeds malicious scripts in content that will be served to web browsers. The goal of the attack is for the target software, the client-side browser, to execute the script with the users' privilege level. An attack of this type exploits a programs' vulnerabilities that are brought on by allowing remote hosts to execute code and scripts. Web browsers, for example, have some simple security controls in place, but if a remote attacker is allowed to execute scripts (through injecting them in to user-generated content like bulletin boards) then these controls may be bypassed. Further, these attacks are very difficult for an end user to detect." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/63.html> ;
-    :related :CWE-20,
-        :CWE-79 .
-
-:CAPEC-64 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Slashes and URL Encoding Combined to Bypass Validation Logic" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-64" ;
-    :definition "This attack targets the encoding of the URL combined with the encoding of the slash characters. An attacker can take advantage of the multiple ways of encoding a URL and abuse the interpretation of the URL. A URL may contain special character that need special syntax handling in order to be interpreted. Special characters are represented using a percentage character followed by two digits representing the octet code of the original character (%HEX-CODE). For instance US-ASCII space character would be represented with %20. This is often referred as escaped ending or percent-encoding. Since the server decodes the URL from the requests, it may restrict the access to some URL paths by validating and filtering out the URL requests it received. An attacker will try to craft an URL with a sequence of special characters which once interpreted by the server will be equivalent to a forbidden URL. It can be difficult to protect against this attack since the URL can contain other format of encoding such as UTF-8 encoding, Unicode-encoding, etc." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/64.html> ;
-    :related :CAPEC-80,
-        :CWE-20,
-        :CWE-22,
-        :CWE-73,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-177,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-65 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Sniff Application Code" ;
-    rdfs:subClassOf :CAPEC-157 ;
-    :capec-id "CAPEC-65" ;
-    :definition "An adversary passively sniffs network communications and captures application code bound for an authorized client. Once obtained, they can use it as-is, or through reverse-engineering glean sensitive information or exploit the trust relationship between the client and server. Such code may belong to a dynamic update to the client, a patch being applied to a client component or any such interaction where the client is authorized to communicate with the server." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/65.html> ;
-    :related :CWE-311,
-        :CWE-318,
-        :CWE-319,
-        :CWE-693,
-        :T1040 .
-
-:CAPEC-66 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SQL Injection" ;
-    rdfs:subClassOf :CAPEC-248 ;
-    :capec-id "CAPEC-66" ;
-    :definition "This attack exploits target software that constructs SQL statements based on user input. An attacker crafts input strings so that when the target software constructs SQL statements based on the input, the resulting SQL statement performs actions other than those the application intended. SQL Injection results from failure of the application to appropriately validate input." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/66.html> ;
-    :related :CWE-89,
-        :CWE-1286 .
-
-:CAPEC-67 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "String Format Overflow in syslog()" ;
-    rdfs:subClassOf :CAPEC-100,
-        :CAPEC-135 ;
-    :capec-id "CAPEC-67" ;
-    :definition "This attack targets applications and software that uses the syslog() function insecurely. If an application does not explicitely use a format string parameter in a call to syslog(), user input can be placed in the format string parameter leading to a format string injection attack. Adversaries can then inject malicious format string commands into the function call leading to a buffer overflow. There are many reported software vulnerabilities with the root cause being a misuse of the syslog() function." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/67.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-120,
-        :CWE-134,
-        :CWE-680,
-        :CWE-697 .
-
-:CAPEC-68 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Subvert Code-signing Facilities" ;
-    rdfs:subClassOf :CAPEC-233 ;
-    :capec-id "CAPEC-68" ;
-    :definition "Many languages use code signing facilities to vouch for code's identity and to thus tie code to its assigned privileges within an environment. Subverting this mechanism can be instrumental in an attacker escalating privilege. Any means of subverting the way that a virtual machine enforces code signing classifies for this style of attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/68.html> ;
-    :related :CWE-325,
-        :CWE-328,
-        :CWE-1326,
-        :T1553.002 .
-
-:CAPEC-69 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Target Programs with Elevated Privileges" ;
-    rdfs:subClassOf :CAPEC-233 ;
-    :capec-id "CAPEC-69" ;
-    :definition "This attack targets programs running with elevated privileges. The adversary tries to leverage a vulnerability in the running program and get arbitrary code to execute with elevated privileges." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/69.html> ;
-    :related :CWE-15,
-        :CWE-250 .
-
-:CAPEC-70 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Try Common or Default Usernames and Passwords" ;
-    rdfs:subClassOf :CAPEC-49 ;
-    :capec-id "CAPEC-70" ;
-    :definition "An adversary may try certain common or default usernames and passwords to gain access into the system and perform unauthorized actions. An adversary may try an intelligent brute force using empty passwords, known vendor default credentials, as well as a dictionary of common usernames and passwords. Many vendor products come preconfigured with default (and thus well-known) usernames and passwords that should be deleted prior to usage in a production environment. It is a common mistake to forget to remove these default login credentials. Another problem is that users would pick very simple (common) passwords (e.g. \"secret\" or \"password\") that make it easier for the attacker to gain access to the system compared to using a brute force attack or even a dictionary attack using a full dictionary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/70.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-654,
-        :CWE-798,
-        :T1078.001 .
-
-:CAPEC-71 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Unicode Encoding to Bypass Validation Logic" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-71" ;
-    :definition "An attacker may provide a Unicode string to a system component that is not Unicode aware and use that to circumvent the filter or cause the classifying mechanism to fail to properly understanding the request. That may allow the attacker to slip malicious data past the content filter and/or possibly cause the application to route the request incorrectly." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/71.html> ;
-    :related :CAPEC-80,
-        :CWE-20,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-176,
-        :CWE-179,
-        :CWE-180,
-        :CWE-183,
-        :CWE-184,
-        :CWE-692,
-        :CWE-697 .
-
-:CAPEC-72 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "URL Encoding" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-72" ;
-    :definition "This attack targets the encoding of the URL. An adversary can take advantage of the multiple way of encoding an URL and abuse the interpretation of the URL." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/72.html> ;
-    :related :CWE-20,
-        :CWE-73,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-177 .
-
-:CAPEC-73 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "User-Controlled Filename" ;
-    rdfs:subClassOf :CAPEC-165 ;
-    :capec-id "CAPEC-73" ;
-    :definition "An attack of this type involves an adversary inserting malicious characters (such as a XSS redirection) into a filename, directly or indirectly that is then used by the target software to generate HTML text or other potentially executable content. Many websites rely on user-generated content and dynamically build resources like files, filenames, and URL links directly from user supplied data. In this attack pattern, the attacker uploads code that can execute in the client browser and/or redirect the client browser to a site that the attacker owns. All XSS attack payload variants can be used to pass and exploit these vulnerabilities." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/73.html> ;
-    :related :CWE-20,
-        :CWE-86,
-        :CWE-96,
-        :CWE-116,
-        :CWE-184,
-        :CWE-348,
-        :CWE-350,
-        :CWE-697 .
-
-:CAPEC-74 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulating State" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-74" ;
-    :definition "The adversary modifies state information maintained by the target software or causes a state transition in hardware. If successful, the target will use this tainted state and execute in an unintended manner." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/74.html> ;
-    :related :CWE-315,
-        :CWE-353,
-        :CWE-372,
-        :CWE-693,
-        :CWE-1245,
-        :CWE-1253,
-        :CWE-1265,
-        :CWE-1271 .
-
-:CAPEC-75 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulating Writeable Configuration Files" ;
-    rdfs:subClassOf :CAPEC-176 ;
-    :capec-id "CAPEC-75" ;
-    :definition "Generally these are manually edited files that are not in the preview of the system administrators, any ability on the attackers' behalf to modify these files, for example in a CVS repository, gives unauthorized access directly to the application, the same as authorized users." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/75.html> ;
-    :related :CAPEC-35,
-        :CWE-77,
-        :CWE-99,
-        :CWE-346,
-        :CWE-349,
-        :CWE-353,
-        :CWE-354 .
-
-:CAPEC-76 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulating Web Input to File System Calls" ;
-    rdfs:subClassOf :CAPEC-126 ;
-    :capec-id "CAPEC-76" ;
-    :definition "An attacker manipulates inputs to the target software which the target software passes to file system calls in the OS. The goal is to gain access to, and perhaps modify, areas of the file system that the target software did not intend to be accessible." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/76.html> ;
-    :related :CWE-15,
-        :CWE-22,
-        :CWE-23,
-        :CWE-59,
-        :CWE-73,
-        :CWE-74,
-        :CWE-77,
-        :CWE-272,
-        :CWE-285,
-        :CWE-346,
-        :CWE-348 .
-
-:CAPEC-77 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulating User-Controlled Variables" ;
-    rdfs:subClassOf :CAPEC-22 ;
-    :capec-id "CAPEC-77" ;
-    :definition "This attack targets user controlled variables (DEBUG=1, PHP Globals, and So Forth). An adversary can override variables leveraging user-supplied, untrusted query variables directly used on the application server without any data sanitization. In extreme cases, the adversary can change variables controlling the business logic of the application. For instance, in languages like PHP, a number of poorly set default configurations may allow the user to override variables." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/77.html> ;
-    :related :CWE-15,
-        :CWE-94,
-        :CWE-96,
-        :CWE-285,
-        :CWE-302,
-        :CWE-473,
-        :CWE-1321 .
-
-:CAPEC-78 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Escaped Slashes in Alternate Encoding" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-78" ;
-    :definition "This attack targets the use of the backslash in alternate encoding. An adversary can provide a backslash as a leading character and causes a parser to believe that the next character is special. This is called an escape. By using that trick, the adversary tries to exploit alternate ways to encode the same character which leads to filter problems and opens avenues to attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/78.html> ;
-    :related :CWE-20,
-        :CWE-22,
-        :CWE-73,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-180,
-        :CWE-181,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-79 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using Slashes in Alternate Encoding" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-79" ;
-    :definition "This attack targets the encoding of the Slash characters. An adversary would try to exploit common filtering problems related to the use of the slashes characters to gain access to resources on the target host. Directory-driven systems, such as file systems and databases, typically use the slash character to indicate traversal between directories or other container components. For murky historical reasons, PCs (and, as a result, Microsoft OSs) choose to use a backslash, whereas the UNIX world typically makes use of the forward slash. The schizophrenic result is that many MS-based systems are required to understand both forms of the slash. This gives the adversary many opportunities to discover and abuse a number of common filtering problems. The goal of this pattern is to discover server software that only applies filters to one version, but not the other." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/79.html> ;
-    :related :CWE-20,
-        :CWE-22,
-        :CWE-73,
-        :CWE-74,
-        :CWE-173,
-        :CWE-180,
-        :CWE-181,
-        :CWE-185,
-        :CWE-200,
-        :CWE-697,
-        :CWE-707 .
-
-:CAPEC-80 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using UTF-8 Encoding to Bypass Validation Logic" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-80" ;
-    :definition "This attack is a specific variation on leveraging alternate encodings to bypass validation logic. This attack leverages the possibility to encode potentially harmful input in UTF-8 and submit it to applications not expecting or effective at validating this encoding standard making input filtering difficult. UTF-8 (8-bit UCS/Unicode Transformation Format) is a variable-length character encoding for Unicode. Legal UTF-8 characters are one to four bytes long. However, early version of the UTF-8 specification got some entries wrong (in some cases it permitted overlong characters). UTF-8 encoders are supposed to use the \"shortest possible\" encoding, but naive decoders may accept encodings that are longer than necessary. According to the RFC 3629, a particularly subtle form of this attack can be carried out against a parser which performs security-critical validity checks against the UTF-8 encoded form of its input, but interprets certain illegal octet sequences as characters." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/80.html> ;
-    :related :CAPEC-64,
-        :CAPEC-71,
-        :CWE-20,
-        :CWE-73,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-180,
-        :CWE-181,
-        :CWE-692,
-        :CWE-697 .
-
-:CAPEC-81 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Web Server Logs Tampering" ;
-    rdfs:subClassOf :CAPEC-268 ;
-    :capec-id "CAPEC-81" ;
-    :definition "Web Logs Tampering attacks involve an attacker injecting, deleting or otherwise tampering with the contents of web logs typically for the purposes of masking other malicious behavior. Additionally, writing malicious data to log files may target jobs, filters, reports, and other agents that process the logs in an asynchronous attack pattern. This pattern of attack is similar to \"Log Injection-Tampering-Forging\" except that in this case, the attack is targeting the logs of the web server and not the application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/81.html> ;
-    :related :CWE-20,
-        :CWE-75,
-        :CWE-93,
-        :CWE-96,
-        :CWE-116,
-        :CWE-117,
-        :CWE-150,
-        :CWE-221,
-        :CWE-276,
-        :CWE-279 .
-
-:CAPEC-82 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Violating Implicit Assumptions Regarding XML Content (aka XML Denial of Service (XDoS))" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-230: XML Nested Payloads, CAPEC-231: XML Oversized Payloads, and CAPEC-147: XML Ping of Death. Please refer to these CAPECs going forward." ;
-    :capec-id "CAPEC-82" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/82.html> .
-
-:CAPEC-83 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XPath Injection" ;
-    rdfs:subClassOf :CAPEC-250 ;
-    :capec-id "CAPEC-83" ;
-    :definition "An attacker can craft special user-controllable input consisting of XPath expressions to inject the XML database and bypass authentication or glean information that they normally would not be able to. XPath Injection enables an attacker to talk directly to the XML database, thus bypassing the application completely. XPath Injection results from the failure of an application to properly sanitize input used as part of dynamic XPath expressions used to query an XML database." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/83.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-91,
-        :CWE-707 .
-
-:CAPEC-84 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XQuery Injection" ;
-    rdfs:subClassOf :CAPEC-250 ;
-    :capec-id "CAPEC-84" ;
-    :definition "This attack utilizes XQuery to probe and attack server systems; in a similar manner that SQL Injection allows an attacker to exploit SQL calls to RDBMS, XQuery Injection uses improperly validated data that is passed to XQuery commands to traverse and execute commands that the XQuery routines have access to. XQuery injection can be used to enumerate elements on the victim's environment, inject commands to the local host, or execute queries to remote files and data sources." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/84.html> ;
-    :related :CWE-74,
-        :CWE-707 .
-
-:CAPEC-85 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "AJAX Footprinting" ;
-    rdfs:subClassOf :CAPEC-580 ;
-    :capec-id "CAPEC-85" ;
-    :definition "This attack utilizes the frequent client-server roundtrips in Ajax conversation to scan a system. While Ajax does not open up new vulnerabilities per se, it does optimize them from an attacker point of view. A common first step for an attacker is to footprint the target environment to understand what attacks will work. Since footprinting relies on enumeration, the conversational pattern of rapid, multiple requests and responses that are typical in Ajax applications enable an attacker to look for many vulnerabilities, well-known ports, network locations and so on. The knowledge gained through Ajax fingerprinting can be used to support other attacks, such as XSS." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/85.html> ;
-    :related :CWE-20,
-        :CWE-79,
-        :CWE-86,
-        :CWE-96,
-        :CWE-113,
-        :CWE-116,
-        :CWE-184,
-        :CWE-348,
-        :CWE-692 .
-
-:CAPEC-86 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Through HTTP Headers" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-86" ;
-    :definition "An adversary exploits web applications that generate web content, such as links in a HTML page, based on unvalidated or improperly validated data submitted by other actors. XSS in HTTP Headers attacks target the HTTP headers which are hidden from most users and may not be validated by web applications." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/86.html> ;
-    :related :CWE-80 .
-
-:CAPEC-87 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Forceful Browsing" ;
-    rdfs:subClassOf :CAPEC-115 ;
-    :capec-id "CAPEC-87" ;
-    :definition "An attacker employs forceful browsing (direct URL entry) to access portions of a website that are otherwise unreachable. Usually, a front controller or similar design pattern is employed to protect access to portions of a web application. Forceful browsing enables an attacker to access information, perform privileged operations and otherwise reach sections of the web application that have been improperly protected." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/87.html> ;
-    :related :CWE-285,
-        :CWE-425,
-        :CWE-693 .
-
-:CAPEC-88 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "OS Command Injection" ;
-    rdfs:subClassOf :CAPEC-248 ;
-    :capec-id "CAPEC-88" ;
-    :definition "In this type of an attack, an adversary injects operating system commands into existing application functions. An application that uses untrusted input to build command strings is vulnerable. An adversary can leverage OS command injection in an application to elevate privileges, execute arbitrary commands and compromise the underlying operating system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/88.html> ;
-    :related :CWE-20,
-        :CWE-78,
-        :CWE-88,
-        :CWE-697 .
-
-:CAPEC-89 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pharming" ;
-    rdfs:subClassOf :CAPEC-151 ;
-    :capec-id "CAPEC-89" ;
-    :definition "A pharming attack occurs when the victim is fooled into entering sensitive data into supposedly trusted locations, such as an online bank site or a trading platform. An attacker can impersonate these supposedly trusted sites and have the victim be directed to their site rather than the originally intended one. Pharming does not require script injection or clicking on malicious links for the attack to succeed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/89.html> ;
-    :related :CWE-346,
-        :CWE-350 .
-
-:CAPEC-90 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Reflection Attack in Authentication Protocol" ;
-    rdfs:subClassOf :CAPEC-114,
-        :CAPEC-272 ;
-    :capec-id "CAPEC-90" ;
-    :definition "An adversary can abuse an authentication protocol susceptible to reflection attack in order to defeat it. Doing so allows the adversary illegitimate access to the target system, without possessing the requisite credentials. Reflection attacks are of great concern to authentication protocols that rely on a challenge-handshake or similar mechanism. An adversary can impersonate a legitimate user and can gain illegitimate access to the system by successfully mounting a reflection attack during authentication." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/90.html> ;
-    :related :CWE-301,
-        :CWE-303 .
-
-:CAPEC-91 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: XSS in IMG Tags" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is contained in the existing attack pattern \"CAPEC-18 : XSS Targeting Non-Script Elements\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-91" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/91.html> .
-
-:CAPEC-92 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Forced Integer Overflow" ;
-    rdfs:subClassOf :CAPEC-128 ;
-    :capec-id "CAPEC-92" ;
-    :definition "This attack forces an integer variable to go out of range. The integer variable is often used as an offset such as size of memory allocation or similarly. The attacker would typically control the value of such variable and try to get it out of range. For instance the integer in question is incremented past the maximum possible value, it may wrap to become a very small, or negative number, therefore providing a very incorrect value which can lead to unexpected behavior. At worst the attacker can execute arbitrary code." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/92.html> ;
-    :related :CWE-120,
-        :CWE-122,
-        :CWE-128,
-        :CWE-190,
-        :CWE-196,
-        :CWE-680,
-        :CWE-697 .
-
-:CAPEC-93 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Log Injection-Tampering-Forging" ;
-    rdfs:subClassOf :CAPEC-268 ;
-    :capec-id "CAPEC-93" ;
-    :definition "This attack targets the log files of the target host. The attacker injects, manipulates or forges malicious log entries in the log file, allowing them to mislead a log audit, cover traces of attack, or perform other malicious actions. The target host is not properly controlling log access. As a result tainted data is resulting in the log files leading to a failure in accountability, non-repudiation and incident forensics capability." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/93.html> ;
-    :related :CWE-75,
-        :CWE-117,
-        :CWE-150 .
-
-:CAPEC-94 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Adversary in the Middle (AiTM)" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-94" ;
-    :definition "An adversary targets the communication between two components (typically client and server), in order to alter or obtain data from transactions. A general approach entails the adversary placing themself within the communication channel between the two components." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/94.html> ;
-    :related :CWE-287,
-        :CWE-290,
-        :CWE-294,
-        :CWE-300,
-        :CWE-593,
-        :T1557 .
-
-:CAPEC-95 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "WSDL Scanning" ;
-    rdfs:subClassOf :CAPEC-54 ;
-    :capec-id "CAPEC-95" ;
-    :definition "This attack targets the WSDL interface made available by a web service. The attacker may scan the WSDL interface to reveal sensitive information about invocation patterns, underlying technology implementations and associated vulnerabilities. This type of probing is carried out to perform more serious attacks (e.g. parameter tampering, malicious content injection, command injection, etc.). WSDL files provide detailed information about the services ports and bindings available to consumers. For instance, the attacker can submit special characters or malicious content to the Web service and can cause a denial of service condition or illegal access to database records. In addition, the attacker may try to guess other private methods by using the information provided in the WSDL files." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/95.html> ;
-    :related :CWE-538 .
-
-:CAPEC-96 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Block Access to Libraries" ;
-    rdfs:subClassOf :CAPEC-603 ;
-    :capec-id "CAPEC-96" ;
-    :definition "An application typically makes calls to functions that are a part of libraries external to the application. These libraries may be part of the operating system or they may be third party libraries. It is possible that the application does not handle situations properly where access to these libraries has been blocked. Depending on the error handling within the application, blocked access to libraries may leave the system in an insecure state that could be leveraged by an attacker." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/96.html> ;
-    :related :CWE-589 .
-
-:CAPEC-97 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cryptanalysis" ;
-    rdfs:subClassOf :CAPEC-192 ;
-    :capec-id "CAPEC-97" ;
-    :definition "Cryptanalysis is a process of finding weaknesses in cryptographic algorithms and using these weaknesses to decipher the ciphertext without knowing the secret key (instance deduction). Sometimes the weakness is not in the cryptographic algorithm itself, but rather in how it is applied that makes cryptanalysis successful. An attacker may have other goals as well, such as: Total Break (finding the secret key), Global Deduction (finding a functionally equivalent algorithm for encryption and decryption that does not require knowledge of the secret key), Information Deduction (gaining some information about plaintexts or ciphertexts that was not previously known) and Distinguishing Algorithm (the attacker has the ability to distinguish the output of the encryption (ciphertext) from a random permutation of bits)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/97.html> ;
-    :related :CWE-327,
-        :CWE-1204,
-        :CWE-1240,
-        :CWE-1241,
-        :CWE-1279 .
-
-:CAPEC-98 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Phishing" ;
-    rdfs:subClassOf :CAPEC-151 ;
-    :capec-id "CAPEC-98" ;
-    :definition "Phishing is a social engineering technique where an attacker masquerades as a legitimate entity with which the victim might do business in order to prompt the user to reveal some confidential information (very frequently authentication credentials) that can later be used by an attacker. Phishing is essentially a form of information gathering or \"fishing\" for information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/98.html> ;
-    :related :CWE-451,
-        :T1566,
-        :T1598 .
-
-:CAPEC-99 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: XML Parser Attack" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-230: XML Nested Payloads and CAPEC-231: XML Oversized Payloads. Please refer to these CAPECs going forward." ;
-    :capec-id "CAPEC-99" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/99.html> .
-
-:CAPEC-100 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Overflow Buffers" ;
-    rdfs:subClassOf :CAPEC-123 ;
-    :capec-id "CAPEC-100" ;
-    :definition "Buffer Overflow attacks target improper or missing bounds checking on buffer operations, typically triggered by input injected by an adversary. As a consequence, an adversary is able to write past the boundaries of allocated buffer regions in memory, causing a program crash or potentially redirection of execution as per the adversaries' choice." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/100.html> ;
-    :related :CWE-119,
-        :CWE-120,
-        :CWE-129,
-        :CWE-131,
-        :CWE-680,
-        :CWE-805 .
-
-:CAPEC-101 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Server Side Include (SSI) Injection" ;
-    rdfs:subClassOf :CAPEC-253 ;
-    :capec-id "CAPEC-101" ;
-    :definition "An attacker can use Server Side Include (SSI) Injection to send code to a web application that then gets executed by the web server. Doing so enables the attacker to achieve similar results to Cross Site Scripting, viz., arbitrary code execution and information disclosure, albeit on a more limited scale, since the SSI directives are nowhere near as powerful as a full-fledged scripting language. Nonetheless, the attacker can conveniently gain access to sensitive files, such as password files, and execute shell commands." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/101.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-97 .
-
-:CAPEC-102 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Session Sidejacking" ;
-    rdfs:subClassOf :CAPEC-593 ;
-    :capec-id "CAPEC-102" ;
-    :definition "Session sidejacking takes advantage of an unencrypted communication channel between a victim and target system. The attacker sniffs traffic on a network looking for session tokens in unencrypted traffic. Once a session token is captured, the attacker performs malicious actions by using the stolen token with the targeted application to impersonate the victim. This attack is a specific method of session hijacking, which is exploiting a valid session token to gain unauthorized access to a target system or information. Other methods to perform a session hijacking are session fixation, cross-site scripting, or compromising a user or server machine and stealing the session token." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/102.html> ;
-    :related :CWE-294,
-        :CWE-319,
-        :CWE-522,
-        :CWE-523,
-        :CWE-614 .
-
-:CAPEC-103 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Clickjacking" ;
-    rdfs:subClassOf :CAPEC-173 ;
-    :capec-id "CAPEC-103" ;
-    :definition "An adversary tricks a victim into unknowingly initiating some action in one system while interacting with the UI from a seemingly completely different, usually an adversary controlled or intended, system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/103.html> ;
-    :related :CWE-1021 .
-
-:CAPEC-104 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross Zone Scripting" ;
-    rdfs:subClassOf :CAPEC-233 ;
-    :capec-id "CAPEC-104" ;
-    :definition "An attacker is able to cause a victim to load content into their web-browser that bypasses security zone controls and gain access to increased privileges to execute scripting code or other web objects such as unsigned ActiveX controls or applets. This is a privilege elevation attack targeted at zone-based web-browser security." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/104.html> ;
-    :related :CWE-20,
-        :CWE-116,
-        :CWE-250,
-        :CWE-285,
-        :CWE-638 .
-
-:CAPEC-105 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP Request Splitting" ;
-    rdfs:subClassOf :CAPEC-220 ;
-    :capec-id "CAPEC-105" ;
-    :definition "An adversary abuses the flexibility and discrepancies in the parsing and interpretation of HTTP Request messages by different intermediary HTTP agents (e.g., load balancer, reverse proxy, web caching proxies, application firewalls, etc.) to split a single HTTP request into multiple unauthorized and malicious HTTP requests to a back-end HTTP agent (e.g., web server)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/105.html> ;
-    :related :CAPEC-34,
-        :CWE-74,
-        :CWE-113,
-        :CWE-138,
-        :CWE-436 .
-
-:CAPEC-106 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: XSS through Log Files" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it referes to an existing chain relationship between \"CAPEC-93 : Log Injection-Tampering-Forging\" and \"CAPEC-63 : Cross-Site Scripting\". Please refer to these CAPECs going forward." ;
-    :capec-id "CAPEC-106" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/106.html> .
-
-:CAPEC-107 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross Site Tracing" ;
-    rdfs:subClassOf :CAPEC-593 ;
-    :capec-id "CAPEC-107" ;
-    :definition "Cross Site Tracing (XST) enables an adversary to steal the victim's session cookie and possibly other authentication credentials transmitted in the header of the HTTP request when the victim's browser communicates to a destination system's web server." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/107.html> ;
-    :related :CWE-648,
-        :CWE-693 .
-
-:CAPEC-108 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Command Line Execution through SQL Injection" ;
-    rdfs:subClassOf :CAPEC-66 ;
-    :capec-id "CAPEC-108" ;
-    :definition "An attacker uses standard SQL injection methods to inject data into the command line for execution. This could be done directly through misuse of directives such as MSSQL_xp_cmdshell or indirectly through injection of data into the database that would be interpreted as shell commands. Sometime later, an unscrupulous backend application (or could be part of the functionality of the same application) fetches the injected data stored in the database and uses this data as command line arguments without performing proper validation. The malicious data escapes that data plane by spawning new commands to be executed on the host." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/108.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-78,
-        :CWE-89,
-        :CWE-114 .
-
-:CAPEC-109 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Object Relational Mapping Injection" ;
-    rdfs:subClassOf :CAPEC-66 ;
-    :capec-id "CAPEC-109" ;
-    :definition "An attacker leverages a weakness present in the database access layer code generated with an Object Relational Mapping (ORM) tool or a weakness in the way that a developer used a persistence framework to inject their own SQL commands to be executed against the underlying database. The attack here is similar to plain SQL injection, except that the application does not use JDBC to directly talk to the database, but instead it uses a data access layer generated by an ORM tool or framework (e.g. Hibernate). While most of the time code generated by an ORM tool contains safe access methods that are immune to SQL injection, sometimes either due to some weakness in the generated code or due to the fact that the developer failed to use the generated access methods properly, SQL injection is still possible." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/109.html> ;
-    :related :CWE-20,
-        :CWE-89,
-        :CWE-564 .
-
-:CAPEC-110 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SQL Injection through SOAP Parameter Tampering" ;
-    rdfs:subClassOf :CAPEC-66 ;
-    :capec-id "CAPEC-110" ;
-    :definition "An attacker modifies the parameters of the SOAP message that is sent from the service consumer to the service provider to initiate a SQL injection attack. On the service provider side, the SOAP message is parsed and parameters are not properly validated before being used to access a database in a way that does not use parameter binding, thus enabling the attacker to control the structure of the executed SQL query. This pattern describes a SQL injection attack with the delivery mechanism being a SOAP message." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/110.html> ;
-    :related :CWE-20,
-        :CWE-89 .
-
-:CAPEC-111 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "JSON Hijacking (aka JavaScript Hijacking)" ;
-    rdfs:subClassOf :CAPEC-212 ;
-    :capec-id "CAPEC-111" ;
-    :definition "An attacker targets a system that uses JavaScript Object Notation (JSON) as a transport mechanism between the client and the server (common in Web 2.0 systems using AJAX) to steal possibly confidential information transmitted from the server back to the client inside the JSON object by taking advantage of the loophole in the browser's Same Origin Policy that does not prohibit JavaScript from one website to be included and executed in the context of another website." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/111.html> ;
-    :related :CWE-345,
-        :CWE-346,
-        :CWE-352 .
-
-:CAPEC-112 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Brute Force" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-112" ;
-    :definition "In this attack, some asset (information, functionality, identity, etc.) is protected by a finite secret value. The attacker attempts to gain access to this asset by using trial-and-error to exhaustively explore all the possible secret values in the hope of finding the secret (or a value that is functionally equivalent) that will unlock the asset." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/112.html> ;
-    :related :CWE-326,
-        :CWE-330,
-        :CWE-521,
-        :T1110 .
-
-:CAPEC-113 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Interface Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-113" ;
-    :definition "An adversary manipulates the use or processing of an interface (e.g. Application Programming Interface (API) or System-on-Chip (SoC)) resulting in an adverse impact upon the security of the system implementing the interface. This can allow the adversary to bypass access control and/or execute functionality not intended by the interface implementation, possibly compromising the system which integrates the interface. Interface manipulation can take on a number of forms including forcing the unexpected use of an interface or the use of an interface in an unintended way." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/113.html> ;
-    :related :CWE-1192 .
-
-:CAPEC-114 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Authentication Abuse" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-114" ;
-    :definition "An attacker obtains unauthorized access to an application, service or device either through knowledge of the inherent weaknesses of an authentication mechanism, or by exploiting a flaw in the authentication scheme's implementation. In such an attack an authentication mechanism is functioning but a carefully controlled sequence of events causes the mechanism to grant access to the attacker." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/114.html> ;
-    :related :CWE-287,
-        :CWE-1244,
-        :T1548 .
-
-:CAPEC-115 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Authentication Bypass" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-115" ;
-    :definition "An attacker gains access to application, service, or device with the privileges of an authorized or privileged user by evading or circumventing an authentication mechanism. The attacker is therefore able to access protected data without authentication ever having taken place." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/115.html> ;
-    :related :CWE-287,
-        :T1548 .
-
-:CAPEC-116 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Excavation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-116" ;
-    :definition "An adversary actively probes the target in a manner that is designed to solicit information that could be leveraged for malicious purposes." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/116.html> ;
-    :related :CWE-200,
-        :CWE-1243 .
-
-:CAPEC-117 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Interception" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-117" ;
-    :definition "An adversary monitors data streams to or from the target for information gathering purposes. This attack may be undertaken to solely gather sensitive information or to support a further attack against the target. This attack pattern can involve sniffing network traffic as well as other types of data streams (e.g. radio). The adversary can attempt to initiate the establishment of a data stream or passively observe the communications as they unfold. In all variants of this attack, the adversary is not the intended recipient of the data stream. In contrast to other means of gathering information (e.g., targeting data leaks), the adversary must actively position themself so as to observe explicit data channels (e.g. network traffic) and read the content. However, this attack differs from a Adversary-In-the-Middle (CAPEC-94) attack, as the adversary does not alter the content of the communications nor forward data to the intended recipient." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/117.html> ;
-    :related :CWE-319 .
-
-:CAPEC-120 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Double Encoding" ;
-    rdfs:subClassOf :CAPEC-267 ;
-    :capec-id "CAPEC-120" ;
-    :definition "The adversary utilizes a repeating of the encoding process for a set of characters (that is, character encoding a character encoding of a character) to obfuscate the payload of a particular request. This may allow the adversary to bypass filters that attempt to detect illegal characters or strings, such as those that might be used in traversal or injection attacks. Filters may be able to catch illegal encoded strings, but may not catch doubly encoded strings. For example, a dot (.), often used in path traversal attacks and therefore often blocked by filters, could be URL encoded as %2E. However, many filters recognize this encoding and would still block the request. In a double encoding, the % in the above URL encoding would be encoded again as %25, resulting in %252E which some filters might not catch, but which could still be interpreted as a dot (.) by interpreters on the target." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/120.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-177,
-        :CWE-181,
-        :CWE-183,
-        :CWE-184,
-        :CWE-692,
-        :CWE-697 .
-
-:CAPEC-121 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploit Non-Production Interfaces" ;
-    rdfs:subClassOf :CAPEC-113 ;
-    :capec-id "CAPEC-121" ;
-    :definition "An adversary exploits a sample, demonstration, test, or debug interface that is unintentionally enabled on a production system, with the goal of gleaning information or leveraging functionality that would otherwise be unavailable." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/121.html> ;
-    :related :CWE-489,
-        :CWE-1209,
-        :CWE-1259,
-        :CWE-1267,
-        :CWE-1270,
-        :CWE-1294,
-        :CWE-1295,
-        :CWE-1296,
-        :CWE-1302,
-        :CWE-1313 .
-
-:CAPEC-122 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Privilege Abuse" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-122" ;
-    :definition "An adversary is able to exploit features of the target that should be reserved for privileged users or administrators but are exposed to use by lower or non-privileged accounts. Access to sensitive information and functionality must be controlled to ensure that only authorized users are able to access these resources." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/122.html> ;
-    :related :CWE-269,
-        :CWE-732,
-        :CWE-1317,
-        :T1548 .
-
-:CAPEC-123 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Buffer Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-123" ;
-    :definition "An adversary manipulates an application's interaction with a buffer in an attempt to read or modify data they shouldn't have access to. Buffer attacks are distinguished in that it is the buffer space itself that is the target of the attack rather than any code responsible for interpreting the content of the buffer. In virtually all buffer attacks the content that is placed in the buffer is immaterial. Instead, most buffer attacks involve retrieving or providing more input than can be stored in the allocated buffer, resulting in the reading or overwriting of other unintended program memory." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/123.html> ;
-    :related :CWE-119 .
-
-:CAPEC-124 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Shared Resource Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-124" ;
-    :definition "An adversary exploits a resource shared between multiple applications, an application pool or hardware pin multiplexing to affect behavior. Resources may be shared between multiple applications or between multiple threads of a single application. Resource sharing is usually accomplished through mutual access to a single memory location or multiplexed hardware pins. If an adversary can manipulate this shared resource (usually by co-opting one of the applications or threads) the other applications or threads using the shared resource will often continue to trust the validity of the compromised shared resource and use it in their calculations. This can result in invalid trust assumptions, corruption of additional data through the normal operations of the other users of the shared resource, or even cause a crash or compromise of the sharing applications." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/124.html> ;
-    :related :CAPEC-663,
-        :CWE-1189,
-        :CWE-1331 .
-
-:CAPEC-125 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Flooding" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-125" ;
-    :definition "An adversary consumes the resources of a target by rapidly engaging in a large number of interactions with the target. This type of attack generally exposes a weakness in rate limiting or flow. When successful this attack prevents legitimate users from accessing the service and can cause the target to crash. This attack differs from resource depletion through leaks or allocations in that the latter attacks do not rely on the volume of requests made to the target but instead focus on manipulation of the target's operations. The key factor in a flooding attack is the number of requests the adversary can make in a given period of time. The greater this number, the more likely an attack is to succeed against a given target." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/125.html> ;
-    :related :CWE-404,
-        :CWE-770,
-        :T1498.001,
-        :T1499 .
-
-:CAPEC-126 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Path Traversal" ;
-    rdfs:subClassOf :CAPEC-153 ;
-    :capec-id "CAPEC-126" ;
-    :definition "An adversary uses path manipulation methods to exploit insufficient input validation of a target to obtain access to data that should be not be retrievable by ordinary well-formed requests. A typical variety of this attack involves specifying a path to a desired file together with dot-dot-slash characters, resulting in the file access API or function traversing out of the intended directory structure and into the root file system. By replacing or modifying the expected path information the access function or API retrieves the file desired by the attacker. These attacks either involve the attacker providing a complete path to a targeted file or using control characters (e.g. path separators (/ or \\) and/or dots (.)) to reach desired directories or files." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/126.html> ;
-    :related :CWE-22 .
-
-:CAPEC-127 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Directory Indexing" ;
-    rdfs:subClassOf :CAPEC-54 ;
-    :capec-id "CAPEC-127" ;
-    :definition "An adversary crafts a request to a target that results in the target listing/indexing the content of a directory as output. One common method of triggering directory contents as output is to construct a request containing a path that terminates in a directory name rather than a file name since many applications are configured to provide a list of the directory's contents when such a request is received. An adversary can use this to explore the directory tree on a target as well as learn the names of files. This can often end up revealing test files, backup files, temporary files, hidden files, configuration files, user accounts, script contents, as well as naming conventions, all of which can be used by an attacker to mount additional attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/127.html> ;
-    :related :CWE-276,
-        :CWE-285,
-        :CWE-288,
-        :CWE-424,
-        :CWE-425,
-        :CWE-693,
-        :CWE-732,
-        :T1083 .
-
-:CAPEC-128 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Integer Attacks" ;
-    rdfs:subClassOf :CAPEC-153 ;
-    :capec-id "CAPEC-128" ;
-    :definition "An attacker takes advantage of the structure of integer variables to cause these variables to assume values that are not expected by an application. For example, adding one to the largest positive integer in a signed integer variable results in a negative number. Negative numbers may be illegal in an application and the application may prevent an attacker from providing them directly, but the application may not consider that adding two positive numbers can create a negative number do to the structure of integer storage formats." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/128.html> ;
-    :related :CWE-682 .
-
-:CAPEC-129 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pointer Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-129" ;
-    :definition "This attack pattern involves an adversary manipulating a pointer within a target application resulting in the application accessing an unintended memory location. This can result in the crashing of the application or, for certain pointer values, access to data that would not normally be possible or the execution of arbitrary code. Since pointers are simply integer variables, Integer Attacks may often be used in Pointer Attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/129.html> ;
-    :related :CWE-682,
-        :CWE-822,
-        :CWE-823 .
-
-:CAPEC-130 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Excessive Allocation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-130" ;
-    :definition "An adversary causes the target to allocate excessive resources to servicing the attackers' request, thereby reducing the resources available for legitimate services and degrading or denying services. Usually, this attack focuses on memory allocation, but any finite resource on the target could be the attacked, including bandwidth, processing cycles, or other resources. This attack does not attempt to force this allocation through a large number of requests (that would be Resource Depletion through Flooding) but instead uses one or a small number of requests that are carefully formatted to force the target to allocate excessive resources to service this request(s). Often this attack takes advantage of a bug in the target to cause the target to allocate resources vastly beyond what would be needed for a normal request." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/130.html> ;
-    :related :CWE-404,
-        :CWE-770,
-        :CWE-1325,
-        :T1499.003 .
-
-:CAPEC-131 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Resource Leak Exposure" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-131" ;
-    :definition "An adversary utilizes a resource leak on the target to deplete the quantity of the resource available to service legitimate requests." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/131.html> ;
-    :related :CWE-404,
-        :T1499 .
-
-:CAPEC-132 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Symlink Attack" ;
-    rdfs:subClassOf :CAPEC-159 ;
-    :capec-id "CAPEC-132" ;
-    :definition "An adversary positions a symbolic link in such a manner that the targeted user or application accesses the link's endpoint, assuming that it is accessing a file with the link's name." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/132.html> ;
-    :related :CWE-59,
-        :T1547.009 .
-
-:CAPEC-133 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Try All Common Switches" ;
-    rdfs:subClassOf :CAPEC-113 ;
-    :capec-id "CAPEC-133" ;
-    :definition "An attacker attempts to invoke all common switches and options in the target application for the purpose of discovering weaknesses in the target. For example, in some applications, adding a --debug switch causes debugging information to be displayed, which can sometimes reveal sensitive processing or configuration information to an attacker. This attack differs from other forms of API abuse in that the attacker is indiscriminately attempting to invoke options in the hope that one of them will work rather than specifically targeting a known option. Nonetheless, even if the attacker is familiar with the published options of a targeted application this attack method may still be fruitful as it might discover unpublicized functionality." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/133.html> ;
-    :related :CWE-912 .
-
-:CAPEC-134 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Email Injection" ;
-    rdfs:subClassOf :CAPEC-137 ;
-    :capec-id "CAPEC-134" ;
-    :definition "An adversary manipulates the headers and content of an email message by injecting data via the use of delimiter characters native to the protocol." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/134.html> ;
-    :related :CWE-150 .
-
-:CAPEC-135 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Format String Injection" ;
-    rdfs:subClassOf :CAPEC-137 ;
-    :capec-id "CAPEC-135" ;
-    :definition "An adversary includes formatting characters in a string input field on the target application. Most applications assume that users will provide static text and may respond unpredictably to the presence of formatting character. For example, in certain functions of the C programming languages such as printf, the formatting character %s will print the contents of a memory location expecting this location to identify a string and the formatting character %n prints the number of DWORD written in the memory. An adversary can use this to read or write to memory locations or files, or simply to manipulate the value of the resulting text in unexpected ways. Reading or writing memory may result in program crashes and writing memory could result in the execution of arbitrary code if the adversary can write to the program stack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/135.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-134 .
-
-:CAPEC-136 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "LDAP Injection" ;
-    rdfs:subClassOf :CAPEC-248 ;
-    :capec-id "CAPEC-136" ;
-    :definition "An attacker manipulates or crafts an LDAP query for the purpose of undermining the security of the target. Some applications use user input to create LDAP queries that are processed by an LDAP server. For example, a user might provide their username during authentication and the username might be inserted in an LDAP query during the authentication process. An attacker could use this input to inject additional commands into an LDAP query that could disclose sensitive information. For example, entering a * in the aforementioned query might return information about all users on the system. This attack is very similar to an SQL injection attack in that it manipulates a query to gather additional information or coerce a particular return value." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/136.html> ;
-    :related :CWE-20,
-        :CWE-77,
-        :CWE-90 .
-
-:CAPEC-137 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Parameter Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-137" ;
-    :definition "An adversary manipulates the content of request parameters for the purpose of undermining the security of the target. Some parameter encodings use text characters as separators. For example, parameters in a HTTP GET message are encoded as name-value pairs separated by an ampersand (&). If an attacker can supply text strings that are used to fill in these parameters, then they can inject special characters used in the encoding scheme to add or modify parameters. For example, if user input is fed directly into an HTTP GET request and the user provides the value \"myInput&new_param=myValue\", then the input parameter is set to myInput, but a new parameter (new_param) is also added with a value of myValue. This can significantly change the meaning of the query that is processed by the server. Any encoding scheme where parameters are identified and separated by text characters is potentially vulnerable to this attack - the HTTP GET encoding used above is just one example." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/137.html> ;
-    :related :CWE-88 .
-
-:CAPEC-138 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Reflection Injection" ;
-    rdfs:subClassOf :CAPEC-137 ;
-    :capec-id "CAPEC-138" ;
-    :definition "An adversary supplies a value to the target application which is then used by reflection methods to identify a class, method, or field. For example, in the Java programming language the reflection libraries permit an application to inspect, load, and invoke classes and their components by name. If an adversary can control the input into these methods including the name of the class/method/field or the parameters passed to methods, they can cause the targeted application to invoke incorrect methods, read random fields, or even to load and utilize malicious classes that the adversary created. This can lead to the application revealing sensitive information, returning incorrect results, or even having the adversary take control of the targeted application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/138.html> ;
-    :related :CWE-470 .
-
-:CAPEC-139 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Relative Path Traversal" ;
-    rdfs:subClassOf :CAPEC-126 ;
-    :capec-id "CAPEC-139" ;
-    :definition "An attacker exploits a weakness in input validation on the target by supplying a specially constructed path utilizing dot and slash characters for the purpose of obtaining access to arbitrary files or resources. An attacker modifies a known path on the target in order to reach material that is not available through intended channels. These attacks normally involve adding additional path separators (/ or \\) and/or dots (.), or encodings thereof, in various combinations in order to reach parent directories or entirely separate trees of the target's directory structure." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/139.html> ;
-    :related :CWE-23 .
-
-:CAPEC-140 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Bypassing of Intermediate Forms in Multiple-Form Sets" ;
-    rdfs:subClassOf :CAPEC-74 ;
-    :capec-id "CAPEC-140" ;
-    :definition "Some web applications require users to submit information through an ordered sequence of web forms. This is often done if there is a very large amount of information being collected or if information on earlier forms is used to pre-populate fields or determine which additional information the application needs to collect. An attacker who knows the names of the various forms in the sequence may be able to explicitly type in the name of a later form and navigate to it without first going through the previous forms. This can result in incomplete collection of information, incorrect assumptions about the information submitted by the attacker, or other problems that can impair the functioning of the application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/140.html> ;
-    :related :CWE-372 .
-
-:CAPEC-141 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cache Poisoning" ;
-    rdfs:subClassOf :CAPEC-161 ;
-    :capec-id "CAPEC-141" ;
-    :definition "An attacker exploits the functionality of cache technologies to cause specific data to be cached that aids the attackers' objectives. This describes any attack whereby an attacker places incorrect or harmful material in cache. The targeted cache can be an application's cache (e.g. a web browser cache) or a public cache (e.g. a DNS or ARP cache). Until the cache is refreshed, most applications or clients will treat the corrupted cache value as valid. This can lead to a wide range of exploits including redirecting web browsers towards sites that install malware and repeatedly incorrect calculations based on the incorrect value." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/141.html> ;
-    :related :CWE-345,
-        :CWE-346,
-        :CWE-348,
-        :CWE-349,
-        :T1557.002 .
-
-:CAPEC-142 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DNS Cache Poisoning" ;
-    rdfs:subClassOf :CAPEC-141 ;
-    :capec-id "CAPEC-142" ;
-    :definition "A domain name server translates a domain name (such as www.example.com) into an IP address that Internet hosts use to contact Internet resources. An adversary modifies a public DNS cache to cause certain names to resolve to incorrect addresses that the adversary specifies. The result is that client applications that rely upon the targeted cache for domain name resolution will be directed not to the actual address of the specified domain name but to some other address. Adversaries can use this to herd clients to sites that install malware on the victim's computer or to masquerade as part of a Pharming attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/142.html> ;
-    :related :CWE-345,
-        :CWE-346,
-        :CWE-348,
-        :CWE-349,
-        :CWE-350,
-        :T1584.002 .
-
-:CAPEC-143 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Detect Unpublicized Web Pages" ;
-    rdfs:subClassOf :CAPEC-150 ;
-    :capec-id "CAPEC-143" ;
-    :definition "An adversary searches a targeted web site for web pages that have not been publicized. In doing this, the adversary may be able to gain access to information that the targeted site did not intend to make public." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/143.html> ;
-    :related :CWE-425 .
-
-:CAPEC-144 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Detect Unpublicized Web Services" ;
-    rdfs:subClassOf :CAPEC-150 ;
-    :capec-id "CAPEC-144" ;
-    :definition "An adversary searches a targeted web site for web services that have not been publicized. This attack can be especially dangerous since unpublished but available services may not have adequate security controls placed upon them given that an administrator may believe they are unreachable." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/144.html> ;
-    :related :CWE-425 .
-
-:CAPEC-145 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Checksum Spoofing" ;
-    rdfs:subClassOf :CAPEC-148 ;
-    :capec-id "CAPEC-145" ;
-    :definition "An adversary spoofs a checksum message for the purpose of making a payload appear to have a valid corresponding checksum. Checksums are used to verify message integrity. They consist of some value based on the value of the message they are protecting. Hash codes are a common checksum mechanism. Both the sender and recipient are able to compute the checksum based on the contents of the message. If the message contents change between the sender and recipient, the sender and recipient will compute different checksum values. Since the sender's checksum value is transmitted with the message, the recipient would know that a modification occurred. In checksum spoofing an adversary modifies the message body and then modifies the corresponding checksum so that the recipient's checksum calculation will match the checksum (created by the adversary) in the message. This would prevent the recipient from realizing that a change occurred." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/145.html> ;
-    :related :CWE-354 .
-
-:CAPEC-146 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XML Schema Poisoning" ;
-    rdfs:subClassOf :CAPEC-271 ;
-    :capec-id "CAPEC-146" ;
-    :definition "An adversary corrupts or modifies the content of XML schema information passed between a client and server for the purpose of undermining the security of the target. XML Schemas provide the structure and content definitions for XML documents. Schema poisoning is the ability to manipulate a schema either by replacing or modifying it to compromise the programs that process documents that use this schema." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/146.html> ;
-    :related :CWE-15,
-        :CWE-472 .
-
-:CAPEC-147 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XML Ping of the Death" ;
-    rdfs:subClassOf :CAPEC-528 ;
-    :capec-id "CAPEC-147" ;
-    :definition "An attacker initiates a resource depletion attack where a large number of small XML messages are delivered at a sufficiently rapid rate to cause a denial of service or crash of the target. Transactions such as repetitive SOAP transactions can deplete resources faster than a simple flooding attack because of the additional resources used by the SOAP protocol and the resources necessary to process SOAP messages. The transactions used are immaterial as long as they cause resource utilization on the target. In other words, this is a normal flooding attack augmented by using messages that will require extra processing on the target." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/147.html> ;
-    :related :CWE-400,
-        :CWE-770 .
-
-:CAPEC-148 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Content Spoofing" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-148" ;
-    :definition "An adversary modifies content to make it contain something other than what the original content producer intended while keeping the apparent source of the content unchanged. The term content spoofing is most often used to describe modification of web pages hosted by a target to display the adversary's content instead of the owner's content. However, any content can be spoofed, including the content of email messages, file transfers, or the content of other network communication protocols. Content can be modified at the source (e.g. modifying the source file for a web page) or in transit (e.g. intercepting and modifying a message between the sender and recipient). Usually, the adversary will attempt to hide the fact that the content has been modified, but in some cases, such as with web site defacement, this is not necessary. Content Spoofing can lead to malware exposure, financial fraud (if the content governs financial transactions), privacy violations, and other unwanted outcomes." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/148.html> ;
-    :related :CAPEC-665,
-        :CWE-345,
-        :T1491 .
-
-:CAPEC-149 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Explore for Predictable Temporary File Names" ;
-    rdfs:subClassOf :CAPEC-497 ;
-    :capec-id "CAPEC-149" ;
-    :definition "An attacker explores a target to identify the names and locations of predictable temporary files for the purpose of launching further attacks against the target. This involves analyzing naming conventions and storage locations of the temporary files created by a target application. If an attacker can predict the names of temporary files they can use this information to mount other attacks, such as information gathering and symlink attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/149.html> ;
-    :related :CWE-377 .
-
-:CAPEC-150 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Collect Data from Common Resource Locations" ;
-    rdfs:subClassOf :CAPEC-116 ;
-    :capec-id "CAPEC-150" ;
-    :definition "An adversary exploits well-known locations for resources for the purposes of undermining the security of the target. In many, if not most systems, files and resources are organized in a default tree structure. This can be useful for adversaries because they often know where to look for resources or files that are necessary for attacks. Even when the precise location of a targeted resource may not be known, naming conventions may indicate a small area of the target machine's file tree where the resources are typically located. For example, configuration files are normally stored in the /etc director on Unix systems. Adversaries can take advantage of this to commit other types of attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/150.html> ;
-    :related :CWE-552,
-        :CWE-1239,
-        :CWE-1258,
-        :CWE-1266,
-        :CWE-1272,
-        :CWE-1323,
-        :CWE-1330,
-        :T1003,
-        :T1119,
-        :T1213,
-        :T1530,
-        :T1555,
-        :T1602 .
-
-:CAPEC-151 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Identity Spoofing" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-151" ;
-    :definition "Identity Spoofing refers to the action of assuming (i.e., taking on) the identity of some other entity (human or non-human) and then using that identity to accomplish a goal. An adversary may craft messages that appear to come from a different principle or use stolen / spoofed authentication credentials." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/151.html> ;
-    :related :CAPEC-665,
-        :CWE-287 .
-
-:CAPEC-153 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Input Data Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-153" ;
-    :definition "An attacker exploits a weakness in input validation by controlling the format, structure, and composition of data to an input-processing interface. By supplying input of a non-standard or unexpected form an attacker can adversely impact the security of the target." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/153.html> ;
-    :related :CWE-20 .
-
-:CAPEC-154 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Resource Location Spoofing" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-154" ;
-    :definition "An adversary deceives an application or user and convinces them to request a resource from an unintended location. By spoofing the location, the adversary can cause an alternate resource to be used, often one that the adversary controls and can be used to help them achieve their malicious goals." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/154.html> ;
-    :related :CWE-451 .
-
-:CAPEC-155 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Screen Temporary Files for Sensitive Information" ;
-    rdfs:subClassOf :CAPEC-150 ;
-    :capec-id "CAPEC-155" ;
-    :definition "An adversary exploits the temporary, insecure storage of information by monitoring the content of files used to store temp data during an application's routine execution flow. Many applications use temporary files to accelerate processing or to provide records of state across multiple executions of the application. Sometimes, however, these temporary files may end up storing sensitive information. By screening an application's temporary files, an adversary might be able to discover such sensitive information. For example, web browsers often cache content to accelerate subsequent lookups. If the content contains sensitive information then the adversary could recover this from the web cache." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/155.html> ;
-    :related :CWE-377 .
-
-:CAPEC-157 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Sniffing Attacks" ;
-    rdfs:subClassOf :CAPEC-117 ;
-    :capec-id "CAPEC-157" ;
-    :definition "In this attack pattern, the adversary intercepts information transmitted between two third parties. The adversary must be able to observe, read, and/or hear the communication traffic, but not necessarily block the communication or change its content. Any transmission medium can theoretically be sniffed if the adversary can examine the contents between the sender and recipient. Sniffing Attacks are similar to Adversary-In-The-Middle attacks (CAPEC-94), but are entirely passive. AiTM attacks are predominantly active and often alter the content of the communications themselves." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/157.html> ;
-    :related :CWE-311 .
-
-:CAPEC-158 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Sniffing Network Traffic" ;
-    rdfs:subClassOf :CAPEC-157 ;
-    :capec-id "CAPEC-158" ;
-    :definition "In this attack pattern, the adversary monitors network traffic between nodes of a public or multicast network in an attempt to capture sensitive information at the protocol level. Network sniffing applications can reveal TCP/IP, DNS, Ethernet, and other low-level network communication information. The adversary takes a passive role in this attack pattern and simply observes and analyzes the traffic. The adversary may precipitate or indirectly influence the content of the observed transaction, but is never the intended recipient of the target information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/158.html> ;
-    :related :CWE-311,
-        :T1040,
-        :T1111 .
-
-:CAPEC-159 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Redirect Access to Libraries" ;
-    rdfs:subClassOf :CAPEC-154 ;
-    :capec-id "CAPEC-159" ;
-    :definition "An adversary exploits a weakness in the way an application searches for external libraries to manipulate the execution flow to point to an adversary supplied library or code base. This pattern of attack allows the adversary to compromise the application or server via the execution of unauthorized code. An application typically makes calls to functions that are a part of libraries external to the application. These libraries may be part of the operating system or they may be third party libraries. If an adversary can redirect an application's attempts to access these libraries to other libraries that the adversary supplies, the adversary will be able to force the targeted application to execute arbitrary code. This is especially dangerous if the targeted application has enhanced privileges. Access can be redirected through a number of techniques, including the use of symbolic links, search path modification, and relative path manipulation." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/159.html> ;
-    :related :CWE-706,
-        :T1574.008 .
-
-:CAPEC-160 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploit Script-Based APIs" ;
-    rdfs:subClassOf :CAPEC-113 ;
-    :capec-id "CAPEC-160" ;
-    :definition "Some APIs support scripting instructions as arguments. Methods that take scripted instructions (or references to scripted instructions) can be very flexible and powerful. However, if an attacker can specify the script that serves as input to these methods they can gain access to a great deal of functionality. For example, HTML pages support <script> tags that allow scripting languages to be embedded in the page and then interpreted by the receiving web browser. If the content provider is malicious, these scripts can compromise the client application. Some applications may even execute the scripts under their own identity (rather than the identity of the user providing the script) which can allow attackers to perform activities that would otherwise be denied to them." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/160.html> ;
-    :related :CWE-346 .
-
-:CAPEC-161 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Infrastructure Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-161" ;
-    :definition "An attacker exploits characteristics of the infrastructure of a network entity in order to perpetrate attacks or information gathering on network objects or effect a change in the ordinary information flow between network objects. Most often, this involves manipulation of the routing of network messages so, instead of arriving at their proper destination, they are directed towards an entity of the attackers' choosing, usually a server controlled by the attacker. The victim is often unaware that their messages are not being processed correctly. For example, a targeted client may believe they are connecting to their own bank but, in fact, be connecting to a Pharming site controlled by the attacker which then collects the user's login information in order to hijack the actual bank account." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/161.html> ;
-    :related :CWE-923 .
-
-:CAPEC-162 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulating Hidden Fields" ;
-    rdfs:subClassOf :CAPEC-77 ;
-    :capec-id "CAPEC-162" ;
-    :definition "An adversary exploits a weakness in the server's trust of client-side processing by modifying data on the client-side, such as price information, and then submitting this data to the server, which processes the modified data. For example, eShoplifting is a data manipulation attack against an on-line merchant during a purchasing transaction. The manipulation of price, discount or quantity fields in the transaction message allows the adversary to acquire items at a lower cost than the merchant intended. The adversary performs a normal purchasing transaction but edits hidden fields within the HTML form response that store price or other information to give themselves a better deal. The merchant then uses the modified pricing information in calculating the cost of the selected items." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/162.html> ;
-    :related :CWE-602 .
-
-:CAPEC-163 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Spear Phishing" ;
-    rdfs:subClassOf :CAPEC-98 ;
-    :capec-id "CAPEC-163" ;
-    :definition "An adversary targets a specific user or group with a Phishing (CAPEC-98) attack tailored to a category of users in order to have maximum relevance and deceptive capability. Spear Phishing is an enhanced version of the Phishing attack targeted to a specific user or group. The quality of the targeted email is usually enhanced by appearing to come from a known or trusted entity. If the email account of some trusted entity has been compromised the message may be digitally signed. The message will contain information specific to the targeted users that will enhance the probability that they will follow the URL to the compromised site. For example, the message may indicate knowledge of the targets employment, residence, interests, or other information that suggests familiarity. As soon as the user follows the instructions in the message, the attack proceeds as a standard Phishing attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/163.html> ;
-    :related :CWE-451,
-        :T1534,
-        :T1566.001,
-        :T1566.002,
-        :T1566.003,
-        :T1598.001,
-        :T1598.002,
-        :T1598.003 .
-
-:CAPEC-164 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Mobile Phishing" ;
-    rdfs:subClassOf :CAPEC-98 ;
-    :capec-id "CAPEC-164" ;
-    :definition "An adversary targets mobile phone users with a phishing attack for the purpose of soliciting account passwords or sensitive information from the user. Mobile Phishing is a variation of the Phishing social engineering technique where the attack is initiated via a text or SMS message, rather than email. The user is enticed to provide information or visit a compromised web site via this message. Apart from the manner in which the attack is initiated, the attack proceeds as a standard Phishing attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/164.html> ;
-    :related :CWE-451 .
-
-:CAPEC-165 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "File Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-165" ;
-    :definition "An attacker modifies file contents or attributes (such as extensions or names) of files in a manner to cause incorrect processing by an application. Attackers use this class of attacks to cause applications to enter unstable states, overwrite or expose sensitive information, and even execute arbitrary code with the application's privileges. This class of attacks differs from attacks on configuration information (even if file-based) in that file manipulation causes the file processing to result in non-standard behaviors, such as buffer overflows or use of the incorrect interpreter. Configuration attacks rely on the application interpreting files correctly in order to insert harmful configuration information. Likewise, resource location attacks rely on controlling an application's ability to locate files, whereas File Manipulation attacks do not require the application to look in a non-default location, although the two classes of attacks are often combined." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/165.html> ;
-    :related :T1036.003 .
-
-:CAPEC-166 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Force the System to Reset Values" ;
-    rdfs:subClassOf :CAPEC-161 ;
-    :capec-id "CAPEC-166" ;
-    :definition "An attacker forces the target into a previous state in order to leverage potential weaknesses in the target dependent upon a prior configuration or state-dependent factors. Even in cases where an attacker may not be able to directly control the configuration of the targeted application, they may be able to reset the configuration to a prior state since many applications implement reset functions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/166.html> ;
-    :related :CWE-306,
-        :CWE-1221,
-        :CWE-1232 .
-
-:CAPEC-167 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "White Box Reverse Engineering" ;
-    rdfs:subClassOf :CAPEC-188 ;
-    :capec-id "CAPEC-167" ;
-    :definition "An attacker discovers the structure, function, and composition of a type of computer software through white box analysis techniques. White box techniques involve methods which can be applied to a piece of software when an executable or some other compiled object can be directly subjected to analysis, revealing at least a portion of its machine instructions that can be observed upon execution." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/167.html> ;
-    :related :CWE-1323 .
-
-:CAPEC-168 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Windows ::DATA Alternate Data Stream" ;
-    rdfs:subClassOf :CAPEC-636 ;
-    :capec-id "CAPEC-168" ;
-    :definition "An attacker exploits the functionality of Microsoft NTFS Alternate Data Streams (ADS) to undermine system security. ADS allows multiple \"files\" to be stored in one directory entry referenced as filename:streamname. One or more alternate data streams may be stored in any file or directory. Normal Microsoft utilities do not show the presence of an ADS stream attached to a file. The additional space for the ADS is not recorded in the displayed file size. The additional space for ADS is accounted for in the used space on the volume. An ADS can be any type of file. ADS are copied by standard Microsoft utilities between NTFS volumes. ADS can be used by an attacker or intruder to hide tools, scripts, and data from detection by normal system utilities. Many anti-virus programs do not check for or scan ADS. Windows Vista does have a switch (-R) on the command line DIR command that will display alternate streams." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/168.html> ;
-    :related :CWE-69,
-        :CWE-212 .
-
-:CAPEC-169 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Footprinting" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-169" ;
-    :definition "An adversary engages in probing and exploration activities to identify constituents and properties of the target." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/169.html> ;
-    :related :CWE-200,
-        :T1217,
-        :T1592,
-        :T1595 .
-
-:CAPEC-170 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Web Application Fingerprinting" ;
-    rdfs:subClassOf :CAPEC-541 ;
-    :capec-id "CAPEC-170" ;
-    :definition "An attacker sends a series of probes to a web application in order to elicit version-dependent and type-dependent behavior that assists in identifying the target. An attacker could learn information such as software versions, error pages, and response headers, variations in implementations of the HTTP protocol, directory structures, and other similar information about the targeted service. This information can then be used by an attacker to formulate a targeted attack plan. While web application fingerprinting is not intended to be damaging (although certain activities, such as network scans, can sometimes cause disruptions to vulnerable applications inadvertently) it may often pave the way for more damaging attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/170.html> ;
-    :related :CWE-497 .
-
-:CAPEC-171 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Variable Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-77 : Manipulating User-Controlled Variables\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-171" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/171.html> .
-
-:CAPEC-173 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Action Spoofing" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-173" ;
-    :definition "An adversary is able to disguise one action for another and therefore trick a user into initiating one type of action when they intend to initiate a different action. For example, a user might be led to believe that clicking a button will submit a query, but in fact it downloads software. Adversaries may perform this attack through social means, such as by simply convincing a victim to perform the action or relying on a user's natural inclination to do so, or through technical means, such as a clickjacking attack where a user sees one interface but is actually interacting with a second, invisible, interface." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/173.html> ;
-    :related :CWE-451 .
-
-:CAPEC-174 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Flash Parameter Injection" ;
-    rdfs:subClassOf :CAPEC-182 ;
-    :capec-id "CAPEC-174" ;
-    :definition "An adversary takes advantage of improper data validation to inject malicious global parameters into a Flash file embedded within an HTML document. Flash files can leverage user-submitted data to configure the Flash document and access the embedding HTML document." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/174.html> ;
-    :related :CWE-88 .
-
-:CAPEC-175 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Code Inclusion" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-175" ;
-    :definition "An adversary exploits a weakness on the target to force arbitrary code to be retrieved locally or from a remote location and executed. This differs from code injection in that code injection involves the direct inclusion of code while code inclusion involves the addition or replacement of a reference to a code file, which is subsequently loaded by the target and used as part of the code of some application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/175.html> ;
-    :related :CWE-829 .
-
-:CAPEC-176 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Configuration/Environment Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-176" ;
-    :definition "An attacker manipulates files or settings external to a target application which affect the behavior of that application. For example, many applications use external configuration files and libraries - modification of these entities or otherwise affecting the application's ability to use them would constitute a configuration/environment manipulation attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/176.html> ;
-    :related :CWE-15,
-        :CWE-1233,
-        :CWE-1234,
-        :CWE-1304,
-        :CWE-1328 .
-
-:CAPEC-177 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Create files with the same name as files protected with a higher classification" ;
-    rdfs:subClassOf :CAPEC-17 ;
-    :capec-id "CAPEC-177" ;
-    :definition "An attacker exploits file location algorithms in an operating system or application by creating a file with the same name as a protected or privileged file. The attacker could manipulate the system if the attacker-created file is trusted by the operating system or an application component that attempts to load the original file. Applications often load or include external files, such as libraries or configuration files. These files should be protected against malicious manipulation. However, if the application only uses the name of the file when locating it, an attacker may be able to create a file with the same name and place it in a directory that the application will search before the directory with the legitimate file is searched. Because the attackers' file is discovered first, it would be used by the target application. This attack can be extremely destructive if the referenced file is executable and/or is granted special privileges based solely on having a particular name." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/177.html> ;
-    :related :CWE-706,
-        :T1036 .
-
-:CAPEC-178 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross-Site Flashing" ;
-    rdfs:subClassOf :CAPEC-182 ;
-    :capec-id "CAPEC-178" ;
-    :definition "An attacker is able to trick the victim into executing a Flash document that passes commands or calls to a Flash player browser plugin, allowing the attacker to exploit native Flash functionality in the client browser. This attack pattern occurs where an attacker can provide a crafted link to a Flash document (SWF file) which, when followed, will cause additional malicious instructions to be executed. The attacker does not need to serve or control the Flash document. The attack takes advantage of the fact that Flash files can reference external URLs. If variables that serve as URLs that the Flash application references can be controlled through parameters, then by creating a link that includes values for those parameters, an attacker can cause arbitrary content to be referenced and possibly executed by the targeted Flash application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/178.html> ;
-    :related :CWE-601 .
-
-:CAPEC-179 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Calling Micro-Services Directly" ;
-    rdfs:subClassOf :CAPEC-554 ;
-    :capec-id "CAPEC-179" ;
-    :definition "An attacker is able to discover and query Micro-services at a web location and thereby expose the Micro-services to further exploitation by gathering information about their implementation and function. Micro-services in web pages allow portions of a page to connect to the server and update content without needing to cause the entire page to update. This allows user activity to change portions of the page more quickly without causing disruptions elsewhere." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/179.html> .
-
-:CAPEC-180 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploiting Incorrectly Configured Access Control Security Levels" ;
-    rdfs:subClassOf :CAPEC-122 ;
-    :capec-id "CAPEC-180" ;
-    :definition "An attacker exploits a weakness in the configuration of access controls and is able to bypass the intended protection that these measures guard against and thereby obtain unauthorized access to the system or network. Sensitive functionality should always be protected with access controls. However configuring all but the most trivial access control systems can be very complicated and there are many opportunities for mistakes. If an attacker can learn of incorrectly configured access security settings, they may be able to exploit this in an attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/180.html> ;
-    :related :CAPEC-663,
-        :CWE-732,
-        :CWE-1190,
-        :CWE-1191,
-        :CWE-1193,
-        :CWE-1220,
-        :CWE-1268,
-        :CWE-1280,
-        :CWE-1297,
-        :CWE-1311,
-        :CWE-1315,
-        :CWE-1318,
-        :CWE-1320,
-        :CWE-1321,
-        :T1574.010 .
-
-:CAPEC-181 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Flash File Overlay" ;
-    rdfs:subClassOf :CAPEC-103 ;
-    :capec-id "CAPEC-181" ;
-    :definition "An attacker creates a transparent overlay using flash in order to intercept user actions for the purpose of performing a clickjacking attack. In this technique, the Flash file provides a transparent overlay over HTML content. Because the Flash application is on top of the content, user actions, such as clicks, are caught by the Flash application rather than the underlying HTML. The action is then interpreted by the overlay to perform the actions the attacker wishes." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/181.html> ;
-    :related :CWE-1021 .
-
-:CAPEC-182 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Flash Injection" ;
-    rdfs:subClassOf :CAPEC-137 ;
-    :capec-id "CAPEC-182" ;
-    :definition "An attacker tricks a victim to execute malicious flash content that executes commands or makes flash calls specified by the attacker. One example of this attack is cross-site flashing, an attacker controlled parameter to a reference call loads from content specified by the attacker." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/182.html> ;
-    :related :CWE-20,
-        :CWE-184,
-        :CWE-697 .
-
-:CAPEC-183 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "IMAP/SMTP Command Injection" ;
-    rdfs:subClassOf :CAPEC-248 ;
-    :capec-id "CAPEC-183" ;
-    :definition "An adversary exploits weaknesses in input validation on web-mail servers to execute commands on the IMAP/SMTP server. Web-mail servers often sit between the Internet and the IMAP or SMTP mail server. User requests are received by the web-mail servers which then query the back-end mail server for the requested information and return this response to the user. In an IMAP/SMTP command injection attack, mail-server commands are embedded in parts of the request sent to the web-mail server. If the web-mail server fails to adequately sanitize these requests, these commands are then sent to the back-end mail server when it is queried by the web-mail server, where the commands are then executed. This attack can be especially dangerous since administrators may assume that the back-end server is protected against direct Internet access and therefore may not secure it adequately against the execution of malicious commands." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/183.html> ;
-    :related :CWE-77 .
-
-:CAPEC-184 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Software Integrity Attack" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-184" ;
-    :definition "An attacker initiates a series of events designed to cause a user, program, server, or device to perform actions which undermine the integrity of software code, device data structures, or device firmware, achieving the modification of the target's integrity to achieve an insecure state." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/184.html> ;
-    :related :CWE-494 .
-
-:CAPEC-185 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Software Download" ;
-    rdfs:subClassOf :CAPEC-184 ;
-    :capec-id "CAPEC-185" ;
-    :definition "An attacker uses deceptive methods to cause a user or an automated process to download and install dangerous code that originates from an attacker controlled source. There are several variations to this strategy of attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/185.html> ;
-    :related :CWE-494 .
-
-:CAPEC-186 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Software Update" ;
-    rdfs:subClassOf :CAPEC-184 ;
-    :capec-id "CAPEC-186" ;
-    :definition "An adversary uses deceptive methods to cause a user or an automated process to download and install dangerous code believed to be a valid update that originates from an adversary controlled source." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/186.html> ;
-    :related :CWE-494,
-        :T1195.002 .
-
-:CAPEC-187 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Automated Software Update via Redirection" ;
-    rdfs:subClassOf :CAPEC-186 ;
-    :capec-id "CAPEC-187" ;
-    :definition "An attacker exploits two layers of weaknesses in server or client software for automated update mechanisms to undermine the integrity of the target code-base. The first weakness involves a failure to properly authenticate a server as a source of update or patch content. This type of weakness typically results from authentication mechanisms which can be defeated, allowing a hostile server to satisfy the criteria that establish a trust relationship. The second weakness is a systemic failure to validate the identity and integrity of code downloaded from a remote location, hence the inability to distinguish malicious code from a legitimate update." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/187.html> ;
-    :related :CWE-494,
-        :T1072 .
-
-:CAPEC-188 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Reverse Engineering" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-188" ;
-    :definition "An adversary discovers the structure, function, and composition of an object, resource, or system by using a variety of analysis techniques to effectively determine how the analyzed entity was constructed or operates. The goal of reverse engineering is often to duplicate the function, or a part of the function, of an object in order to duplicate or \"back engineer\" some aspect of its functioning. Reverse engineering techniques can be applied to mechanical objects, electronic devices, or software, although the methodology and techniques involved in each type of analysis differ widely." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/188.html> ;
-    :related :CWE-1278 .
-
-:CAPEC-189 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Black Box Reverse Engineering" ;
-    rdfs:subClassOf :CAPEC-188 ;
-    :capec-id "CAPEC-189" ;
-    :definition "An adversary discovers the structure, function, and composition of a type of computer software through black box analysis techniques. 'Black Box' methods involve interacting with the software indirectly, in the absence of direct access to the executable object. Such analysis typically involves interacting with the software at the boundaries of where the software interfaces with a larger execution environment, such as input-output vectors, libraries, or APIs. Black Box Reverse Engineering also refers to gathering physical side effects of a hardware device, such as electromagnetic radiation or sounds." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/189.html> ;
-    :related :CWE-203,
-        :CWE-1255,
-        :CWE-1300 .
-
-:CAPEC-190 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Reverse Engineer an Executable to Expose Assumed Hidden Functionality" ;
-    rdfs:subClassOf :CAPEC-167 ;
-    :capec-id "CAPEC-190" ;
-    :definition "An attacker analyzes a binary file or executable for the purpose of discovering the structure, function, and possibly source-code of the file by using a variety of analysis techniques to effectively determine how the software functions and operates. This type of analysis is also referred to as Reverse Code Engineering, as techniques exist for extracting source code from an executable. Several techniques are often employed for this purpose, both black box and white box. The use of computer bus analyzers and packet sniffers allows the binary to be studied at a level of interactions with its computing environment, such as a host OS, inter-process communication, and/or network communication. This type of analysis falls into the 'black box' category because it involves behavioral analysis of the software without reference to source code, object code, or protocol specifications." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/190.html> ;
-    :related :CWE-912 .
-
-:CAPEC-191 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Read Sensitive Constants Within an Executable" ;
-    rdfs:subClassOf :CAPEC-167 ;
-    :capec-id "CAPEC-191" ;
-    :definition "An adversary engages in activities to discover any sensitive constants present within the compiled code of an executable. These constants may include literal ASCII strings within the file itself, or possibly strings hard-coded into particular routines that can be revealed by code refactoring methods including static and dynamic analysis." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/191.html> ;
-    :related :CWE-798,
-        :T1552.001 .
-
-:CAPEC-192 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Protocol Analysis" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-192" ;
-    :definition "An adversary engages in activities to decipher and/or decode protocol information for a network or application communication protocol used for transmitting information between interconnected nodes or systems on a packet-switched data network. While this type of analysis involves the analysis of a networking protocol inherently, it does not require the presence of an actual or physical network." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/192.html> ;
-    :related :CWE-326 .
-
-:CAPEC-193 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "PHP Remote File Inclusion" ;
-    rdfs:subClassOf :CAPEC-253 ;
-    :capec-id "CAPEC-193" ;
-    :definition "In this pattern the adversary is able to load and execute arbitrary code remotely available from the application. This is usually accomplished through an insecurely configured PHP runtime environment and an improperly sanitized \"include\" or \"require\" call, which the user can then control to point to any web-accessible file. This allows adversaries to hijack the targeted application and force it to execute their own instructions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/193.html> ;
-    :related :CWE-80,
-        :CWE-98 .
-
-:CAPEC-194 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Fake the Source of Data" ;
-    rdfs:subClassOf :CAPEC-151 ;
-    :capec-id "CAPEC-194" ;
-    :definition "An adversary takes advantage of improper authentication to provide data or services under a falsified identity. The purpose of using the falsified identity may be to prevent traceability of the provided data or to assume the rights granted to another individual. One of the simplest forms of this attack would be the creation of an email message with a modified \"From\" field in order to appear that the message was sent from someone other than the actual sender. The root of the attack (in this case the email system) fails to properly authenticate the source and this results in the reader incorrectly performing the instructed action. Results of the attack vary depending on the details of the attack, but common results include privilege escalation, obfuscation of other attacks, and data corruption/manipulation." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/194.html> ;
-    :related :CWE-287 .
-
-:CAPEC-195 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Principal Spoof" ;
-    rdfs:subClassOf :CAPEC-151 ;
-    :capec-id "CAPEC-195" ;
-    :definition "A Principal Spoof is a form of Identity Spoofing where an adversary pretends to be some other person in an interaction. This is often accomplished by crafting a message (either written, verbal, or visual) that appears to come from a person other than the adversary. Phishing and Pharming attacks often attempt to do this so that their attempts to gather sensitive information appear to come from a legitimate source. A Principal Spoof does not use stolen or spoofed authentication credentials, instead relying on the appearance and content of the message to reflect identity." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/195.html> .
-
-:CAPEC-196 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Session Credential Falsification through Forging" ;
-    rdfs:subClassOf :CAPEC-21 ;
-    :capec-id "CAPEC-196" ;
-    :definition "An attacker creates a false but functional session credential in order to gain or usurp access to a service. Session credentials allow users to identify themselves to a service after an initial authentication without needing to resend the authentication information (usually a username and password) with every message. If an attacker is able to forge valid session credentials they may be able to bypass authentication or piggy-back off some other authenticated user's session. This attack differs from Reuse of Session IDs and Session Sidejacking attacks in that in the latter attacks an attacker uses a previous or existing credential without modification while, in a forging attack, the attacker must create their own credential, although it may be based on previously observed credentials." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/196.html> ;
-    :related :CWE-384,
-        :CWE-664,
-        :T1134.002,
-        :T1134.003,
-        :T1606 .
-
-:CAPEC-197 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exponential Data Expansion" ;
-    rdfs:subClassOf :CAPEC-230 ;
-    :capec-id "CAPEC-197" ;
-    :definition "An adversary submits data to a target application which contains nested exponential data expansion to produce excessively large output. Many data format languages allow the definition of macro-like structures that can be used to simplify the creation of complex structures. However, this capability can be abused to create excessive demands on a processor's CPU and memory. A small number of nested expansions can result in an exponential growth in demands on memory." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/197.html> ;
-    :related :CWE-770,
-        :CWE-776 .
-
-:CAPEC-198 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Targeting Error Pages" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-198" ;
-    :definition "An adversary distributes a link (or possibly some other query structure) with a request to a third party web server that is malformed and also contains a block of exploit code in order to have the exploit become live code in the resulting error page." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/198.html> ;
-    :related :CWE-81 .
-
-:CAPEC-199 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Using Alternate Syntax" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-199" ;
-    :definition "An adversary uses alternate forms of keywords or commands that result in the same action as the primary form but which may not be caught by filters. For example, many keywords are processed in a case insensitive manner. If the site's web filtering algorithm does not convert all tags into a consistent case before the comparison with forbidden keywords it is possible to bypass filters (e.g., incomplete black lists) by using an alternate case structure. For example, the \"script\" tag using the alternate forms of \"Script\" or \"ScRiPt\" may bypass filters where \"script\" is the only form tested. Other variants using different syntax representations are also possible as well as using pollution meta-characters or entities that are eventually ignored by the rendering engine. The attack can result in the execution of otherwise prohibited functionality." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/199.html> ;
-    :related :CWE-87 .
-
-:CAPEC-200 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Removal of filters: Input filters, output filters, data masking" ;
-    rdfs:subClassOf :CAPEC-207 ;
-    :capec-id "CAPEC-200" ;
-    :definition "An attacker removes or disables filtering mechanisms on the target application. Input filters prevent invalid data from being sent to an application (for example, overly large inputs that might cause a buffer overflow or other malformed inputs that may not be correctly handled by an application). Input filters might also be designed to constrained executable content." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/200.html> .
-
-:CAPEC-201 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Serialized Data External Linking" ;
-    rdfs:subClassOf :CAPEC-122,
-        :CAPEC-278 ;
-    :capec-id "CAPEC-201" ;
-    :definition "An adversary creates a serialized data file (e.g. XML, YAML, etc...) that contains an external data reference. Because serialized data parsers may not validate documents with external references, there may be no checks on the nature of the reference in the external data. This can allow an adversary to open arbitrary files or connections, which may further lead to the adversary gaining access to information on the system that they would normally be unable to obtain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/201.html> ;
-    :related :CWE-829 .
-
-:CAPEC-202 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Create Malicious Client" ;
-    rdfs:subClassOf :CAPEC-22 ;
-    :capec-id "CAPEC-202" ;
-    :definition "An adversary creates a client application to interface with a target service where the client violates assumptions the service makes about clients. Services that have designated client applications (as opposed to services that use general client applications, such as IMAP or POP mail servers which can interact with any IMAP or POP client) may assume that the client will follow specific procedures." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/202.html> ;
-    :related :CWE-602 .
-
-:CAPEC-203 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulate Registry Information" ;
-    rdfs:subClassOf :CAPEC-176 ;
-    :capec-id "CAPEC-203" ;
-    :definition "An adversary exploits a weakness in authorization in order to modify content within a registry (e.g., Windows Registry, Mac plist, application registry). Editing registry information can permit the adversary to hide configuration information or remove indicators of compromise to cover up activity. Many applications utilize registries to store configuration and service information. As such, modification of registry information can affect individual services (affecting billing, authorization, or even allowing for identity spoofing) or the overall configuration of a targeted application. For example, both Java RMI and SOAP use registries to track available services. Changing registry values is sometimes a preliminary step towards completing another attack pattern, but given the long term usage of many registry values, manipulation of registry information could be its own end." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/203.html> ;
-    :related :CWE-15,
-        :T1112,
-        :T1647 .
-
-:CAPEC-204 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Lifting Sensitive Data Embedded in Cache" ;
-    rdfs:subClassOf :CAPEC-167 ;
-    :capec-id "CAPEC-204" ;
-    :definition "An adversary examines a target application's cache, or a browser cache, for sensitive information. Many applications that communicate with remote entities or which perform intensive calculations utilize caches to improve efficiency. However, if the application computes or receives sensitive information and the cache is not appropriately protected, an attacker can browse the cache and retrieve this information. This can result in the disclosure of sensitive information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/204.html> ;
-    :related :CWE-311,
-        :CWE-524,
-        :CWE-1239,
-        :CWE-1258,
-        :T1005 .
-
-:CAPEC-205 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Lifting credential(s)/key material embedded in client distributions (thick or thin)" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-37 : Retrieve Embedded Sensitive Data. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-205" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/205.html> .
-
-:CAPEC-206 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signing Malicious Code" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-206" ;
-    :definition "The adversary extracts credentials used for code signing from a production environment and then uses these credentials to sign malicious content with the developer's key. Many developers use signing keys to sign code or hashes of code. When users or applications verify the signatures are accurate they are led to believe that the code came from the owner of the signing key and that the code has not been modified since the signature was applied. If the adversary has extracted the signing credentials then they can use those credentials to sign their own code bundles. Users or tools that verify the signatures attached to the code will likely assume the code came from the legitimate developer and install or run the code, effectively allowing the adversary to execute arbitrary code on the victim's computer. This differs from CAPEC-673, because the adversary is performing the code signing." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/206.html> ;
-    :related :CWE-732,
-        :T1553.002 .
-
-:CAPEC-207 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Removing Important Client Functionality" ;
-    rdfs:subClassOf :CAPEC-22 ;
-    :capec-id "CAPEC-207" ;
-    :definition "An adversary removes or disables functionality on the client that the server assumes to be present and trustworthy." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/207.html> ;
-    :related :CWE-602 .
-
-:CAPEC-208 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Removing/short-circuiting 'Purse' logic: removing/mutating 'cash' decrements" ;
-    rdfs:subClassOf :CAPEC-207 ;
-    :capec-id "CAPEC-208" ;
-    :definition "An attacker removes or modifies the logic on a client associated with monetary calculations resulting in incorrect information being sent to the server. A server may rely on a client to correctly compute monetary information. For example, a server might supply a price for an item and then rely on the client to correctly compute the total cost of a purchase given the number of items the user is buying. If the attacker can remove or modify the logic that controls these calculations, they can return incorrect values to the server. The attacker can use this to make purchases for a fraction of the legitimate cost or otherwise avoid correct billing for activities." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/208.html> ;
-    :related :CWE-602 .
-
-:CAPEC-209 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Using MIME Type Mismatch" ;
-    rdfs:subClassOf :CAPEC-592 ;
-    :capec-id "CAPEC-209" ;
-    :definition "An adversary creates a file with scripting content but where the specified MIME type of the file is such that scripting is not expected. The adversary tricks the victim into accessing a URL that responds with the script file. Some browsers will detect that the specified MIME type of the file does not match the actual type of its content and will automatically switch to using an interpreter for the real content type. If the browser does not invoke script filters before doing this, the adversary's script may run on the target unsanitized, possibly revealing the victim's cookies or executing arbitrary script in their browser." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/209.html> ;
-    :related :CWE-20,
-        :CWE-79,
-        :CWE-646 .
-
-:CAPEC-211 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Leveraging web tools (e.g. Mozilla's GreaseMonkey, Firebug) to change application behavior" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern." ;
-    :capec-id "CAPEC-211" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/211.html> .
-
-:CAPEC-212 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Functionality Misuse" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-212" ;
-    :definition "An adversary leverages a legitimate capability of an application in such a way as to achieve a negative technical impact. The system functionality is not altered or modified but used in a way that was not intended. This is often accomplished through the overuse of a specific functionality or by leveraging functionality with design flaws that enables the adversary to gain access to unauthorized, sensitive data." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/212.html> ;
-    :related :CAPEC-663,
-        :CWE-1242,
-        :CWE-1246,
-        :CWE-1281 .
-
-:CAPEC-213 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Directory Traversal" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-126 : Path Traversal\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-213" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/213.html> .
-
-:CAPEC-214 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Fuzzing for garnering J2EE/.NET-based stack traces, for application mapping" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was merged into \"CAPEC-215 : Fuzzing for application mapping\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-214" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/214.html> .
-
-:CAPEC-215 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Fuzzing for application mapping" ;
-    rdfs:subClassOf :CAPEC-28,
-        :CAPEC-54 ;
-    :capec-id "CAPEC-215" ;
-    :definition "An attacker sends random, malformed, or otherwise unexpected messages to a target application and observes the application's log or error messages returned. The attacker does not initially know how a target will respond to individual messages but by attempting a large number of message variants they may find a variant that trigger's desired behavior. In this attack, the purpose of the fuzzing is to observe the application's log and error messages, although fuzzing a target can also sometimes cause the target to enter an unstable state, causing a crash." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/215.html> ;
-    :related :CWE-209,
-        :CWE-532 .
-
-:CAPEC-216 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Communication Channel Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-216" ;
-    :definition "An adversary manipulates a setting or parameter on communications channel in order to compromise its security. This can result in information exposure, insertion/removal of information from the communications stream, and/or potentially system compromise." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/216.html> ;
-    :related :CWE-306 .
-
-:CAPEC-217 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploiting Incorrectly Configured SSL/TLS" ;
-    rdfs:subClassOf :CAPEC-216 ;
-    :capec-id "CAPEC-217" ;
-    :definition "An adversary takes advantage of incorrectly configured SSL/TLS communications that enables access to data intended to be encrypted. The adversary may also use this type of attack to inject commands or other traffic into the encrypted stream to cause compromise of either the client or server." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/217.html> ;
-    :related :CWE-201 .
-
-:CAPEC-218 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Spoofing of UDDI/ebXML Messages" ;
-    rdfs:subClassOf :CAPEC-148 ;
-    :capec-id "CAPEC-218" ;
-    :definition "An attacker spoofs a UDDI, ebXML, or similar message in order to impersonate a service provider in an e-business transaction. UDDI, ebXML, and similar standards are used to identify businesses in e-business transactions. Among other things, they identify a particular participant, WSDL information for SOAP transactions, and supported communication protocols, including security protocols. By spoofing one of these messages an attacker could impersonate a legitimate business in a transaction or could manipulate the protocols used between a client and business. This could result in disclosure of sensitive information, loss of message integrity, or even financial fraud." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/218.html> ;
-    :related :CWE-345 .
-
-:CAPEC-219 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XML Routing Detour Attacks" ;
-    rdfs:subClassOf :CAPEC-94 ;
-    :capec-id "CAPEC-219" ;
-    :definition "An attacker subverts an intermediate system used to process XML content and forces the intermediate to modify and/or re-route the processing of the content. XML Routing Detour Attacks are Adversary in the Middle type attacks (CAPEC-94). The attacker compromises or inserts an intermediate system in the processing of the XML message. For example, WS-Routing can be used to specify a series of nodes or intermediaries through which content is passed. If any of the intermediate nodes in this route are compromised by an attacker they could be used for a routing detour attack. From the compromised system the attacker is able to route the XML process to other nodes of their choice and modify the responses so that the normal chain of processing is unaware of the interception. This system can forward the message to an outside entity and hide the forwarding and processing from the legitimate processing systems by altering the header information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/219.html> ;
-    :related :CWE-441,
-        :CWE-610 .
-
-:CAPEC-220 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Client-Server Protocol Manipulation" ;
-    rdfs:subClassOf :CAPEC-272 ;
-    :capec-id "CAPEC-220" ;
-    :definition "An adversary takes advantage of weaknesses in the protocol by which a client and server are communicating to perform unexpected actions. Communication protocols are necessary to transfer messages between client and server applications. Moreover, different protocols may be used for different types of interactions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/220.html> ;
-    :related :CWE-757 .
-
-:CAPEC-221 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Data Serialization External Entities Blowup" ;
-    rdfs:subClassOf :CAPEC-231,
-        :CAPEC-278 ;
-    :capec-id "CAPEC-221" ;
-    :definition "This attack takes advantage of the entity replacement property of certain data serialization languages (e.g., XML, YAML, etc.) where the value of the replacement is a URI. A well-crafted file could have the entity refer to a URI that consumes a large amount of resources to create a denial of service condition. This can cause the system to either freeze, crash, or execute arbitrary code depending on the URI." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/221.html> ;
-    :related :CWE-611 .
-
-:CAPEC-222 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "iFrame Overlay" ;
-    rdfs:subClassOf :CAPEC-103 ;
-    :capec-id "CAPEC-222" ;
-    :definition "In an iFrame overlay attack the victim is tricked into unknowingly initiating some action in one system while interacting with the UI from seemingly completely different system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/222.html> ;
-    :related :CWE-1021 .
-
-:CAPEC-224 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Fingerprinting" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-224" ;
-    :definition "An adversary compares output from a target system to known indicators that uniquely identify specific details about the target. Most commonly, fingerprinting is done to determine operating system and application versions. Fingerprinting can be done passively as well as actively. Fingerprinting by itself is not usually detrimental to the target. However, the information gathered through fingerprinting often enables an adversary to discover existing weaknesses in the target." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/224.html> ;
-    :related :CWE-200 .
-
-:CAPEC-226 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Session Credential Falsification through Manipulation" ;
-    rdfs:subClassOf :CAPEC-196 ;
-    :capec-id "CAPEC-226" ;
-    :definition "An attacker manipulates an existing credential in order to gain access to a target application. Session credentials allow users to identify themselves to a service after an initial authentication without needing to resend the authentication information (usually a username and password) with every message. An attacker may be able to manipulate a credential sniffed from an existing connection in order to gain access to a target server." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/226.html> ;
-    :related :CWE-472,
-        :CWE-565 .
-
-:CAPEC-227 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Sustained Client Engagement" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-227" ;
-    :definition "An adversary attempts to deny legitimate users access to a resource by continually engaging a specific resource in an attempt to keep the resource tied up as long as possible. The adversary's primary goal is not to crash or flood the target, which would alert defenders; rather it is to repeatedly perform actions or abuse algorithmic flaws such that a given resource is tied up and not available to a legitimate user. By carefully crafting a requests that keep the resource engaged through what is seemingly benign requests, legitimate users are limited or completely denied access to the resource." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/227.html> ;
-    :related :CWE-400,
-        :T1499 .
-
-:CAPEC-228 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DTD Injection" ;
-    rdfs:subClassOf :CAPEC-250 ;
-    :capec-id "CAPEC-228" ;
-    :definition "An attacker injects malicious content into an application's DTD in an attempt to produce a negative technical impact. DTDs are used to describe how XML documents are processed. Certain malformed DTDs (for example, those with excessive entity expansion as described in CAPEC 197) can cause the XML parsers that process the DTDs to consume excessive resources resulting in resource depletion." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/228.html> ;
-    :related :CWE-829 .
-
-:CAPEC-229 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Serialized Data Parameter Blowup" ;
-    rdfs:subClassOf :CAPEC-231 ;
-    :capec-id "CAPEC-229" ;
-    :definition "This attack exploits certain serialized data parsers (e.g., XML, YAML, etc.) which manage data in an inefficient manner. The attacker crafts an serialized data file with multiple configuration parameters in the same dataset. In a vulnerable parser, this results in a denial of service condition where CPU resources are exhausted because of the parsing algorithm. The weakness being exploited is tied to parser implementation and not language specific." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/229.html> ;
-    :related :CWE-770 .
-
-:CAPEC-230 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Serialized Data with Nested Payloads" ;
-    rdfs:subClassOf :CAPEC-130 ;
-    :capec-id "CAPEC-230" ;
-    :definition "Applications often need to transform data in and out of a data format (e.g., XML and YAML) by using a parser. It may be possible for an adversary to inject data that may have an adverse effect on the parser when it is being processed. Many data format languages allow the definition of macro-like structures that can be used to simplify the creation of complex structures. By nesting these structures, causing the data to be repeatedly substituted, an adversary can cause the parser to consume more resources while processing, causing excessive memory consumption and CPU utilization." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/230.html> ;
-    :related :CWE-20,
-        :CWE-112,
-        :CWE-674,
-        :CWE-770 .
-
-:CAPEC-231 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Oversized Serialized Data Payloads" ;
-    rdfs:subClassOf :CAPEC-130 ;
-    :capec-id "CAPEC-231" ;
-    :definition "An adversary injects oversized serialized data payloads into a parser during data processing to produce adverse effects upon the parser such as exhausting system resources and arbitrary code execution." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/231.html> ;
-    :related :CWE-20,
-        :CWE-112,
-        :CWE-674,
-        :CWE-770 .
-
-:CAPEC-233 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Privilege Escalation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-233" ;
-    :definition "An adversary exploits a weakness enabling them to elevate their privilege and perform an action that they are not supposed to be authorized to perform." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/233.html> ;
-    :related :CWE-269,
-        :CWE-1264,
-        :CWE-1311,
-        :T1548 .
-
-:CAPEC-234 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hijacking a privileged process" ;
-    rdfs:subClassOf :CAPEC-233 ;
-    :capec-id "CAPEC-234" ;
-    :definition "An adversary gains control of a process that is assigned elevated privileges in order to execute arbitrary code with those privileges. Some processes are assigned elevated privileges on an operating system, usually through association with a particular user, group, or role. If an attacker can hijack this process, they will be able to assume its level of privilege in order to execute their own code." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/234.html> ;
-    :related :CWE-648,
-        :CWE-732 .
-
-:CAPEC-235 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Implementing a callback to system routine (old AWT Queue)" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated. Please refer to CAPEC:30 - Hijacking a Privileged Thread of Execution." ;
-    :capec-id "CAPEC-235" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/235.html> .
-
-:CAPEC-236 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Catching exception throw/signal from privileged block" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it did not have enough distinction from CAPEC-30 : Hijacking a Privileged Thread of Execution. Please refer to CAPEC-30 moving forward." ;
-    :capec-id "CAPEC-236" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/236.html> .
-
-:CAPEC-237 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Escaping a Sandbox by Calling Code in Another Language" ;
-    rdfs:subClassOf :CAPEC-480 ;
-    :capec-id "CAPEC-237" ;
-    :definition "The attacker may submit malicious code of another language to obtain access to privileges that were not intentionally exposed by the sandbox, thus escaping the sandbox. For instance, Java code cannot perform unsafe operations, such as modifying arbitrary memory locations, due to restrictions placed on it by the Byte code Verifier and the JVM. If allowed, Java code can call directly into native C code, which may perform unsafe operations, such as call system calls and modify arbitrary memory locations on their behalf. To provide isolation, Java does not grant untrusted code with unmediated access to native C code. Instead, the sandboxed code is typically allowed to call some subset of the pre-existing native code that is part of standard libraries." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/237.html> ;
-    :related :CWE-693 .
-
-:CAPEC-238 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Using URL/codebase / G.A.C. (code source) to convince sandbox of privilege" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it did not appear to be a valid attack pattern." ;
-    :capec-id "CAPEC-238" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/238.html> .
-
-:CAPEC-239 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Subversion of Authorization Checks: Cache Filtering, Programmatic Security, etc." ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it did not contain any content and did not serve any useful purpose. Please refer to \"CAPEC-207: removing Important Client Functionality\" going forward." ;
-    :capec-id "CAPEC-239" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/239.html> .
-
-:CAPEC-240 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Resource Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-240" ;
-    :definition "An adversary exploits weaknesses in input validation by manipulating resource identifiers enabling the unintended modification or specification of a resource." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/240.html> ;
-    :related :CWE-99 .
-
-:CAPEC-241 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Code Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-242 : Code Injection\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-241" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/241.html> .
-
-:CAPEC-242 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Code Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-242" ;
-    :definition "An adversary exploits a weakness in input validation on the target to inject new code into that which is currently executing. This differs from code inclusion in that code inclusion involves the addition or replacement of a reference to a code file, which is subsequently loaded by the target and used as part of the code of some application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/242.html> ;
-    :related :CWE-94 .
-
-:CAPEC-243 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Targeting HTML Attributes" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-243" ;
-    :definition "An adversary inserts commands to perform cross-site scripting (XSS) actions in HTML attributes. Many filters do not adequately sanitize attributes against the presence of potentially dangerous commands even if they adequately sanitize tags. For example, dangerous expressions could be inserted into a style attribute in an anchor tag, resulting in the execution of malicious code when the resulting page is rendered. If a victim is tricked into viewing the rendered page the attack proceeds like a normal XSS attack, possibly resulting in the loss of sensitive cookies or other malicious activities." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/243.html> ;
-    :related :CWE-83 .
-
-:CAPEC-244 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Targeting URI Placeholders" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-244" ;
-    :definition "An attack of this type exploits the ability of most browsers to interpret \"data\", \"javascript\" or other URI schemes as client-side executable content placeholders. This attack consists of passing a malicious URI in an anchor tag HREF attribute or any other similar attributes in other HTML tags. Such malicious URI contains, for example, a base64 encoded HTML content with an embedded cross-site scripting payload. The attack is executed when the browser interprets the malicious content i.e., for example, when the victim clicks on the malicious link." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/244.html> ;
-    :related :CWE-83 .
-
-:CAPEC-245 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Using Doubled Characters" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-245" ;
-    :definition "The adversary bypasses input validation by using doubled characters in order to perform a cross-site scripting attack. Some filters fail to recognize dangerous sequences if they are preceded by repeated characters. For example, by doubling the < before a script command, (<<script or %3C%3script using URI encoding) the filters of some web applications may fail to recognize the presence of a script tag. If the targeted server is vulnerable to this type of bypass, the adversary can create a crafted URL or other trap to cause a victim to view a page on the targeted server where the malicious content is executed, as per a normal XSS attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/245.html> ;
-    :related :CWE-85 .
-
-:CAPEC-246 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: XSS Using Flash" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This pattern has been deprecated as it is covered by a chaining relationship between CAPEC-174: Flash Parameter Injection and CAPEC-591: Stored XSS. Please refer to these CAPECs going forward." ;
-    :capec-id "CAPEC-246" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/246.html> .
-
-:CAPEC-247 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XSS Using Invalid Characters" ;
-    rdfs:subClassOf :CAPEC-588,
-        :CAPEC-591,
-        :CAPEC-592 ;
-    :capec-id "CAPEC-247" ;
-    :definition "An adversary inserts invalid characters in identifiers to bypass application filtering of input. Filters may not scan beyond invalid characters but during later stages of processing content that follows these invalid characters may still be processed. This allows the adversary to sneak prohibited commands past filters and perform normally prohibited operations. Invalid characters may include null, carriage return, line feed or tab in an identifier. Successful bypassing of the filter can result in a XSS attack, resulting in the disclosure of web cookies or possibly other results." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/247.html> ;
-    :related :CWE-86 .
-
-:CAPEC-248 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Command Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-248" ;
-    :definition "An adversary looking to execute a command of their choosing, injects new items into an existing command thus modifying interpretation away from what was intended. Commands in this context are often standalone strings that are interpreted by a downstream component and cause specific responses. This type of attack is possible when untrusted values are used to build these command strings. Weaknesses in input validation or command construction can enable the attack and lead to successful exploitation." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/248.html> ;
-    :related :CWE-77 .
-
-:CAPEC-249 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Linux Terminal Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is covered by \"CAPEC-40 : Manipulating Writeable Terminal Devices\". Please refer to this CAPEC going forward." ;
-    :capec-id "CAPEC-249" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/249.html> .
-
-:CAPEC-250 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XML Injection" ;
-    rdfs:subClassOf :CAPEC-248 ;
-    :capec-id "CAPEC-250" ;
-    :definition "An attacker utilizes crafted XML user-controllable input to probe, attack, and inject data into the XML database, using techniques similar to SQL injection. The user-controllable input can allow for unauthorized viewing of data, bypassing authentication or the front-end application for direct XML database access, and possibly altering database information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/250.html> ;
-    :related :CWE-20,
-        :CWE-74,
-        :CWE-91,
-        :CWE-707 .
-
-:CAPEC-251 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Local Code Inclusion" ;
-    rdfs:subClassOf :CAPEC-175 ;
-    :capec-id "CAPEC-251" ;
-    :definition "The attacker forces an application to load arbitrary code files from the local machine. The attacker could use this to try to load old versions of library files that have known vulnerabilities, to load files that the attacker placed on the local machine during a prior attack, or to otherwise change the functionality of the targeted application in unexpected ways." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/251.html> ;
-    :related :CWE-829,
-        :T1055 .
-
-:CAPEC-252 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "PHP Local File Inclusion" ;
-    rdfs:subClassOf :CAPEC-251 ;
-    :capec-id "CAPEC-252" ;
-    :definition "The attacker loads and executes an arbitrary local PHP file on a target machine. The attacker could use this to try to load old versions of PHP files that have known vulnerabilities, to load PHP files that the attacker placed on the local machine during a prior attack, or to otherwise change the functionality of the targeted application in unexpected ways." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/252.html> ;
-    :related :CWE-829 .
-
-:CAPEC-253 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Remote Code Inclusion" ;
-    rdfs:subClassOf :CAPEC-175 ;
-    :capec-id "CAPEC-253" ;
-    :definition "The attacker forces an application to load arbitrary code files from a remote location. The attacker could use this to try to load old versions of library files that have known vulnerabilities, to load malicious files that the attacker placed on the remote machine, or to otherwise change the functionality of the targeted application in unexpected ways." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/253.html> ;
-    :related :CWE-829 .
-
-:CAPEC-254 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: DTD Injection in a SOAP Message" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the pattern CAPEC-228 : DTD Injection going forward." ;
-    :capec-id "CAPEC-254" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/254.html> .
-
-:CAPEC-256 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SOAP Array Overflow" ;
-    rdfs:subClassOf :CAPEC-100 ;
-    :capec-id "CAPEC-256" ;
-    :definition "An attacker sends a SOAP request with an array whose actual length exceeds the length indicated in the request. If the server processing the transmission naively trusts the specified size, then an attacker can intentionally understate the size of the array, possibly resulting in a buffer overflow if the server attempts to read the entire data set into the memory it allocated for a smaller array." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/256.html> ;
-    :related :CWE-805 .
-
-:CAPEC-257 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Abuse of Transaction Data Structure" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern." ;
-    :capec-id "CAPEC-257" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/257.html> .
-
-:CAPEC-258 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Passively Sniffing and Capturing Application Code Bound for an Authorized Client During Dynamic Update" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-65 : Sniff Application Code\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-258" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/258.html> .
-
-:CAPEC-259 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Passively Sniffing and Capturing Application Code Bound for an Authorized Client During Patching" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-65 : Sniff Application Code\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-259" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/259.html> .
-
-:CAPEC-260 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Passively Sniffing and Capturing Application Code Bound for an Authorized Client During Initial Distribution" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-65 : Sniff Application Code\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-260" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/260.html> .
-
-:CAPEC-261 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Fuzzing for garnering other adjacent user/sensitive data" ;
-    rdfs:subClassOf :CAPEC-54 ;
-    :capec-id "CAPEC-261" ;
-    :definition "An adversary who is authorized to send queries to a target sends variants of expected queries in the hope that these modified queries might return information (directly or indirectly through error logs) beyond what the expected set of queries should provide." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/261.html> ;
-    :related :CWE-20 .
-
-:CAPEC-263 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Force Use of Corrupted Files" ;
-    rdfs:subClassOf :CAPEC-17 ;
-    :capec-id "CAPEC-263" ;
-    :definition "This describes an attack where an application is forced to use a file that an attacker has corrupted. The result is often a denial of service caused by the application being unable to process the corrupted file, but other results, including the disabling of filters or access controls (if the application fails in an unsafe way rather than failing by locking down) or buffer overflows are possible." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/263.html> ;
-    :related :CWE-829 .
-
-:CAPEC-264 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Environment Variable Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-13 : Subverting Environment Variable Values\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-264" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/264.html> .
-
-:CAPEC-265 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Global variable manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-77 : Manipulating User-Controlled Variables\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-265" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/265.html> .
-
-:CAPEC-266 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Manipulate Canonicalization" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated." ;
-    :capec-id "CAPEC-266" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/266.html> .
-
-:CAPEC-267 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Leverage Alternate Encoding" ;
-    rdfs:subClassOf :CAPEC-153 ;
-    :capec-id "CAPEC-267" ;
-    :definition "An adversary leverages the possibility to encode potentially harmful input or content used by applications such that the applications are ineffective at validating this encoding standard." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/267.html> ;
-    :related :CWE-20,
-        :CWE-73,
-        :CWE-74,
-        :CWE-172,
-        :CWE-173,
-        :CWE-180,
-        :CWE-181,
-        :CWE-692,
-        :CWE-697,
-        :T1027 .
-
-:CAPEC-268 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Audit Log Manipulation" ;
-    rdfs:subClassOf :CAPEC-161 ;
-    :capec-id "CAPEC-268" ;
-    :definition "The attacker injects, manipulates, deletes, or forges malicious log entries into the log file, in an attempt to mislead an audit of the log file or cover tracks of an attack. Due to either insufficient access controls of the log files or the logging mechanism, the attacker is able to perform such actions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/268.html> ;
-    :related :CWE-117,
-        :T1070,
-        :T1562.002,
-        :T1562.003,
-        :T1562.008 .
-
-:CAPEC-269 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Registry Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This pattern has been deprecated as it was determined to be a duplicate of another pattern. Please refer to the pattern CAPEC-203 : Manipulate Application Registry Values going forward." ;
-    :capec-id "CAPEC-269" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/269.html> .
-
-:CAPEC-270 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Modification of Registry Run Keys" ;
-    rdfs:subClassOf :CAPEC-203 ;
-    :capec-id "CAPEC-270" ;
-    :definition "An adversary adds a new entry to the \"run keys\" in the Windows registry so that an application of their choosing is executed when a user logs in. In this way, the adversary can get their executable to operate and run on the target system with the authorized user's level of permissions. This attack is a good way for an adversary to run persistent spyware on a user's machine, such as a keylogger." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/270.html> ;
-    :related :CWE-15,
-        :T1547.001,
-        :T1547.014 .
-
-:CAPEC-271 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Schema Poisoning" ;
-    rdfs:subClassOf :CAPEC-176 ;
-    :capec-id "CAPEC-271" ;
-    :definition "An adversary corrupts or modifies the content of a schema for the purpose of undermining the security of the target. Schemas provide the structure and content definitions for resources used by an application. By replacing or modifying a schema, the adversary can affect how the application handles or interprets a resource, often leading to possible denial of service, entering into an unexpected state, or recording incomplete data." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/271.html> ;
-    :related :CWE-15 .
-
-:CAPEC-272 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Protocol Manipulation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-272" ;
-    :definition "An adversary subverts a communications protocol to perform an attack. This type of attack can allow an adversary to impersonate others, discover sensitive information, control the outcome of a session, or perform other attacks. This type of attack targets invalid assumptions that may be inherent in implementers of the protocol, incorrect implementations of the protocol, or vulnerabilities in the protocol itself." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/272.html> .
-
-:CAPEC-273 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP Response Smuggling" ;
-    rdfs:subClassOf :CAPEC-220 ;
-    :capec-id "CAPEC-273" ;
-    :definition "An adversary manipulates and injects malicious content in the form of secret unauthorized HTTP responses, into a single HTTP response from a vulnerable or compromised back-end HTTP agent (e.g., server)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/273.html> ;
-    :related :CAPEC-33,
-        :CWE-74,
-        :CWE-436,
-        :CWE-444 .
-
-:CAPEC-274 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP Verb Tampering" ;
-    rdfs:subClassOf :CAPEC-220 ;
-    :capec-id "CAPEC-274" ;
-    :definition "An attacker modifies the HTTP Verb (e.g. GET, PUT, TRACE, etc.) in order to bypass access restrictions. Some web environments allow administrators to restrict access based on the HTTP Verb used with requests. However, attackers can often provide a different HTTP Verb, or even provide a random string as a verb in order to bypass these protections. This allows the attacker to access data that should otherwise be protected." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/274.html> ;
-    :related :CWE-302,
-        :CWE-654 .
-
-:CAPEC-275 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DNS Rebinding" ;
-    rdfs:subClassOf :CAPEC-194 ;
-    :capec-id "CAPEC-275" ;
-    :definition "An adversary serves content whose IP address is resolved by a DNS server that the adversary controls. After initial contact by a web browser (or similar client), the adversary changes the IP address to which its name resolves, to an address within the target organization that is not publicly accessible. This allows the web browser to examine this internal address on behalf of the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/275.html> ;
-    :related :CWE-350 .
-
-:CAPEC-276 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Inter-component Protocol Manipulation" ;
-    rdfs:subClassOf :CAPEC-272 ;
-    :capec-id "CAPEC-276" ;
-    :definition "Inter-component protocols are used to communicate between different software and hardware modules within a single computer. Common examples are: interrupt signals and data pipes. Subverting the protocol can allow an adversary to impersonate others, discover sensitive information, control the outcome of a session, or perform other attacks. This type of attack targets invalid assumptions that may be inherent in implementers of the protocol, incorrect implementations of the protocol, or vulnerabilities in the protocol itself." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/276.html> ;
-    :related :CWE-707 .
-
-:CAPEC-277 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Data Interchange Protocol Manipulation" ;
-    rdfs:subClassOf :CAPEC-272 ;
-    :capec-id "CAPEC-277" ;
-    :definition "Data Interchange Protocols are used to transmit structured data between entities. These protocols are often specific to a particular domain (B2B: purchase orders, invoices, transport logistics and waybills, medical records). They are often, but not always, XML-based. Subverting the protocol can allow an adversary to impersonate others, discover sensitive information, control the outcome of a session, or perform other attacks. This type of attack targets invalid assumptions that may be inherent in implementers of the protocol, incorrect implementations of the protocol, or vulnerabilities in the protocol itself." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/277.html> ;
-    :related :CWE-707 .
-
-:CAPEC-278 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Web Services Protocol Manipulation" ;
-    rdfs:subClassOf :CAPEC-272 ;
-    :capec-id "CAPEC-278" ;
-    :definition "An adversary manipulates a web service related protocol to cause a web application or service to react differently than intended. This can either be performed through the manipulation of call parameters to include unexpected values, or by changing the called function to one that should normally be restricted or limited. By leveraging this pattern of attack, the adversary is able to gain access to data or resources normally restricted, or to cause the application or service to crash." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/278.html> ;
-    :related :CWE-707 .
-
-:CAPEC-279 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SOAP Manipulation" ;
-    rdfs:subClassOf :CAPEC-278 ;
-    :capec-id "CAPEC-279" ;
-    :definition "Simple Object Access Protocol (SOAP) is used as a communication protocol between a client and server to invoke web services on the server. It is an XML-based protocol, and therefore suffers from many of the same shortcomings as other XML-based protocols. Adversaries can make use of these shortcomings and manipulate the content of SOAP paramters, leading to undesirable behavior on the server and allowing the adversary to carry out a number of further attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/279.html> ;
-    :related :CWE-707 .
-
-:CAPEC-280 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: SOAP Parameter Tampering" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as its contents have been included in CAPEC-279 : SOAP Manipulation. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-280" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/280.html> .
-
-:CAPEC-285 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP Echo Request Ping" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-285" ;
-    :definition "An adversary sends out an ICMP Type 8 Echo Request, commonly known as a 'Ping', in order to determine if a target system is responsive. If the request is not blocked by a firewall or ACL, the target host will respond with an ICMP Type 0 Echo Reply datagram. This type of exchange is usually referred to as a 'Ping' due to the Ping utility present in almost all operating systems. Ping, as commonly implemented, allows a user to test for alive hosts, measure round-trip time, and measure the percentage of packet loss." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/285.html> ;
-    :related :CWE-200 .
-
-:CAPEC-287 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP SYN Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-287" ;
-    :definition "An adversary uses a SYN scan to determine the status of ports on the remote target. SYN scanning is the most common type of port scanning that is used because of its many advantages and few drawbacks. As a result, novice attackers tend to overly rely on the SYN scan while performing system reconnaissance. As a scanning method, the primary advantages of SYN scanning are its universality and speed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/287.html> ;
-    :related :CWE-200 .
-
-:CAPEC-288 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: ICMP Echo Request Ping" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-285\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-288" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/288.html> .
-
-:CAPEC-289 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Infrastructure-based footprinting" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the meta level pattern CAPEC-169 : going forward, or to any of its children patterns." ;
-    :capec-id "CAPEC-289" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/289.html> .
-
-:CAPEC-290 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Enumerate Mail Exchange (MX) Records" ;
-    rdfs:subClassOf :CAPEC-309 ;
-    :capec-id "CAPEC-290" ;
-    :definition "An adversary enumerates the MX records for a given via a DNS query. This type of information gathering returns the names of mail servers on the network. Mail servers are often not exposed to the Internet but are located within the DMZ of a network protected by a firewall. A side effect of this configuration is that enumerating the MX records for an organization my reveal the IP address of the firewall or possibly other internal systems. Attackers often resort to MX record enumeration when a DNS Zone Transfer is not possible." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/290.html> ;
-    :related :CWE-200 .
-
-:CAPEC-291 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DNS Zone Transfers" ;
-    rdfs:subClassOf :CAPEC-309 ;
-    :capec-id "CAPEC-291" ;
-    :definition "An attacker exploits a DNS misconfiguration that permits a ZONE transfer. Some external DNS servers will return a list of IP address and valid hostnames. Under certain conditions, it may even be possible to obtain Zone data about the organization's internal network. When successful the attacker learns valuable information about the topology of the target organization, including information about particular servers, their role within the IT structure, and possibly information about the operating systems running upon the network. This is configuration dependent behavior so it may also be required to search out multiple DNS servers while attempting to find one with ZONE transfers allowed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/291.html> ;
-    :related :CWE-200 .
-
-:CAPEC-292 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Host Discovery" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-292" ;
-    :definition "An adversary sends a probe to an IP address to determine if the host is alive. Host discovery is one of the earliest phases of network reconnaissance. The adversary usually starts with a range of IP addresses belonging to a target network and uses various methods to determine if a host is present at that IP address. Host discovery is usually referred to as 'Ping' scanning using a sonar analogy. The goal is to send a packet through to the IP address and solicit a response from the host. As such, a 'ping' can be virtually any crafted packet whatsoever, provided the adversary can identify a functional host based on its response. An attack of this nature is usually carried out with a 'ping sweep,' where a particular kind of ping is sent to a range of IP addresses." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/292.html> ;
-    :related :CWE-200,
-        :T1018 .
-
-:CAPEC-293 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Traceroute Route Enumeration" ;
-    rdfs:subClassOf :CAPEC-309 ;
-    :capec-id "CAPEC-293" ;
-    :definition "An adversary uses a traceroute utility to map out the route which data flows through the network in route to a target destination. Tracerouting can allow the adversary to construct a working topology of systems and routers by listing the systems through which data passes through on their way to the targeted machine. This attack can return varied results depending upon the type of traceroute that is performed. Traceroute works by sending packets to a target while incrementing the Time-to-Live field in the packet header. As the packet traverses each hop along its way to the destination, its TTL expires generating an ICMP diagnostic message that identifies where the packet expired. Traditional techniques for tracerouting involved the use of ICMP and UDP, but as more firewalls began to filter ingress ICMP, methods of traceroute using TCP were developed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/293.html> ;
-    :related :CWE-200 .
-
-:CAPEC-294 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP Address Mask Request" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-294" ;
-    :definition "An adversary sends an ICMP Type 17 Address Mask Request to gather information about a target's networking configuration. ICMP Address Mask Requests are defined by RFC-950, \"Internet Standard Subnetting Procedure.\" An Address Mask Request is an ICMP type 17 message that triggers a remote system to respond with a list of its related subnets, as well as its default gateway and broadcast address via an ICMP type 18 Address Mask Reply datagram. Gathering this type of information helps the adversary plan router-based attacks as well as denial-of-service attacks against the broadcast address." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/294.html> ;
-    :related :CWE-200 .
-
-:CAPEC-295 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Timestamp Request" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-295" ;
-    :definition "This pattern of attack leverages standard requests to learn the exact time associated with a target system. An adversary may be able to use the timestamp returned from the target to attack time-based security algorithms, such as random number generators, or time-based authentication mechanisms." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/295.html> ;
-    :related :CWE-200,
-        :T1124 .
-
-:CAPEC-296 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP Information Request" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-296" ;
-    :definition "An adversary sends an ICMP Information Request to a host to determine if it will respond to this deprecated mechanism. ICMP Information Requests are a deprecated message type. Information Requests were originally used for diskless machines to automatically obtain their network configuration, but this message type has been superseded by more robust protocol implementations like DHCP." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/296.html> ;
-    :related :CWE-200 .
-
-:CAPEC-297 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP ACK Ping" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-297" ;
-    :definition "An adversary sends a TCP segment with the ACK flag set to a remote host for the purpose of determining if the host is alive. This is one of several TCP 'ping' types. The RFC 793 expected behavior for a service is to respond with a RST 'reset' packet to any unsolicited ACK segment that is not part of an existing connection. So by sending an ACK segment to a port, the adversary can identify that the host is alive by looking for a RST packet. Typically, a remote server will respond with a RST regardless of whether a port is open or closed. In this way, TCP ACK pings cannot discover the state of a remote port because the behavior is the same in either case. The firewall will look up the ACK packet in its state-table and discard the segment because it does not correspond to any active connection. A TCP ACK Ping can be used to discover if a host is alive via RST response packets sent from the host." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/297.html> ;
-    :related :CWE-200 .
-
-:CAPEC-298 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "UDP Ping" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-298" ;
-    :definition "An adversary sends a UDP datagram to the remote host to determine if the host is alive. If a UDP datagram is sent to an open UDP port there is very often no response, so a typical strategy for using a UDP ping is to send the datagram to a random high port on the target. The goal is to solicit an 'ICMP port unreachable' message from the target, indicating that the host is alive. UDP pings are useful because some firewalls are not configured to block UDP datagrams sent to strange or typically unused ports, like ports in the 65K range. Additionally, while some firewalls may filter incoming ICMP, weaknesses in firewall rule-sets may allow certain types of ICMP (host unreachable, port unreachable) which are useful for UDP ping attempts." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/298.html> ;
-    :related :CWE-200 .
-
-:CAPEC-299 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP SYN Ping" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-299" ;
-    :definition "An adversary uses TCP SYN packets as a means towards host discovery. Typical RFC 793 behavior specifies that when a TCP port is open, a host must respond to an incoming SYN \"synchronize\" packet by completing stage two of the 'three-way handshake' - by sending an SYN/ACK in response. When a port is closed, RFC 793 behavior is to respond with a RST \"reset\" packet. This behavior can be used to 'ping' a target to see if it is alive by sending a TCP SYN packet to a port and then looking for a RST or an ACK packet in response." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/299.html> ;
-    :related :CWE-200 .
-
-:CAPEC-300 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Port Scanning" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-300" ;
-    :definition "An adversary uses a combination of techniques to determine the state of the ports on a remote target. Any service or application available for TCP or UDP networking will have a port open for communications over the network." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/300.html> ;
-    :related :CWE-200,
-        :T1046 .
-
-:CAPEC-301 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Connect Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-301" ;
-    :definition "An adversary uses full TCP connection attempts to determine if a port is open on the target system. The scanning process involves completing a 'three-way handshake' with a remote port, and reports the port as closed if the full handshake cannot be established. An advantage of TCP connect scanning is that it works against any TCP/IP stack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/301.html> ;
-    :related :CWE-200 .
-
-:CAPEC-302 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP FIN Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-302" ;
-    :definition "An adversary uses a TCP FIN scan to determine if ports are closed on the target machine. This scan type is accomplished by sending TCP segments with the FIN bit set in the packet header. The RFC 793 expected behavior is that any TCP segment with an out-of-state Flag sent to an open port is discarded, whereas segments with out-of-state flags sent to closed ports should be handled with a RST in response. This behavior should allow the adversary to scan for closed ports by sending certain types of rule-breaking packets (out of sync or disallowed by the TCB) and detect closed ports via RST packets." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/302.html> ;
-    :related :CWE-200 .
-
-:CAPEC-303 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Xmas Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-303" ;
-    :definition "An adversary uses a TCP XMAS scan to determine if ports are closed on the target machine. This scan type is accomplished by sending TCP segments with all possible flags set in the packet header, generating packets that are illegal based on RFC 793. The RFC 793 expected behavior is that any TCP segment with an out-of-state Flag sent to an open port is discarded, whereas segments with out-of-state flags sent to closed ports should be handled with a RST in response. This behavior should allow an attacker to scan for closed ports by sending certain types of rule-breaking packets (out of sync or disallowed by the TCB) and detect closed ports via RST packets." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/303.html> ;
-    :related :CWE-200 .
-
-:CAPEC-304 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Null Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-304" ;
-    :definition "An adversary uses a TCP NULL scan to determine if ports are closed on the target machine. This scan type is accomplished by sending TCP segments with no flags in the packet header, generating packets that are illegal based on RFC 793. The RFC 793 expected behavior is that any TCP segment with an out-of-state Flag sent to an open port is discarded, whereas segments with out-of-state flags sent to closed ports should be handled with a RST in response. This behavior should allow an attacker to scan for closed ports by sending certain types of rule-breaking packets (out of sync or disallowed by the TCB) and detect closed ports via RST packets." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/304.html> ;
-    :related :CWE-200 .
-
-:CAPEC-305 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP ACK Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-305" ;
-    :definition "An adversary uses TCP ACK segments to gather information about firewall or ACL configuration. The purpose of this type of scan is to discover information about filter configurations rather than port state. This type of scanning is rarely useful alone, but when combined with SYN scanning, gives a more complete picture of the type of firewall rules that are present." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/305.html> ;
-    :related :CWE-200 .
-
-:CAPEC-306 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Window Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-306" ;
-    :definition "An adversary engages in TCP Window scanning to analyze port status and operating system type. TCP Window scanning uses the ACK scanning method but examine the TCP Window Size field of response RST packets to make certain inferences. While TCP Window Scans are fast and relatively stealthy, they work against fewer TCP stack implementations than any other type of scan. Some operating systems return a positive TCP window size when a RST packet is sent from an open port, and a negative value when the RST originates from a closed port. TCP Window scanning is one of the most complex scan types, and its results are difficult to interpret. Window scanning alone rarely yields useful information, but when combined with other types of scanning is more useful. It is a generally more reliable means of making inference about operating system versions than port status." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/306.html> ;
-    :related :CWE-200 .
-
-:CAPEC-307 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP RPC Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-307" ;
-    :definition "An adversary scans for RPC services listing on a Unix/Linux host." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/307.html> ;
-    :related :CWE-200 .
-
-:CAPEC-308 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "UDP Scan" ;
-    rdfs:subClassOf :CAPEC-300 ;
-    :capec-id "CAPEC-308" ;
-    :definition "An adversary engages in UDP scanning to gather information about UDP port status on the target system. UDP scanning methods involve sending a UDP datagram to the target port and looking for evidence that the port is closed. Open UDP ports usually do not respond to UDP datagrams as there is no stateful mechanism within the protocol that requires building or establishing a session. Responses to UDP datagrams are therefore application specific and cannot be relied upon as a method of detecting an open port. UDP scanning relies heavily upon ICMP diagnostic messages in order to determine the status of a remote port." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/308.html> ;
-    :related :CWE-200 .
-
-:CAPEC-309 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Network Topology Mapping" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-309" ;
-    :definition "An adversary engages in scanning activities to map network nodes, hosts, devices, and routes. Adversaries usually perform this type of network reconnaissance during the early stages of attack against an external network. Many types of scanning utilities are typically employed, including ICMP tools, network mappers, port scanners, and route testing utilities such as traceroute." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/309.html> ;
-    :related :CWE-200,
-        :T1016,
-        :T1049,
-        :T1590 .
-
-:CAPEC-310 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Scanning for Vulnerable Software" ;
-    rdfs:subClassOf :CAPEC-541 ;
-    :capec-id "CAPEC-310" ;
-    :definition "An attacker engages in scanning activity to find vulnerable software versions or types, such as operating system versions or network services. Vulnerable or exploitable network configurations, such as improperly firewalled systems, or misconfigured systems in the DMZ or external network, provide windows of opportunity for an attacker. Common types of vulnerable software include unpatched operating systems or services (e.g FTP, Telnet, SMTP, SNMP) running on open ports that the attacker has identified. Attackers usually begin probing for vulnerable software once the external network has been port scanned and potential targets have been revealed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/310.html> ;
-    :related :CWE-200 .
-
-:CAPEC-311 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: OS Fingerprinting" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level patterns CAPEC-312 : Active OS Fingerprinting or CAPEC-313 : Passive OS Fingerprinting going forward, or to any of the detailed patterns that are children of them." ;
-    :capec-id "CAPEC-311" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/311.html> .
-
-:CAPEC-312 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Active OS Fingerprinting" ;
-    rdfs:subClassOf :CAPEC-224 ;
-    :capec-id "CAPEC-312" ;
-    :definition "An adversary engages in activity to detect the operating system or firmware version of a remote target by interrogating a device, server, or platform with a probe designed to solicit behavior that will reveal information about the operating systems or firmware in the environment. Operating System detection is possible because implementations of common protocols (Such as IP or TCP) differ in distinct ways. While the implementation differences are not sufficient to 'break' compatibility with the protocol the differences are detectable because the target will respond in unique ways to specific probing activity that breaks the semantic or logical rules of packet construction for a protocol. Different operating systems will have a unique response to the anomalous input, providing the basis to fingerprint the OS behavior. This type of OS fingerprinting can distinguish between operating system types and versions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/312.html> ;
-    :related :CWE-200,
-        :T1082 .
-
-:CAPEC-313 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Passive OS Fingerprinting" ;
-    rdfs:subClassOf :CAPEC-224 ;
-    :capec-id "CAPEC-313" ;
-    :definition "An adversary engages in activity to detect the version or type of OS software in a an environment by passively monitoring communication between devices, nodes, or applications. Passive techniques for operating system detection send no actual probes to a target, but monitor network or client-server communication between nodes in order to identify operating systems based on observed behavior as compared to a database of known signatures or values. While passive OS fingerprinting is not usually as reliable as active methods, it is generally better able to evade detection." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/313.html> ;
-    :related :CWE-200,
-        :T1082 .
-
-:CAPEC-314 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: IP Fingerprinting Probes" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level pattern CAPEC-312 : Active OS Fingerprinting going forward, or to any of the detailed patterns that children of CAPEC-312." ;
-    :capec-id "CAPEC-314" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/314.html> .
-
-:CAPEC-315 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: TCP/IP Fingerprinting Probes" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level pattern CAPEC-312 : Active OS Fingerprinting going forward, or to any of the detailed patterns that are children of CAPEC-312." ;
-    :capec-id "CAPEC-315" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/315.html> .
-
-:CAPEC-316 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: ICMP Fingerprinting Probes" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This pattern has been deprecated as it was determined to be an unnecessary layer of abstraction. Please refer to the standard level pattern CAPEC-312 : Active OS Fingerprinting going forward, or to any of the detailed patterns that are children of CAPEC-312." ;
-    :capec-id "CAPEC-316" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/316.html> .
-
-:CAPEC-317 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "IP ID Sequencing Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-317" ;
-    :definition "This OS fingerprinting probe analyzes the IP 'ID' field sequence number generation algorithm of a remote host. Operating systems generate IP 'ID' numbers differently, allowing an attacker to identify the operating system of the host by examining how is assigns ID numbers when generating response packets. RFC 791 does not specify how ID numbers are chosen or their ranges, so ID sequence generation differs from implementation to implementation. There are two kinds of IP 'ID' sequence number analysis - IP 'ID' Sequencing: analyzing the IP 'ID' sequence generation algorithm for one protocol used by a host and Shared IP 'ID' Sequencing: analyzing the packet ordering via IP 'ID' values spanning multiple protocols, such as between ICMP and TCP." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/317.html> ;
-    :related :CWE-200 .
-
-:CAPEC-318 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "IP 'ID' Echoed Byte-Order Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-318" ;
-    :definition "This OS fingerprinting probe tests to determine if the remote host echoes back the IP 'ID' value from the probe packet. An attacker sends a UDP datagram with an arbitrary IP 'ID' value to a closed port on the remote host to observe the manner in which this bit is echoed back in the ICMP error message. The identification field (ID) is typically utilized for reassembling a fragmented packet. Some operating systems or router firmware reverse the bit order of the ID field when echoing the IP Header portion of the original datagram within an ICMP error message." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/318.html> ;
-    :related :CWE-200 .
-
-:CAPEC-319 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "IP (DF) 'Don't Fragment Bit' Echoing Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-319" ;
-    :definition "This OS fingerprinting probe tests to determine if the remote host echoes back the IP 'DF' (Don't Fragment) bit in a response packet. An attacker sends a UDP datagram with the DF bit set to a closed port on the remote host to observe whether the 'DF' bit is set in the response packet. Some operating systems will echo the bit in the ICMP error message while others will zero out the bit in the response packet." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/319.html> ;
-    :related :CWE-200 .
-
-:CAPEC-320 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Timestamp Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-320" ;
-    :definition "This OS fingerprinting probe examines the remote server's implementation of TCP timestamps. Not all operating systems implement timestamps within the TCP header, but when timestamps are used then this provides the attacker with a means to guess the operating system of the target. The attacker begins by probing any active TCP service in order to get response which contains a TCP timestamp. Different Operating systems update the timestamp value using different intervals. This type of analysis is most accurate when multiple timestamp responses are received and then analyzed. TCP timestamps can be found in the TCP Options field of the TCP header." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/320.html> ;
-    :related :CWE-200 .
-
-:CAPEC-321 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Sequence Number Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-321" ;
-    :definition "This OS fingerprinting probe tests the target system's assignment of TCP sequence numbers. One common way to test TCP Sequence Number generation is to send a probe packet to an open port on the target and then compare the how the Sequence Number generated by the target relates to the Acknowledgement Number in the probe packet. Different operating systems assign Sequence Numbers differently, so a fingerprint of the operating system can be obtained by categorizing the relationship between the acknowledgement number and sequence number as follows: 1) the Sequence Number generated by the target is Zero, 2) the Sequence Number generated by the target is the same as the acknowledgement number in the probe, 3) the Sequence Number generated by the target is the acknowledgement number plus one, or 4) the Sequence Number is any other non-zero number." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/321.html> ;
-    :related :CWE-200 .
-
-:CAPEC-322 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP (ISN) Greatest Common Divisor Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-322" ;
-    :definition "This OS fingerprinting probe sends a number of TCP SYN packets to an open port of a remote machine. The Initial Sequence Number (ISN) in each of the SYN/ACK response packets is analyzed to determine the smallest number that the target host uses when incrementing sequence numbers. This information can be useful for identifying an operating system because particular operating systems and versions increment sequence numbers using different values. The result of the analysis is then compared against a database of OS behaviors to determine the OS type and/or version." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/322.html> ;
-    :related :CWE-200 .
-
-:CAPEC-323 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP (ISN) Counter Rate Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-323" ;
-    :definition "This OS detection probe measures the average rate of initial sequence number increments during a period of time. Sequence numbers are incremented using a time-based algorithm and are susceptible to a timing analysis that can determine the number of increments per unit time. The result of this analysis is then compared against a database of operating systems and versions to determine likely operation system matches." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/323.html> ;
-    :related :CWE-200 .
-
-:CAPEC-324 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP (ISN) Sequence Predictability Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-324" ;
-    :definition "This type of operating system probe attempts to determine an estimate for how predictable the sequence number generation algorithm is for a remote host. Statistical techniques, such as standard deviation, can be used to determine how predictable the sequence number generation is for a system. This result can then be compared to a database of operating system behaviors to determine a likely match for operating system and version." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/324.html> ;
-    :related :CWE-200 .
-
-:CAPEC-325 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Congestion Control Flag (ECN) Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-325" ;
-    :definition "This OS fingerprinting probe checks to see if the remote host supports explicit congestion notification (ECN) messaging. ECN messaging was designed to allow routers to notify a remote host when signal congestion problems are occurring. Explicit Congestion Notification messaging is defined by RFC 3168. Different operating systems and versions may or may not implement ECN notifications, or may respond uniquely to particular ECN flag types." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/325.html> ;
-    :related :CWE-200 .
-
-:CAPEC-326 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Initial Window Size Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-326" ;
-    :definition "This OS fingerprinting probe checks the initial TCP Window size. TCP stacks limit the range of sequence numbers allowable within a session to maintain the \"connected\" state within TCP protocol logic. The initial window size specifies a range of acceptable sequence numbers that will qualify as a response to an ACK packet within a session. Various operating systems use different Initial window sizes. The initial window size can be sampled by establishing an ordinary TCP connection." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/326.html> ;
-    :related :CWE-200 .
-
-:CAPEC-327 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Options Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-327" ;
-    :definition "This OS fingerprinting probe analyzes the type and order of any TCP header options present within a response segment. Most operating systems use unique ordering and different option sets when options are present. RFC 793 does not specify a required order when options are present, so different implementations use unique ways of ordering or structuring TCP options. TCP options can be generated by ordinary TCP traffic." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/327.html> ;
-    :related :CWE-200 .
-
-:CAPEC-328 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP 'RST' Flag Checksum Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-328" ;
-    :definition "This OS fingerprinting probe performs a checksum on any ASCII data contained within the data portion or a RST packet. Some operating systems will report a human-readable text message in the payload of a 'RST' (reset) packet when specific types of connection errors occur. RFC 1122 allows text payloads within reset packets but not all operating systems or routers implement this functionality." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/328.html> ;
-    :related :CWE-200 .
-
-:CAPEC-329 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP Error Message Quoting Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-329" ;
-    :definition "An adversary uses a technique to generate an ICMP Error message (Port Unreachable, Destination Unreachable, Redirect, Source Quench, Time Exceeded, Parameter Problem) from a target and then analyze the amount of data returned or \"Quoted\" from the originating request that generated the ICMP error message." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/329.html> ;
-    :related :CWE-200 .
-
-:CAPEC-330 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP Error Message Echoing Integrity Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-330" ;
-    :definition "An adversary uses a technique to generate an ICMP Error message (Port Unreachable, Destination Unreachable, Redirect, Source Quench, Time Exceeded, Parameter Problem) from a target and then analyze the integrity of data returned or \"Quoted\" from the originating request that generated the error message." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/330.html> ;
-    :related :CWE-200 .
-
-:CAPEC-331 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP IP Total Length Field Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-331" ;
-    :definition "An adversary sends a UDP packet to a closed port on the target machine to solicit an IP Header's total length field value within the echoed 'Port Unreachable\" error message. This type of behavior is useful for building a signature-base of operating system responses, particularly when error messages contain other types of information that is useful identifying specific operating system responses." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/331.html> ;
-    :related :CWE-204 .
-
-:CAPEC-332 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP IP 'ID' Field Error Message Probe" ;
-    rdfs:subClassOf :CAPEC-312 ;
-    :capec-id "CAPEC-332" ;
-    :definition "An adversary sends a UDP datagram having an assigned value to its internet identification field (ID) to a closed port on a target to observe the manner in which this bit is echoed back in the ICMP error message. This allows the attacker to construct a fingerprint of specific OS behaviors." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/332.html> ;
-    :related :CWE-204 .
-
-:CAPEC-383 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Harvesting Information via API Event Monitoring" ;
-    rdfs:subClassOf :CAPEC-407 ;
-    :capec-id "CAPEC-383" ;
-    :definition "An adversary hosts an event within an application framework and then monitors the data exchanged during the course of the event for the purpose of harvesting any important data leaked during the transactions. One example could be harvesting lists of usernames or userIDs for the purpose of sending spam messages to those users. One example of this type of attack involves the adversary creating an event within the sub-application. Assume the adversary hosts a \"virtual sale\" of rare items. As other users enter the event, the attacker records via AiTM (CAPEC-94) proxy the user_ids and usernames of everyone who attends. The adversary would then be able to spam those users within the application using an automated script." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/383.html> ;
-    :related :CWE-311,
-        :CWE-319,
-        :CWE-419,
-        :CWE-602,
-        :T1056.004 .
-
-:CAPEC-384 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Application API Message Manipulation via Man-in-the-Middle" ;
-    rdfs:subClassOf :CAPEC-94 ;
-    :capec-id "CAPEC-384" ;
-    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the content of messages. Performing this attack can allow the attacker to gain unauthorized privileges within the application, or conduct attacks such as phishing, deceptive strategies to spread malware, or traditional web-application attacks. The techniques require use of specialized software that allow the attacker to perform adversary-in-the-middle (CAPEC-94) communications between the web browser and the remote system. Despite the use of AiTH software, the attack is actually directed at the server, as the client is one node in a series of content brokers that pass information along to the application framework. Additionally, it is not true \"Adversary-in-the-Middle\" attack at the network layer, but an application-layer attack the root cause of which is the master applications trust in the integrity of code supplied by the client." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/384.html> ;
-    :related :CWE-311,
-        :CWE-345,
-        :CWE-346,
-        :CWE-471,
-        :CWE-602 .
-
-:CAPEC-385 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Transaction or Event Tampering via Application API Manipulation" ;
-    rdfs:subClassOf :CAPEC-384 ;
-    :capec-id "CAPEC-385" ;
-    :definition "An attacker hosts or joins an event or transaction within an application framework in order to change the content of messages or items that are being exchanged. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that look authentic but may contain deceptive links, substitute one item or another, spoof an existing item and conduct a false exchange, or otherwise change the amounts or identity of what is being exchanged. The techniques require use of specialized software that allow the attacker to man-in-the-middle communications between the web browser and the remote system in order to change the content of various application elements. Often, items exchanged in game can be monetized via sales for coin, virtual dollars, etc. The purpose of the attack is for the attack to scam the victim by trapping the data packets involved the exchange and altering the integrity of the transfer process." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/385.html> ;
-    :related :CWE-311,
-        :CWE-345,
-        :CWE-346,
-        :CWE-471,
-        :CWE-602 .
-
-:CAPEC-386 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Application API Navigation Remapping" ;
-    rdfs:subClassOf :CAPEC-94 ;
-    :capec-id "CAPEC-386" ;
-    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the destination and/or content of links/buttons displayed to a user within API messages. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that looks authentic but contains links/buttons that point to an attacker controlled destination. Some applications make navigation remapping more difficult to detect because the actual HREF values of images, profile elements, and links/buttons are masked. One example would be to place an image in a user's photo gallery that when clicked upon redirected the user to an off-site location. Also, traditional web vulnerabilities (such as CSRF) can be constructed with remapped buttons or links. In some cases navigation remapping can be used for Phishing attacks or even means to artificially boost the page view, user site reputation, or click-fraud." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/386.html> ;
-    :related :CWE-311,
-        :CWE-345,
-        :CWE-346,
-        :CWE-471,
-        :CWE-602 .
-
-:CAPEC-387 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Navigation Remapping To Propagate Malicious Content" ;
-    rdfs:subClassOf :CAPEC-386 ;
-    :capec-id "CAPEC-387" ;
-    :definition "An adversary manipulates either egress or ingress data from a client within an application framework in order to change the content of messages and thereby circumvent the expected application logic." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/387.html> ;
-    :related :CWE-311,
-        :CWE-345,
-        :CWE-346,
-        :CWE-471,
-        :CWE-602 .
-
-:CAPEC-388 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Application API Button Hijacking" ;
-    rdfs:subClassOf :CAPEC-386 ;
-    :capec-id "CAPEC-388" ;
-    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the destination and/or content of buttons displayed to a user within API messages. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that looks authentic but contains buttons that point to an attacker controlled destination." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/388.html> ;
-    :related :CWE-311,
-        :CWE-345,
-        :CWE-346,
-        :CWE-471,
-        :CWE-602 .
-
-:CAPEC-389 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Content Spoofing Via Application API Manipulation" ;
-    rdfs:subClassOf :CAPEC-384 ;
-    :capec-id "CAPEC-389" ;
-    :definition "An attacker manipulates either egress or ingress data from a client within an application framework in order to change the content of messages. Performing this attack allows the attacker to manipulate content in such a way as to produce messages or content that look authentic but may contain deceptive links, spam-like content, or links to the attackers' code. In general, content-spoofing within an application API can be employed to stage many different types of attacks varied based on the attackers' intent. The techniques require use of specialized software that allow the attacker to use adversary-in-the-middle (CAPEC-94) communications between the web browser and the remote system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/389.html> ;
-    :related :CWE-353 .
-
-:CAPEC-390 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Bypassing Physical Security" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-390" ;
-    :definition "Facilities often used layered models for physical security such as traditional locks, Electronic-based card entry systems, coupled with physical alarms. Hardware security mechanisms range from the use of computer case and cable locks as well as RFID tags for tracking computer assets. This layered approach makes it difficult for random physical security breaches to go unnoticed, but is less effective at stopping deliberate and carefully planned break-ins. Avoiding detection begins with evading building security and surveillance and methods for bypassing the electronic or physical locks which secure entry points." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/390.html> .
-
-:CAPEC-391 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Bypassing Physical Locks" ;
-    rdfs:subClassOf :CAPEC-390 ;
-    :capec-id "CAPEC-391" ;
-    :definition "An attacker uses techniques and methods to bypass physical security measures of a building or facility. Physical locks may range from traditional lock and key mechanisms, cable locks used to secure laptops or servers, locks on server cases, or other such devices. Techniques such as lock bumping, lock forcing via snap guns, or lock picking can be employed to bypass those locks and gain access to the facilities or devices they protect, although stealth, evidence of tampering, and the integrity of the lock following an attack, are considerations that may determine the method employed. Physical locks are limited by the complexity of the locking mechanism. While some locks may offer protections such as shock resistant foam to prevent bumping or lock forcing methods, many commonly employed locks offer no such countermeasures." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/391.html> .
-
-:CAPEC-392 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Lock Bumping" ;
-    rdfs:subClassOf :CAPEC-391 ;
-    :capec-id "CAPEC-392" ;
-    :definition "An attacker uses a bump key to force a lock on a building or facility and gain entry. Lock Bumping is the use of a special type of key that can be tapped or bumped to cause the pins within the lock to fall into temporary alignment, allowing the lock to be opened. Lock bumping allows an attacker to open a lock without having the correct key. A standard lock is secured by a set of internal pins that prevent the device from turning. Spring loaded driver pins push down on the key pins. When the correct key is inserted, the ridges on the key push the key pins up and against the driver pins, causing correct alignment which allows the lock cylinder to rotate. A bump key is a specially constructed key that exploits this design. When the bump key is struck or firmly tapped, its teeth transfer the force of the tap into the key pins, causing the lock to momentarily shift into proper alignment for the mechanism to be opened." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/392.html> .
-
-:CAPEC-393 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Lock Picking" ;
-    rdfs:subClassOf :CAPEC-391 ;
-    :capec-id "CAPEC-393" ;
-    :definition "An attacker uses lock picking tools and techniques to bypass the locks on a building or facility. Lock picking is the use of a special set of tools to manipulate the pins within a lock. Different sets of tools are required for each type of lock. Lock picking attacks have the advantage of being non-invasive in that if performed correctly the lock will not be damaged. A standard lock pin-and-tumbler lock is secured by a set of internal pins that prevent the tumbler device from turning. Spring loaded driver pins push down on the key pins preventing rotation so that the bolt remains in a locked position.. When the correct key is inserted, the ridges on the key push the key pins up and against the driver pins, causing correct alignment which allows the lock cylinder to rotate. Most common locks, such as domestic locks in the US, can be picked using a standard 2 tools (i.e. a torsion wrench and a hook pick)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/393.html> .
-
-:CAPEC-394 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Using a Snap Gun Lock to Force a Lock" ;
-    rdfs:subClassOf :CAPEC-391 ;
-    :capec-id "CAPEC-394" ;
-    :definition "An attacker uses a Snap Gun, also known as a Pick Gun, to force the lock on a building or facility. A Pick Gun is a special type of lock picking instrument that works on similar principles as lock bumping. A snap gun is a hand-held device with an attached metal pick. The metal pick strikes the pins within the lock, transferring motion from the key pins to the driver pins and forcing the lock into momentary alignment. A standard lock is secured by a set of internal pins that prevent the device from turning. Spring loaded driver pins push down on the key pins. When the correct key is inserted, the ridges on the key push the key pins up and against the driver pins, causing correct alignment which allows the lock cylinder to rotate. A Snap Gun exploits this design by using a metal pin to strike all of the key pins at once, forcing the driver pins to shift into an unlocked position. Unlike bump keys or lock picks, a Snap Gun may damage the lock more easily, leaving evidence that the lock has been tampered with." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/394.html> .
-
-:CAPEC-395 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Bypassing Electronic Locks and Access Controls" ;
-    rdfs:subClassOf :CAPEC-390 ;
-    :capec-id "CAPEC-395" ;
-    :definition "An attacker exploits security assumptions to bypass electronic locks or other forms of access controls. Most attacks against electronic access controls follow similar methods but utilize different tools. Some electronic locks utilize magnetic strip cards, others employ RFID tags embedded within a card or badge, or may involve more sophisticated protections such as voice-print, thumb-print, or retinal biometrics. Magnetic Strip and RFID technologies are the most widespread because they are cost effective to deploy and more easily integrated with other electronic security measures. These technologies share common weaknesses that an attacker can exploit to gain access to a facility protected by the mechanisms via copying legitimate cards or badges, or generating new cards using reverse-engineered algorithms." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/395.html> .
-
-:CAPEC-396 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Bypassing Card or Badge-Based Systems" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-397: Cloning Magnetic Strip Cards, CAPEC-398: Magnetic Strip Card Brute Force Attacks, CAPEC-399: Cloning RFID Cards or Chips and CAPEC-400: RFID Chip Deactivation or Destruction. Please refer to these CAPECs going forward." ;
-    :capec-id "CAPEC-396" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/396.html> .
-
-:CAPEC-397 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cloning Magnetic Strip Cards" ;
-    rdfs:subClassOf :CAPEC-395 ;
-    :capec-id "CAPEC-397" ;
-    :definition "An attacker duplicates the data on a Magnetic strip card (i.e. 'swipe card' or 'magstripe') to gain unauthorized access to a physical location or a person's private information. Magstripe cards encode data on a band of iron-based magnetic particles arrayed in a stripe along a rectangular card. Most magstripe card data formats conform to ISO standards 7810, 7811, 7813, 8583, and 4909. The primary advantage of magstripe technology is ease of encoding and portability, but this also renders magnetic strip cards susceptible to unauthorized duplication. If magstripe cards are used for access control, all an attacker need do is obtain a valid card long enough to make a copy of the card and then return the card to its location (i.e. a co-worker's desk). Magstripe reader/writers are widely available as well as software for analyzing data encoded on the cards. By swiping a valid card, it becomes trivial to make any number of duplicates that function as the original." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/397.html> .
-
-:CAPEC-398 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Magnetic Strip Card Brute Force Attacks" ;
-    rdfs:subClassOf :CAPEC-395 ;
-    :capec-id "CAPEC-398" ;
-    :definition "An adversary analyzes the data on two or more magnetic strip cards and is able to generate new cards containing valid sequences that allow unauthorized access and/or impersonation of individuals." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/398.html> .
-
-:CAPEC-399 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cloning RFID Cards or Chips" ;
-    rdfs:subClassOf :CAPEC-395 ;
-    :capec-id "CAPEC-399" ;
-    :definition "An attacker analyzes data returned by an RFID chip and uses this information to duplicate a RFID signal that responds identically to the target chip. In some cases RFID chips are used for building access control, employee identification, or as markers on products being delivered along a supply chain. Some organizations also embed RFID tags inside computer assets to trigger alarms if they are removed from particular rooms, zones, or buildings. Similar to Magnetic strip cards, RFID cards are susceptible to duplication (cloning) and reuse." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/399.html> .
-
-:CAPEC-400 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "RFID Chip Deactivation or Destruction" ;
-    rdfs:subClassOf :CAPEC-395 ;
-    :capec-id "CAPEC-400" ;
-    :definition "An attacker uses methods to deactivate a passive RFID tag for the purpose of rendering the tag, badge, card, or object containing the tag unresponsive. RFID tags are used primarily for access control, inventory, or anti-theft devices. The purpose of attacking the RFID chip is to disable or damage the chip without causing damage to the object housing it." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/400.html> .
-
-:CAPEC-401 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Physically Hacking Hardware" ;
-    rdfs:subClassOf :CAPEC-440 ;
-    :capec-id "CAPEC-401" ;
-    :definition "An adversary exploits a weakness in access control to gain access to currently installed hardware and precedes to implement changes or secretly replace a hardware component which undermines the system's integrity for the purpose of carrying out an attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/401.html> ;
-    :related :CWE-1263 .
-
-:CAPEC-402 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Bypassing ATA Password Security" ;
-    rdfs:subClassOf :CAPEC-401 ;
-    :capec-id "CAPEC-402" ;
-    :definition "An adversary exploits a weakness in ATA security on a drive to gain access to the information the drive contains without supplying the proper credentials. ATA Security is often employed to protect hard disk information from unauthorized access. The mechanism requires the user to type in a password before the BIOS is allowed access to drive contents. Some implementations of ATA security will accept the ATA command to update the password without the user having authenticated with the BIOS. This occurs because the security mechanism assumes the user has first authenticated via the BIOS prior to sending commands to the drive. Various methods exist for exploiting this flaw, the most common being installing the ATA protected drive into a system lacking ATA security features (a.k.a. hot swapping). Once the drive is installed into the new system the BIOS can be used to reset the drive password." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/402.html> ;
-    :related :CWE-285 .
-
-:CAPEC-404 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Social Information Gathering Attacks" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
-    :capec-id "CAPEC-404" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/404.html> .
-
-:CAPEC-405 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Social Information Gathering via Research" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
-    :capec-id "CAPEC-405" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/405.html> .
-
-:CAPEC-406 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Dumpster Diving" ;
-    rdfs:subClassOf :CAPEC-150 ;
-    :capec-id "CAPEC-406" ;
-    :definition "An adversary cases an establishment and searches through trash bins, dumpsters, or areas where company information may have been accidentally discarded for information items which may be useful to the dumpster diver. The devastating nature of the items and/or information found can be anything from medical records, resumes, personal photos and emails, bank statements, account details or information about software, tech support logs and so much more, including hardware devices. By collecting this information an adversary may be able to learn important facts about the person or organization that play a role in helping the adversary in their attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/406.html> .
-
-:CAPEC-407 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pretexting" ;
-    rdfs:subClassOf :CAPEC-410,
-        :CAPEC-416 ;
-    :capec-id "CAPEC-407" ;
-    :definition "An adversary engages in pretexting behavior to solicit information from target persons, or manipulate the target into performing some action that serves the adversary's interests. During a pretexting attack, the adversary creates an invented scenario, assuming an identity or role to persuade a targeted victim to release information or perform some action. It is more than just creating a lie; in some cases it can be creating a whole new identity and then using that identity to manipulate the receipt of information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/407.html> ;
-    :related :T1589 .
-
-:CAPEC-408 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Information Gathering from Traditional Sources" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
-    :capec-id "CAPEC-408" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/408.html> .
-
-:CAPEC-409 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Information Gathering from Non-Traditional Sources" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate attack pattern. Please refer to CAPEC-118 : Collect and Analyze Information." ;
-    :capec-id "CAPEC-409" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/409.html> .
-
-:CAPEC-410 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Information Elicitation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-410" ;
-    :definition "An adversary engages an individual using any combination of social engineering methods for the purpose of extracting information. Accurate contextual and environmental queues, such as knowing important information about the target company or individual can greatly increase the success of the attack and the quality of information gathered. Authentic mimicry combined with detailed knowledge increases the success of elicitation attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/410.html> .
-
-:CAPEC-411 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Pretexting" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of the existing attack pattern \"CAPEC-407 : Social Information Gathering via Pretexting\". Please refer to this other CAPEC going forward." ;
-    :capec-id "CAPEC-411" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/411.html> .
-
-:CAPEC-412 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pretexting via Customer Service" ;
-    rdfs:subClassOf :CAPEC-407 ;
-    :capec-id "CAPEC-412" ;
-    :definition "An adversary engages in pretexting behavior, assuming the role of someone who works for Customer Service, to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. One example of a scenario such as this would be to call an individual, articulate your false affiliation with a credit card company, and then attempt to get the individual to verify their credit card number." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/412.html> .
-
-:CAPEC-413 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pretexting via Tech Support" ;
-    rdfs:subClassOf :CAPEC-407 ;
-    :capec-id "CAPEC-413" ;
-    :definition "An adversary engages in pretexting behavior, assuming the role of a tech support worker, to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. An adversary who uses social engineering to impersonate a tech support worker can have devastating effects on a network. This is an effective attack vector, because it can give an adversary physical access to network computers. It only takes a matter of seconds for someone to compromise a computer with physical access. One of the best technological tools at the disposal of a social engineer, posing as a technical support person, is a USB thumb drive. These are small, easy to conceal, and can be loaded with different payloads depending on what task needs to be done. However, this form of attack does not require physical access as it can also be effectively carried out via phone or email." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/413.html> .
-
-:CAPEC-414 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pretexting via Delivery Person" ;
-    rdfs:subClassOf :CAPEC-407 ;
-    :capec-id "CAPEC-414" ;
-    :definition "An adversary engages in pretexting behavior, assuming the role of a delivery person, to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. Impersonating a delivery person is an effective attack and an easy attack since not much acting is involved. Usually the hardest part is looking the part and having all of the proper credentials, papers and \"deliveries\" in order to be able to pull it off." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/414.html> .
-
-:CAPEC-415 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pretexting via Phone" ;
-    rdfs:subClassOf :CAPEC-407 ;
-    :capec-id "CAPEC-415" ;
-    :definition "An adversary engages in pretexting behavior, assuming some sort of trusted role, and contacting the targeted individual or organization via phone to solicit information from target persons, or manipulate the target into performing an action that serves the adversary's interests. This is the most common social engineering attack. Some of the most commonly effective approaches are to impersonate a fellow employee, impersonate a computer technician or to target help desk personnel." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/415.html> .
-
-:CAPEC-416 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulate Human Behavior" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-416" ;
-    :definition "An adversary exploits inherent human psychological predisposition to influence a targeted individual or group to solicit information or manipulate the target into performing an action that serves the adversary's interests. Many interpersonal social engineering techniques do not involve outright deception, although they can; many are subtle ways of manipulating a target to remove barriers, make the target feel comfortable, and produce an exchange in which the target is either more likely to share information directly, or let key information slip out unintentionally. A skilled adversary uses these techniques when appropriate to produce the desired outcome. Manipulation techniques vary from the overt, such as pretending to be a supervisor to a help desk, to the subtle, such as making the target feel comfortable with the adversary's speech and thought patterns." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/416.html> .
-
-:CAPEC-417 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence Perception" ;
-    rdfs:subClassOf :CAPEC-416 ;
-    :capec-id "CAPEC-417" ;
-    :definition "The adversary uses social engineering to exploit the target's perception of the relationship between the adversary and themselves. This goal is to persuade the target to unknowingly perform an action or divulge information that is advantageous to the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/417.html> .
-
-:CAPEC-418 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence Perception of Reciprocation" ;
-    rdfs:subClassOf :CAPEC-417 ;
-    :capec-id "CAPEC-418" ;
-    :definition "An adversary uses a social engineering techniques to produce a sense of obligation in the target to perform a certain action or concede some sensitive or key piece of information. Obligation has to do with actions one feels they need to take due to some sort of social, legal, or moral requirement, duty, contract, or promise. There are various techniques for fostering a sense of obligation to reciprocate or concede during ordinary modes of communication. One method is to compliment the target, and follow up the compliment with a question. If performed correctly the target may volunteer a key piece of information, sometimes involuntarily." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/418.html> .
-
-:CAPEC-419 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Target Influence via Perception of Concession" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it was deemed not to be a legitimate pattern." ;
-    :capec-id "CAPEC-419" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/419.html> .
-
-:CAPEC-420 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence Perception of Scarcity" ;
-    rdfs:subClassOf :CAPEC-417 ;
-    :capec-id "CAPEC-420" ;
-    :definition "The adversary leverages a perception of scarcity to persuade the target to perform an action or divulge information that is advantageous to the adversary. By conveying a perception of scarcity, or a situation of limited supply, the adversary aims to create a sense of urgency in the context of a target's decision-making process." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/420.html> .
-
-:CAPEC-421 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence Perception of Authority" ;
-    rdfs:subClassOf :CAPEC-417 ;
-    :capec-id "CAPEC-421" ;
-    :definition "An adversary uses a social engineering technique to convey a sense of authority that motivates the target to reveal specific information or take specific action. There are various techniques for producing a sense of authority during ordinary modes of communication. One common method is impersonation. By impersonating someone with a position of power within an organization, an adversary may motivate the target individual to reveal some piece of sensitive information or perform an action that benefits the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/421.html> .
-
-:CAPEC-422 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence Perception of Commitment and Consistency" ;
-    rdfs:subClassOf :CAPEC-417 ;
-    :capec-id "CAPEC-422" ;
-    :definition "An adversary uses social engineering to convince the target to do minor tasks as opposed to larger actions. After complying with a request, individuals are more likely to agree to subsequent requests that are similar in type and required effort." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/422.html> .
-
-:CAPEC-423 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence Perception of Liking" ;
-    rdfs:subClassOf :CAPEC-417 ;
-    :capec-id "CAPEC-423" ;
-    :definition "The adversary influences the target's actions by building a relationship where the target has a liking to the adversary. People are more likely to be influenced by people of whom they are fond, so the adversary attempts to ingratiate themself with the target via actions, appearance, or a combination thereof." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/423.html> .
-
-:CAPEC-424 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence Perception of Consensus or Social Proof" ;
-    rdfs:subClassOf :CAPEC-417 ;
-    :capec-id "CAPEC-424" ;
-    :definition "The adversary influences the target's actions by leveraging the inherent human nature to assume behavior of others is appropriate. In situations of uncertainty, people tend to behave in ways they see others behaving. The adversary convinces the target of adopting behavior or actions that is advantageous to the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/424.html> .
-
-:CAPEC-425 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Target Influence via Framing" ;
-    rdfs:subClassOf :CAPEC-416 ;
-    :capec-id "CAPEC-425" ;
-    :definition "An adversary uses framing techniques to contextualize a conversation so that the target is more likely to be influenced by the adversary's point of view. Framing is information and experiences in life that alter the way we react to decisions we must make. This type of persuasive technique exploits the way people are conditioned to perceive data and its significance, while avoiding negative or avoidance responses from the target. Rather than a specific technique framing is a methodology of conversation that slowly encourages the target to adopt to the adversary's perspective. One technique of framing is to avoid the use of the word \"No\" and to contextualize responses in a manner that is positive. When performed skillfully the target is much more likely to volunteer information or perform actions favorable to the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/425.html> .
-
-:CAPEC-426 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence via Incentives" ;
-    rdfs:subClassOf :CAPEC-416 ;
-    :capec-id "CAPEC-426" ;
-    :definition "The adversary incites a behavior from the target by manipulating something of influence. This is commonly associated with financial, social, or ideological incentivization. Examples include monetary fraud, peer pressure, and preying on the target's morals or ethics. The most effective incentive against one target might not be as effective against another, therefore the adversary must gather information about the target's vulnerability to particular incentives." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/426.html> .
-
-:CAPEC-427 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence via Psychological Principles" ;
-    rdfs:subClassOf :CAPEC-416 ;
-    :capec-id "CAPEC-427" ;
-    :definition "The adversary shapes the target's actions or behavior by focusing on the ways human interact and learn, leveraging such elements as cognitive and social psychology. In a variety of ways, a target can be influenced to behave or perform an action through capitalizing on what scholarship and research has learned about how and why humans react to specific scenarios and cues." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/427.html> .
-
-:CAPEC-428 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Influence via Modes of Thinking" ;
-    rdfs:subClassOf :CAPEC-427 ;
-    :capec-id "CAPEC-428" ;
-    :definition "The adversary tailors their communication to the language and thought patterns of the target thereby weakening barriers or reluctance to communication. This method is a way of building rapport with a target by matching their speech patterns and the primary ways or dominant senses with which they make abstractions. This technique can be used to make the target more receptive to sharing information because the adversary has adapted their communication forms to match those of the target. When skillfully employed, the target is likely to be unaware that they are being manipulated." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/428.html> .
-
-:CAPEC-429 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Target Influence via Eye Cues" ;
-    rdfs:subClassOf :CAPEC-427 ;
-    :capec-id "CAPEC-429" ;
-    :definition "The adversary gains information via non-verbal means from the target through eye movements." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/429.html> .
-
-:CAPEC-430 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED:  Target Influence via Micro-Expressions" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated." ;
-    :capec-id "CAPEC-430" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/430.html> .
-
-:CAPEC-431 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED:  Target Influence via Neuro-Linguistic Programming (NLP)" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated." ;
-    :capec-id "CAPEC-431" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/431.html> .
-
-:CAPEC-432 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED:  Target Influence via Voice in NLP" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated." ;
-    :capec-id "CAPEC-432" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/432.html> .
-
-:CAPEC-433 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Target Influence via The Human Buffer Overflow" ;
-    rdfs:subClassOf :CAPEC-427 ;
-    :capec-id "CAPEC-433" ;
-    :definition "An attacker utilizes a technique to insinuate commands to the subconscious mind of the target via communication patterns. The human buffer overflow methodology does not rely on over-stimulating the mind of the target, but rather embedding messages within communication that the mind of the listener assembles at a subconscious level. The human buffer-overflow method is similar to subconscious programming to the extent that messages are embedded within the message." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/433.html> .
-
-:CAPEC-434 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Target Influence via Interview and Interrogation" ;
-    rdfs:subClassOf :CAPEC-427 ;
-    :capec-id "CAPEC-434" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/434.html> .
-
-:CAPEC-435 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Target Influence via Instant Rapport" ;
-    rdfs:subClassOf :CAPEC-427 ;
-    :capec-id "CAPEC-435" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/435.html> .
-
-:CAPEC-438 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Modification During Manufacture" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-438" ;
-    :definition "An attacker modifies a technology, product, or component during a stage in its manufacture for the purpose of carrying out an attack against some entity involved in the supply chain lifecycle. There are an almost limitless number of ways an attacker can modify a technology when they are involved in its manufacture, as the attacker has potential inroads to the software composition, hardware design and assembly, firmware, or basic design mechanics. Additionally, manufacturing of key components is often outsourced with the final product assembled by the primary manufacturer. The greatest risk, however, is deliberate manipulation of design specifications to produce malicious hardware or devices. There are billions of transistors in a single integrated circuit and studies have shown that fewer than 10 transistors are required to create malicious functionality." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/438.html> ;
-    :related :T1195 .
-
-:CAPEC-439 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Manipulation During Distribution" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-439" ;
-    :definition "An attacker undermines the integrity of a product, software, or technology at some stage of the distribution channel. The core threat of modification or manipulation during distribution arise from the many stages of distribution, as a product may traverse multiple suppliers and integrators as the final asset is delivered. Components and services provided from a manufacturer to a supplier may be tampered with during integration or packaging." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/439.html> ;
-    :related :CWE-1269,
-        :T1195 .
-
-:CAPEC-440 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hardware Integrity Attack" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-440" ;
-    :definition "An adversary exploits a weakness in the system maintenance process and causes a change to be made to a technology, product, component, or sub-component or a new one installed during its deployed use at the victim location for the purpose of carrying out an attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/440.html> ;
-    :related :T1195.003,
-        :T1200 .
-
-:CAPEC-441 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Logic Insertion" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-441" ;
-    :definition "An adversary installs or adds malicious logic (also known as malware) into a seemingly benign component of a fielded system. This logic is often hidden from the user of the system and works behind the scenes to achieve negative impacts. With the proliferation of mass digital storage and inexpensive multimedia devices, Bluetooth and 802.11 support, new attack vectors for spreading malware are emerging for things we once thought of as innocuous greeting cards, picture frames, or digital projectors. This pattern of attack focuses on systems already fielded and used in operation as opposed to systems and their components that are still under development and part of the supply chain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/441.html> ;
-    :related :CWE-284 .
-
-:CAPEC-442 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Infected Software" ;
-    rdfs:subClassOf :CAPEC-441 ;
-    :capec-id "CAPEC-442" ;
-    :definition "An adversary adds malicious logic, often in the form of a computer virus, to otherwise benign software. This logic is often hidden from the user of the software and works behind the scenes to achieve negative impacts. Many times, the malicious logic is inserted into empty space between legitimate code, and is then called when the software is executed. This pattern of attack focuses on software already fielded and used in operation as opposed to software that is still under development and part of the supply chain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/442.html> ;
-    :related :CWE-506,
-        :T1195.001,
-        :T1195.002 .
-
-:CAPEC-443 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Logic Inserted Into Product by Authorized Developer" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-443" ;
-    :definition "An adversary uses their privileged position within an authorized development organization to inject malicious logic into a codebase or product." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/443.html> ;
-    :related :T1195.002,
-        :T1195.003 .
-
-:CAPEC-444 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Development Alteration" ;
-    rdfs:subClassOf :CAPEC-438 ;
-    :capec-id "CAPEC-444" ;
-    :definition "An adversary modifies a technology, product, or component during its development to acheive a negative impact once the system is deployed. The goal of the adversary is to modify the system in such a way that the negative impact can be leveraged when the system is later deployed. Development alteration attacks may include attacks that insert malicious logic into the system's software, modify or replace hardware components, and other attacks which negatively impact the system during development. These attacks generally require insider access to modify source code or to tamper with hardware components. The product is then delivered to the user where the negative impact can be leveraged at a later time." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/444.html> .
-
-:CAPEC-445 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Logic Insertion into Product Software via Configuration Management Manipulation" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-445" ;
-    :definition "An adversary exploits a configuration management system so that malicious logic is inserted into a software products build, update or deployed environment. If an adversary can control the elements included in a product's configuration management for build they can potentially replace, modify or insert code files containing malicious logic. If an adversary can control elements of a product's ongoing operational configuration management baseline they can potentially force clients receiving updates from the system to install insecure software when receiving updates from the server." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/445.html> ;
-    :related :T1195.001 .
-
-:CAPEC-446 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Logic Insertion into Product via Inclusion of Third-Party Component" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-446" ;
-    :definition "An adversary conducts supply chain attacks by the inclusion of insecure third-party components into a technology, product, or code-base, possibly packaging a malicious driver or component along with the product before shipping it to the consumer or acquirer." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/446.html> ;
-    :related :T1195 .
-
-:CAPEC-447 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Design Alteration" ;
-    rdfs:subClassOf :CAPEC-438 ;
-    :capec-id "CAPEC-447" ;
-    :definition "An adversary modifies the design of a technology, product, or component to acheive a negative impact once the system is deployed. In this type of attack, the goal of the adversary is to modify the design of the system, prior to development starting, in such a way that the negative impact can be leveraged when the system is later deployed. Design alteration attacks differ from development alteration attacks in that design alteration attacks take place prior to development and which then may or may not be developed by the adverary. Design alteration attacks include modifying system designs to degrade system performance, cause unexpected states or errors, and general design changes that may lead to additional vulnerabilities. These attacks generally require insider access to modify design documents, but they may also be spoofed via web communications. The product is then developed and delivered to the user where the negative impact can be leveraged at a later time." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/447.html> .
-
-:CAPEC-448 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Embed Virus into DLL" ;
-    rdfs:subClassOf :CAPEC-442 ;
-    :capec-id "CAPEC-448" ;
-    :definition "An adversary tampers with a DLL and embeds a computer virus into gaps between legitimate machine instructions. These gaps may be the result of compiler optimizations that pad memory blocks for performance gains. The embedded virus then attempts to infect any machine which interfaces with the product, and possibly steal private data or eavesdrop." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/448.html> ;
-    :related :CWE-506,
-        :T1027.009 .
-
-:CAPEC-449 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Malware Propagation via USB Stick" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-448 : Malware Infection into Product Software. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-449" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/449.html> .
-
-:CAPEC-450 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Malware Propagation via USB U3 Autorun" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-448 : Embed Virus into DLL. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-450" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/450.html> .
-
-:CAPEC-451 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Malware Propagation via Infected Peripheral Device" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-448 : Malware Infection into Product Software. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-451" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/451.html> .
-
-:CAPEC-452 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Infected Hardware" ;
-    rdfs:subClassOf :CAPEC-441 ;
-    :capec-id "CAPEC-452" ;
-    :definition "An adversary inserts malicious logic into hardware, typically in the form of a computer virus or rootkit. This logic is often hidden from the user of the hardware and works behind the scenes to achieve negative impacts. This pattern of attack focuses on hardware already fielded and used in operation as opposed to hardware that is still under development and part of the supply chain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/452.html> .
-
-:CAPEC-453 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Malicious Logic Insertion via Counterfeit Hardware" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-452 : Malicious Logic Insertion into Product Hardware. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-453" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/453.html> .
-
-:CAPEC-454 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Modification of Existing Components with Counterfeit Hardware" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-452 : Malicious Logic Insertion into Product Hardware. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-454" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/454.html> .
-
-:CAPEC-455 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Malicious Logic Insertion via Inclusion of Counterfeit Hardware Components" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it is a duplicate of CAPEC-457 : Malicious Logic Insertion into Product Hardware. Please refer to this other pattern going forward." ;
-    :capec-id "CAPEC-455" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/455.html> .
-
-:CAPEC-456 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Infected Memory" ;
-    rdfs:subClassOf :CAPEC-441 ;
-    :capec-id "CAPEC-456" ;
-    :definition "An adversary inserts malicious logic into memory enabling them to achieve a negative impact. This logic is often hidden from the user of the system and works behind the scenes to achieve negative impacts. This pattern of attack focuses on systems already fielded and used in operation as opposed to systems that are still under development and part of the supply chain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/456.html> ;
-    :related :CWE-1257,
-        :CWE-1260,
-        :CWE-1274,
-        :CWE-1312,
-        :CWE-1316 .
-
-:CAPEC-457 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "USB Memory Attacks" ;
-    rdfs:subClassOf :CAPEC-456 ;
-    :capec-id "CAPEC-457" ;
-    :definition "An adversary loads malicious code onto a USB memory stick in order to infect any system which the device is plugged in to. USB drives present a significant security risk for business and government agencies. Given the ability to integrate wireless functionality into a USB stick, it is possible to design malware that not only steals confidential data, but sniffs the network, or monitor keystrokes, and then exfiltrates the stolen data off-site via a Wireless connection. Also, viruses can be transmitted via the USB interface without the specific use of a memory stick. The attacks from USB devices are often of such sophistication that experts conclude they are not the work of single individuals, but suggest state sponsorship. These attacks can be performed by an adversary with direct access to a target system or can be executed via means such as USB Drop Attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/457.html> ;
-    :related :CWE-1299,
-        :T1091,
-        :T1092 .
-
-:CAPEC-458 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Flash Memory Attacks" ;
-    rdfs:subClassOf :CAPEC-456 ;
-    :capec-id "CAPEC-458" ;
-    :definition "An adversary inserts malicious logic into a product or technology via flashing the on-board memory with a code-base that contains malicious logic. Various attacks exist against the integrity of flash memory, the most direct being rootkits coded into the BIOS or chipset of a device." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/458.html> ;
-    :related :CAPEC-665,
-        :CWE-1282 .
-
-:CAPEC-459 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Creating a Rogue Certification Authority Certificate" ;
-    rdfs:subClassOf :CAPEC-473 ;
-    :capec-id "CAPEC-459" ;
-    :definition "An adversary exploits a weakness resulting from using a hashing algorithm with weak collision resistance to generate certificate signing requests (CSR) that contain collision blocks in their \"to be signed\" parts. The adversary submits one CSR to be signed by a trusted certificate authority then uses the signed blob to make a second certificate appear signed by said certificate authority. Due to the hash collision, both certificates, though different, hash to the same value and so the signed blob works just as well in the second certificate. The net effect is that the adversary's second X.509 certificate, which the Certification Authority has never seen, is now signed and validated by that Certification Authority." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/459.html> ;
-    :related :CWE-290,
-        :CWE-295,
-        :CWE-327 .
-
-:CAPEC-460 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP Parameter Pollution (HPP)" ;
-    rdfs:subClassOf :CAPEC-15 ;
-    :capec-id "CAPEC-460" ;
-    :definition "An adversary adds duplicate HTTP GET/POST parameters by injecting query string delimiters. Via HPP it may be possible to override existing hardcoded HTTP parameters, modify the application behaviors, access and, potentially exploit, uncontrollable variables, and bypass input validation checkpoints and WAF rules." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/460.html> ;
-    :related :CWE-88,
-        :CWE-147,
-        :CWE-235 .
-
-:CAPEC-461 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Web Services API Signature Forgery Leveraging Hash Function Extension Weakness" ;
-    rdfs:subClassOf :CAPEC-115 ;
-    :capec-id "CAPEC-461" ;
-    :definition "An adversary utilizes a hash function extension/padding weakness, to modify the parameters passed to the web service requesting authentication by generating their own call in order to generate a legitimate signature hash (as described in the notes), without knowledge of the secret token sometimes provided by the web service." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/461.html> ;
-    :related :CWE-290,
-        :CWE-328 .
-
-:CAPEC-462 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross-Domain Search Timing" ;
-    rdfs:subClassOf :CAPEC-54 ;
-    :capec-id "CAPEC-462" ;
-    :definition "An attacker initiates cross domain HTTP / GET requests and times the server responses. The timing of these responses may leak important information on what is happening on the server. Browser's same origin policy prevents the attacker from directly reading the server responses (in the absence of any other weaknesses), but does not prevent the attacker from timing the responses to requests that the attacker issued cross domain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/462.html> ;
-    :related :CWE-208,
-        :CWE-352,
-        :CWE-385 .
-
-:CAPEC-463 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Padding Oracle Crypto Attack" ;
-    rdfs:subClassOf :CAPEC-97 ;
-    :capec-id "CAPEC-463" ;
-    :definition "An adversary is able to efficiently decrypt data without knowing the decryption key if a target system leaks data on whether or not a padding error happened while decrypting the ciphertext. A target system that leaks this type of information becomes the padding oracle and an adversary is able to make use of that oracle to efficiently decrypt data without knowing the decryption key by issuing on average 128*b calls to the padding oracle (where b is the number of bytes in the ciphertext block). In addition to performing decryption, an adversary is also able to produce valid ciphertexts (i.e., perform encryption) by using the padding oracle, all without knowing the encryption key." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/463.html> ;
-    :related :CWE-209,
-        :CWE-347,
-        :CWE-354,
-        :CWE-514,
-        :CWE-649,
-        :CWE-696 .
-
-:CAPEC-464 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Evercookie" ;
-    rdfs:subClassOf :CAPEC-554 ;
-    :capec-id "CAPEC-464" ;
-    :definition "An attacker creates a very persistent cookie that stays present even after the user thinks it has been removed. The cookie is stored on the victim's machine in over ten places. When the victim clears the cookie cache via traditional means inside the browser, that operation removes the cookie from certain places but not others. The malicious code then replicates the cookie from all of the places where it was not deleted to all of the possible storage locations once again. So the victim again has the cookie in all of the original storage locations. In other words, failure to delete the cookie in even one location will result in the cookie's resurrection everywhere. The evercookie will also persist across different browsers because certain stores (e.g., Local Shared Objects) are shared between different browsers." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/464.html> ;
-    :related :CWE-359,
-        :T1606.001 .
-
-:CAPEC-465 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Transparent Proxy Abuse" ;
-    rdfs:subClassOf :CAPEC-554 ;
-    :capec-id "CAPEC-465" ;
-    :definition "A transparent proxy serves as an intermediate between the client and the internet at large. It intercepts all requests originating from the client and forwards them to the correct location. The proxy also intercepts all responses to the client and forwards these to the client. All of this is done in a manner transparent to the client." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/465.html> ;
-    :related :CWE-441,
-        :T1090.001 .
-
-:CAPEC-466 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Leveraging Active Adversary in the Middle Attacks to Bypass Same Origin Policy" ;
-    rdfs:subClassOf :CAPEC-94 ;
-    :capec-id "CAPEC-466" ;
-    :definition "An attacker leverages an adversary in the middle attack (CAPEC-94) in order to bypass the same origin policy protection in the victim's browser. This active adversary in the middle attack could be launched, for instance, when the victim is connected to a public WIFI hot spot. An attacker is able to intercept requests and responses between the victim's browser and some non-sensitive website that does not use TLS." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/466.html> ;
-    :related :CWE-300 .
-
-:CAPEC-467 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross Site Identification" ;
-    rdfs:subClassOf :CAPEC-62 ;
-    :capec-id "CAPEC-467" ;
-    :definition "An attacker harvests identifying information about a victim via an active session that the victim's browser has with a social networking site. A victim may have the social networking site open in one tab or perhaps is simply using the \"remember me\" feature to keep their session with the social networking site active. An attacker induces a payload to execute in the victim's browser that transparently to the victim initiates a request to the social networking site (e.g., via available social network site APIs) to retrieve identifying information about a victim. While some of this information may be public, the attacker is able to harvest this information in context and may use it for further attacks on the user (e.g., spear phishing)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/467.html> ;
-    :related :CWE-352,
-        :CWE-359 .
-
-:CAPEC-468 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Generic Cross-Browser Cross-Domain Theft" ;
-    rdfs:subClassOf :CAPEC-242 ;
-    :capec-id "CAPEC-468" ;
-    :definition "An attacker makes use of Cascading Style Sheets (CSS) injection to steal data cross domain from the victim's browser. The attack works by abusing the standards relating to loading of CSS: 1. Send cookies on any load of CSS (including cross-domain) 2. When parsing returned CSS ignore all data that does not make sense before a valid CSS descriptor is found by the CSS parser." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/468.html> ;
-    :related :CWE-149,
-        :CWE-177,
-        :CWE-707,
-        :CWE-838 .
-
-:CAPEC-469 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP DoS" ;
-    rdfs:subClassOf :CAPEC-227 ;
-    :capec-id "CAPEC-469" ;
-    :definition "An attacker performs flooding at the HTTP level to bring down only a particular web application rather than anything listening on a TCP/IP connection. This denial of service attack requires substantially fewer packets to be sent which makes DoS harder to detect. This is an equivalent of SYN flood in HTTP. The idea is to keep the HTTP session alive indefinitely and then repeat that hundreds of times. This attack targets resource depletion weaknesses in web server software. The web server will wait to attacker's responses on the initiated HTTP sessions while the connection threads are being exhausted." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/469.html> ;
-    :related :CWE-770,
-        :CWE-772,
-        :T1499.002 .
-
-:CAPEC-470 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Expanding Control over the Operating System from the Database" ;
-    rdfs:subClassOf :CAPEC-66 ;
-    :capec-id "CAPEC-470" ;
-    :definition "An attacker is able to leverage access gained to the database to read / write data to the file system, compromise the operating system, create a tunnel for accessing the host machine, and use this access to potentially attack other machines on the same network as the database machine. Traditionally SQL injections attacks are viewed as a way to gain unauthorized read access to the data stored in the database, modify the data in the database, delete the data, etc. However, almost every data base management system (DBMS) system includes facilities that if compromised allow an attacker complete access to the file system, operating system, and full access to the host running the database. The attacker can then use this privileged access to launch subsequent attacks. These facilities include dropping into a command shell, creating user defined functions that can call system level libraries present on the host machine, stored procedures, etc." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/470.html> ;
-    :related :CWE-89,
-        :CWE-250 .
-
-:CAPEC-471 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Search Order Hijacking" ;
-    rdfs:subClassOf :CAPEC-159 ;
-    :capec-id "CAPEC-471" ;
-    :definition "An adversary exploits a weakness in an application's specification of external libraries to exploit the functionality of the loader where the process loading the library searches first in the same directory in which the process binary resides and then in other directories. Exploitation of this preferential search order can allow an attacker to make the loading process load the adversary's rogue library rather than the legitimate library. This attack can be leveraged with many different libraries and with many different loading processes. No forensic trails are left in the system's registry or file system that an incorrect library had been loaded." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/471.html> ;
-    :related :CWE-427,
-        :T1574.001,
-        :T1574.004,
-        :T1574.008 .
-
-:CAPEC-472 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Browser Fingerprinting" ;
-    rdfs:subClassOf :CAPEC-541 ;
-    :capec-id "CAPEC-472" ;
-    :definition "An attacker carefully crafts small snippets of Java Script to efficiently detect the type of browser the potential victim is using. Many web-based attacks need prior knowledge of the web browser including the version of browser to ensure successful exploitation of a vulnerability. Having this knowledge allows an attacker to target the victim with attacks that specifically exploit known or zero day weaknesses in the type and version of the browser used by the victim. Automating this process via Java Script as a part of the same delivery system used to exploit the browser is considered more efficient as the attacker can supply a browser fingerprinting method and integrate it with exploit code, all contained in Java Script and in response to the same web page request by the browser." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/472.html> ;
-    :related :CWE-200 .
-
-:CAPEC-473 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signature Spoof" ;
-    rdfs:subClassOf :CAPEC-151 ;
-    :capec-id "CAPEC-473" ;
-    :definition "An attacker generates a message or datablock that causes the recipient to believe that the message or datablock was generated and cryptographically signed by an authoritative or reputable source, misleading a victim or victim operating system into performing malicious actions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/473.html> ;
-    :related :CWE-20,
-        :CWE-290,
-        :CWE-327,
-        :T1036.001,
-        :T1553.002 .
-
-:CAPEC-474 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signature Spoofing by Key Theft" ;
-    rdfs:subClassOf :CAPEC-473 ;
-    :capec-id "CAPEC-474" ;
-    :definition "An attacker obtains an authoritative or reputable signer's private signature key by theft and then uses this key to forge signatures from the original signer to mislead a victim into performing actions that benefit the attacker." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/474.html> ;
-    :related :CWE-522,
-        :T1552.004 .
-
-:CAPEC-475 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signature Spoofing by Improper Validation" ;
-    rdfs:subClassOf :CAPEC-473 ;
-    :capec-id "CAPEC-475" ;
-    :definition "An adversary exploits a cryptographic weakness in the signature verification algorithm implementation to generate a valid signature without knowing the key." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/475.html> ;
-    :related :CWE-295,
-        :CWE-327,
-        :CWE-347 .
-
-:CAPEC-476 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signature Spoofing by Misrepresentation" ;
-    rdfs:subClassOf :CAPEC-473 ;
-    :capec-id "CAPEC-476" ;
-    :definition "An attacker exploits a weakness in the parsing or display code of the recipient software to generate a data blob containing a supposedly valid signature, but the signer's identity is falsely represented, which can lead to the attacker manipulating the recipient software or its victim user to perform compromising actions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/476.html> ;
-    :related :CWE-290 .
-
-:CAPEC-477 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signature Spoofing by Mixing Signed and Unsigned Content" ;
-    rdfs:subClassOf :CAPEC-473 ;
-    :capec-id "CAPEC-477" ;
-    :definition "An attacker exploits the underlying complexity of a data structure that allows for both signed and unsigned content, to cause unsigned data to be processed as though it were signed data." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/477.html> ;
-    :related :CWE-311,
-        :CWE-319,
-        :CWE-693 .
-
-:CAPEC-478 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Modification of Windows Service Configuration" ;
-    rdfs:subClassOf :CAPEC-203 ;
-    :capec-id "CAPEC-478" ;
-    :definition "An adversary exploits a weakness in access control to modify the execution parameters of a Windows service. The goal of this attack is to execute a malicious binary in place of an existing service." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/478.html> ;
-    :related :CWE-284,
-        :T1543.003,
-        :T1574.011 .
-
-:CAPEC-479 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Root Certificate" ;
-    rdfs:subClassOf :CAPEC-473 ;
-    :capec-id "CAPEC-479" ;
-    :definition "An adversary exploits a weakness in authorization and installs a new root certificate on a compromised system. Certificates are commonly used for establishing secure TLS/SSL communications within a web browser. When a user attempts to browse a website that presents a certificate that is not trusted an error message will be displayed to warn the user of the security risk. Depending on the security settings, the browser may not allow the user to establish a connection to the website. Adversaries have used this technique to avoid security warnings prompting users when compromised systems connect over HTTPS to adversary controlled web servers that spoof legitimate websites in order to collect login credentials." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/479.html> ;
-    :related :CWE-284,
-        :T1553.004 .
-
-:CAPEC-480 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Escaping Virtualization" ;
-    rdfs:subClassOf :CAPEC-115 ;
-    :capec-id "CAPEC-480" ;
-    :definition "An adversary gains access to an application, service, or device with the privileges of an authorized or privileged user by escaping the confines of a virtualized environment. The adversary is then able to access resources or execute unauthorized code within the host environment, generally with the privileges of the user running the virtualized process. Successfully executing an attack of this type is often the first step in executing more complex attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/480.html> ;
-    :related :CWE-693,
-        :T1611 .
-
-:CAPEC-481 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Contradictory Destinations in Traffic Routing Schemes" ;
-    rdfs:subClassOf :CAPEC-161 ;
-    :capec-id "CAPEC-481" ;
-    :definition "Adversaries can provide contradictory destinations when sending messages. Traffic is routed in networks using the domain names in various headers available at different levels of the OSI model. In a Content Delivery Network (CDN) multiple domains might be available, and if there are contradictory domain names provided it is possible to route traffic to an inappropriate destination. The technique, called Domain Fronting, involves using different domain names in the SNI field of the TLS header and the Host field of the HTTP header. An alternative technique, called Domainless Fronting, is similar, but the SNI field is left blank." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/481.html> ;
-    :related :CWE-923,
-        :T1090.004 .
-
-:CAPEC-482 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Flood" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-482" ;
-    :definition "An adversary may execute a flooding attack using the TCP protocol with the intent to deny legitimate users access to a service. These attacks exploit the weakness within the TCP protocol where there is some state information for the connection the server needs to maintain. This often involves the use of TCP SYN messages." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/482.html> ;
-    :related :CWE-770,
-        :T1498.001,
-        :T1499.001,
-        :T1499.002 .
-
-:CAPEC-484 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: XML Client-Side Attack" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated as it a generalization of CAPEC-230: XML Nested Payloads and CAPEC-231: XML Oversized Payloads. Please refer to these CAPECs going forward." ;
-    :capec-id "CAPEC-484" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/484.html> .
-
-:CAPEC-485 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signature Spoofing by Key Recreation" ;
-    rdfs:subClassOf :CAPEC-473 ;
-    :capec-id "CAPEC-485" ;
-    :definition "An attacker obtains an authoritative or reputable signer's private signature key by exploiting a cryptographic weakness in the signature algorithm or pseudorandom number generation and then uses this key to forge signatures from the original signer to mislead a victim into performing actions that benefit the attacker." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/485.html> ;
-    :related :CWE-330,
-        :T1552.004 .
-
-:CAPEC-486 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "UDP Flood" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-486" ;
-    :definition "An adversary may execute a flooding attack using the UDP protocol with the intent to deny legitimate users access to a service by consuming the available network bandwidth. Additionally, firewalls often open a port for each UDP connection destined for a service with an open UDP port, meaning the firewalls in essence save the connection state thus the high packet nature of a UDP flood can also overwhelm resources allocated to the firewall. UDP attacks can also target services like DNS or VoIP which utilize these protocols. Additionally, due to the session-less nature of the UDP protocol, the source of a packet is easily spoofed making it difficult to find the source of the attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/486.html> ;
-    :related :CWE-770 .
-
-:CAPEC-487 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP Flood" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-487" ;
-    :definition "An adversary may execute a flooding attack using the ICMP protocol with the intent to deny legitimate users access to a service by consuming the available network bandwidth. A typical attack involves a victim server receiving ICMP packets at a high rate from a wide range of source addresses. Additionally, due to the session-less nature of the ICMP protocol, the source of a packet is easily spoofed making it difficult to find the source of the attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/487.html> ;
-    :related :CWE-770 .
-
-:CAPEC-488 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "HTTP Flood" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-488" ;
-    :definition "An adversary may execute a flooding attack using the HTTP protocol with the intent to deny legitimate users access to a service by consuming resources at the application layer such as web services and their infrastructure. These attacks use legitimate session-based HTTP GET requests designed to consume large amounts of a server's resources. Since these are legitimate sessions this attack is very difficult to detect." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/488.html> ;
-    :related :CWE-770,
-        :T1499.002 .
-
-:CAPEC-489 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SSL Flood" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-489" ;
-    :definition "An adversary may execute a flooding attack using the SSL protocol with the intent to deny legitimate users access to a service by consuming all the available resources on the server side. These attacks take advantage of the asymmetric relationship between the processing power used by the client and the processing power used by the server to create a secure connection. In this manner the attacker can make a large number of HTTPS requests on a low provisioned machine to tie up a disproportionately large number of resources on the server. The clients then continue to keep renegotiating the SSL connection. When multiplied by a large number of attacking machines, this attack can result in a crash or loss of service to legitimate users." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/489.html> ;
-    :related :CWE-770,
-        :T1499.002 .
-
-:CAPEC-490 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Amplification" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-490" ;
-    :definition "An adversary may execute an amplification where the size of a response is far greater than that of the request that generates it. The goal of this attack is to use a relatively few resources to create a large amount of traffic against a target server. To execute this attack, an adversary send a request to a 3rd party service, spoofing the source address to be that of the target server. The larger response that is generated by the 3rd party service is then sent to the target server. By sending a large number of initial requests, the adversary can generate a tremendous amount of traffic directed at the target. The greater the discrepancy in size between the initial request and the final payload delivered to the target increased the effectiveness of this attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/490.html> ;
-    :related :CWE-770,
-        :T1498.002 .
-
-:CAPEC-491 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Quadratic Data Expansion" ;
-    rdfs:subClassOf :CAPEC-230 ;
-    :capec-id "CAPEC-491" ;
-    :definition "An adversary exploits macro-like substitution to cause a denial of service situation due to excessive memory being allocated to fully expand the data. The result of this denial of service could cause the application to freeze or crash. This involves defining a very large entity and using it multiple times in a single entity substitution. CAPEC-197 is a similar attack pattern, but it is easier to discover and defend against. This attack pattern does not perform multi-level substitution and therefore does not obviously appear to consume extensive resources." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/491.html> ;
-    :related :CWE-770 .
-
-:CAPEC-492 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Regular Expression Exponential Blowup" ;
-    rdfs:subClassOf :CAPEC-130 ;
-    :capec-id "CAPEC-492" ;
-    :definition "An adversary may execute an attack on a program that uses a poor Regular Expression(Regex) implementation by choosing input that results in an extreme situation for the Regex. A typical extreme situation operates at exponential time compared to the input size. This is due to most implementations using a Nondeterministic Finite Automaton(NFA) state machine to be built by the Regex algorithm since NFA allows backtracking and thus more complex regular expressions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/492.html> ;
-    :related :CWE-400,
-        :CWE-1333 .
-
-:CAPEC-493 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SOAP Array Blowup" ;
-    rdfs:subClassOf :CAPEC-130 ;
-    :capec-id "CAPEC-493" ;
-    :definition "An adversary may execute an attack on a web service that uses SOAP messages in communication. By sending a very large SOAP array declaration to the web service, the attacker forces the web service to allocate space for the array elements before they are parsed by the XML parser. The attacker message is typically small in size containing a large array declaration of say 1,000,000 elements and a couple of array elements. This attack targets exhaustion of the memory resources of the web service." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/493.html> ;
-    :related :CWE-770 .
-
-:CAPEC-494 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP Fragmentation" ;
-    rdfs:subClassOf :CAPEC-130 ;
-    :capec-id "CAPEC-494" ;
-    :definition "An adversary may execute a TCP Fragmentation attack against a target with the intention of avoiding filtering rules of network controls, by attempting to fragment the TCP packet such that the headers flag field is pushed into the second fragment which typically is not filtered." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/494.html> ;
-    :related :CWE-404,
-        :CWE-770 .
-
-:CAPEC-495 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "UDP Fragmentation" ;
-    rdfs:subClassOf :CAPEC-130 ;
-    :capec-id "CAPEC-495" ;
-    :definition "An attacker may execute a UDP Fragmentation attack against a target server in an attempt to consume resources such as bandwidth and CPU. IP fragmentation occurs when an IP datagram is larger than the MTU of the route the datagram has to traverse. Typically the attacker will use large UDP packets over 1500 bytes of data which forces fragmentation as ethernet MTU is 1500 bytes. This attack is a variation on a typical UDP flood but it enables more network bandwidth to be consumed with fewer packets. Additionally it has the potential to consume server CPU resources and fill memory buffers associated with the processing and reassembling of fragmented packets." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/495.html> ;
-    :related :CWE-404,
-        :CWE-770 .
-
-:CAPEC-496 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ICMP Fragmentation" ;
-    rdfs:subClassOf :CAPEC-130 ;
-    :capec-id "CAPEC-496" ;
-    :definition "An attacker may execute a ICMP Fragmentation attack against a target with the intention of consuming resources or causing a crash. The attacker crafts a large number of identical fragmented IP packets containing a portion of a fragmented ICMP message. The attacker these sends these messages to a target host which causes the host to become non-responsive. Another vector may be sending a fragmented ICMP message to a target host with incorrect sizes in the header which causes the host to hang." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/496.html> ;
-    :related :CWE-404,
-        :CWE-770 .
-
-:CAPEC-497 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "File Discovery" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-497" ;
-    :definition "An adversary engages in probing and exploration activities to determine if common key files exists. Such files often contain configuration and security parameters of the targeted application, system or network. Using this knowledge may often pave the way for more damaging attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/497.html> ;
-    :related :CWE-200,
-        :T1083 .
-
-:CAPEC-498 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Probe iOS Screenshots" ;
-    rdfs:subClassOf :CAPEC-545 ;
-    :capec-id "CAPEC-498" ;
-    :definition "An adversary examines screenshot images created by iOS in an attempt to obtain sensitive information. This attack targets temporary screenshots created by the underlying OS while the application remains open in the background." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/498.html> ;
-    :related :CWE-359 .
-
-:CAPEC-499 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Android Intent Intercept" ;
-    rdfs:subClassOf :CAPEC-117 ;
-    :capec-id "CAPEC-499" ;
-    :definition "An adversary, through a previously installed malicious application, intercepts messages from a trusted Android-based application in an attempt to achieve a variety of different objectives including denial of service, information disclosure, and data injection. An implicit intent sent from a trusted application can be received by any application that has declared an appropriate intent filter. If the intent is not protected by a permission that the malicious application lacks, then the attacker can gain access to the data contained within the intent. Further, the intent can be either blocked from reaching the intended destination, or modified and potentially forwarded along." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/499.html> ;
-    :related :CWE-925 .
-
-:CAPEC-500 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "WebView Injection" ;
-    rdfs:subClassOf :CAPEC-253 ;
-    :capec-id "CAPEC-500" ;
-    :definition "An adversary, through a previously installed malicious application, injects code into the context of a web page displayed by a WebView component. Through the injected code, an adversary is able to manipulate the DOM tree and cookies of the page, expose sensitive information, and can launch attacks against the web application from within the web page." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/500.html> ;
-    :related :CWE-749,
-        :CWE-940 .
-
-:CAPEC-501 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Android Activity Hijack" ;
-    rdfs:subClassOf :CAPEC-173,
-        :CAPEC-499 ;
-    :capec-id "CAPEC-501" ;
-    :definition "An adversary intercepts an implicit intent sent to launch a Android-based trusted activity and instead launches a counterfeit activity in its place. The malicious activity is then used to mimic the trusted activity's user interface and prompt the target to enter sensitive data as if they were interacting with the trusted activity." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/501.html> ;
-    :related :CWE-923 .
-
-:CAPEC-502 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Intent Spoof" ;
-    rdfs:subClassOf :CAPEC-148 ;
-    :capec-id "CAPEC-502" ;
-    :definition "An adversary, through a previously installed malicious application, issues an intent directed toward a specific trusted application's component in an attempt to achieve a variety of different objectives including modification of data, information disclosure, and data injection. Components that have been unintentionally exported and made public are subject to this type of an attack. If the component trusts the intent's action without verififcation, then the target application performs the functionality at the adversary's request, helping the adversary achieve the desired negative technical impact." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/502.html> ;
-    :related :CWE-284 .
-
-:CAPEC-503 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "WebView Exposure" ;
-    rdfs:subClassOf :CAPEC-122 ;
-    :capec-id "CAPEC-503" ;
-    :definition "An adversary, through a malicious web page, accesses application specific functionality by leveraging interfaces registered through WebView's addJavascriptInterface API. Once an interface is registered to WebView through addJavascriptInterface, it becomes global and all pages loaded in the WebView can call this interface." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/503.html> ;
-    :related :CWE-284 .
-
-:CAPEC-504 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Task Impersonation" ;
-    rdfs:subClassOf :CAPEC-173 ;
-    :capec-id "CAPEC-504" ;
-    :definition "An adversary, through a previously installed malicious application, impersonates an expected or routine task in an attempt to steal sensitive information or leverage a user's privileges." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/504.html> ;
-    :related :CWE-1021,
-        :T1036.004 .
-
-:CAPEC-505 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Scheme Squatting" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-505" ;
-    :definition "An adversary, through a previously installed malicious application, registers for a URL scheme intended for a target application that has not been installed. Thereafter, messages intended for the target application are handled by the malicious application. Upon receiving a message, the malicious application displays a screen that mimics the target application, thereby convincing the user to enter sensitive information. This type of attack is most often used to obtain sensitive information (e.g., credentials) from the user as they think that they are interacting with the intended target application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/505.html> .
-
-:CAPEC-506 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Tapjacking" ;
-    rdfs:subClassOf :CAPEC-173 ;
-    :capec-id "CAPEC-506" ;
-    :definition "An adversary, through a previously installed malicious application, displays an interface that misleads the user and convinces them to tap on an attacker desired location on the screen. This is often accomplished by overlaying one screen on top of another while giving the appearance of a single interface. There are two main techniques used to accomplish this. The first is to leverage transparent properties that allow taps on the screen to pass through the visible application to an application running in the background. The second is to strategically place a small object (e.g., a button or text field) on top of the visible screen and make it appear to be a part of the underlying application. In both cases, the user is convinced to tap on the screen but does not realize the application that they are interacting with." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/506.html> ;
-    :related :CWE-1021 .
-
-:CAPEC-507 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Physical Theft" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-507" ;
-    :definition "An adversary gains physical access to a system or device through theft of the item. Possession of a system or device enables a number of unique attacks to be executed and often provides the adversary with an extended timeframe for which to perform an attack. Most protections put in place to secure sensitive information can be defeated when an adversary has physical access and enough time." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/507.html> .
-
-:CAPEC-508 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Shoulder Surfing" ;
-    rdfs:subClassOf :CAPEC-651 ;
-    :capec-id "CAPEC-508" ;
-    :definition "In a shoulder surfing attack, an adversary observes an unaware individual's keystrokes, screen content, or conversations with the goal of obtaining sensitive information. One motive for this attack is to obtain sensitive information about the target for financial, personal, political, or other gains. From an insider threat perspective, an additional motive could be to obtain system/application credentials or cryptographic keys. Shoulder surfing attacks are accomplished by observing the content \"over the victim's shoulder\", as implied by the name of this attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/508.html> ;
-    :related :CWE-200,
-        :CWE-359 .
-
-:CAPEC-509 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Kerberoasting" ;
-    rdfs:subClassOf :CAPEC-652 ;
-    :capec-id "CAPEC-509" ;
-    :definition "Through the exploitation of how service accounts leverage Kerberos authentication with Service Principal Names (SPNs), the adversary obtains and subsequently cracks the hashed credentials of a service account target to exploit its privileges. The Kerberos authentication protocol centers around a ticketing system which is used to request/grant access to services and to then access the requested services. As an authenticated user, the adversary may request Active Directory and obtain a service ticket with portions encrypted via RC4 with the private key of the authenticated account. By extracting the local ticket and saving it disk, the adversary can brute force the hashed value to reveal the target account credentials." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/509.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-294,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-522,
-        :T1558.003 .
-
-:CAPEC-510 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SaaS User Request Forgery" ;
-    rdfs:subClassOf :CAPEC-21 ;
-    :capec-id "CAPEC-510" ;
-    :definition "An adversary, through a previously installed malicious application, performs malicious actions against a third-party Software as a Service (SaaS) application (also known as a cloud based application) by leveraging the persistent and implicit trust placed on a trusted user's session. This attack is executed after a trusted user is authenticated into a cloud service, \"piggy-backing\" on the authenticated session, and exploiting the fact that the cloud service believes it is only interacting with the trusted user. If successful, the actions embedded in the malicious application will be processed and accepted by the targeted SaaS application and executed at the trusted user's privilege level." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/510.html> ;
-    :related :CWE-346 .
-
-:CAPEC-511 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Infiltration of Software Development Environment" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-511" ;
-    :definition "An attacker uses common delivery mechanisms such as email attachments or removable media to infiltrate the IDE (Integrated Development Environment) of a victim manufacturer with the intent of implanting malware allowing for attack control of the victim IDE environment. The attack then uses this access to exfiltrate sensitive data or information, manipulate said data or information, and conceal these actions. This will allow and aid the attack to meet the goal of future compromise of a recipient of the victim's manufactured product further down in the supply chain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/511.html> ;
-    :related :T1195.001 .
-
-:CAPEC-516 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hardware Component Substitution During Baselining" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-516" ;
-    :definition "An adversary with access to system components during allocated baseline development can substitute a maliciously altered hardware component for a baseline component during the product development and research phases. This can lead to adjustments and calibrations being made in the product so that when the final product, now containing the modified component, is deployed it will not perform as designed and be advantageous to the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/516.html> ;
-    :related :T1195.003 .
-
-:CAPEC-517 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Documentation Alteration to Circumvent Dial-down" ;
-    rdfs:subClassOf :CAPEC-447 ;
-    :capec-id "CAPEC-517" ;
-    :definition "An attacker with access to a manufacturer's documentation, which include descriptions of advanced technology and/or specific components' criticality, alters the documents to circumvent dial-down functionality requirements. This alteration would change the interpretation of implementation and manufacturing techniques, allowing for advanced technologies to remain in place even though these technologies might be restricted to certain customers, such as nations on the terrorist watch list, giving the attacker on the receiving end of a shipped product access to an advanced technology that might otherwise be restricted." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/517.html> .
-
-:CAPEC-518 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Documentation Alteration to Produce Under-performing Systems" ;
-    rdfs:subClassOf :CAPEC-447 ;
-    :capec-id "CAPEC-518" ;
-    :definition "An attacker with access to a manufacturer's documentation alters the descriptions of system capabilities with the intent of causing errors in derived system requirements, impacting the overall effectiveness and capability of the system, allowing an attacker to take advantage of the introduced system capability flaw once the system is deployed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/518.html> .
-
-:CAPEC-519 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Documentation Alteration to Cause Errors in System Design" ;
-    rdfs:subClassOf :CAPEC-447 ;
-    :capec-id "CAPEC-519" ;
-    :definition "An attacker with access to a manufacturer's documentation containing requirements allocation and software design processes maliciously alters the documentation in order to cause errors in system design. This allows the attacker to take advantage of a weakness in a deployed system of the manufacturer for malicious purposes." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/519.html> .
-
-:CAPEC-520 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Counterfeit Hardware Component Inserted During Product Assembly" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-520" ;
-    :definition "An adversary with either direct access to the product assembly process or to the supply of subcomponents used in the product assembly process introduces counterfeit hardware components into product assembly. The assembly containing the counterfeit components results in a system specifically designed for malicious purposes." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/520.html> ;
-    :related :T1195.003 .
-
-:CAPEC-521 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hardware Design Specifications Are Altered" ;
-    rdfs:subClassOf :CAPEC-447 ;
-    :capec-id "CAPEC-521" ;
-    :definition "An attacker with access to a manufacturer's hardware manufacturing process documentation alters the design specifications, which introduces flaws advantageous to the attacker once the system is deployed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/521.html> .
-
-:CAPEC-522 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Hardware Component Replacement" ;
-    rdfs:subClassOf :CAPEC-439 ;
-    :capec-id "CAPEC-522" ;
-    :definition "An adversary replaces legitimate hardware in the system with faulty counterfeit or tampered hardware in the supply chain distribution channel, with purpose of causing malicious disruption or allowing for additional compromise when the system is deployed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/522.html> ;
-    :related :T1195.003 .
-
-:CAPEC-523 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Software Implanted" ;
-    rdfs:subClassOf :CAPEC-439 ;
-    :capec-id "CAPEC-523" ;
-    :definition "An attacker implants malicious software into the system in the supply chain distribution channel, with purpose of causing malicious disruption or allowing for additional compromise when the system is deployed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/523.html> ;
-    :related :T1195.002 .
-
-:CAPEC-524 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Rogue Integration Procedures" ;
-    rdfs:subClassOf :CAPEC-439 ;
-    :capec-id "CAPEC-524" ;
-    :definition "An attacker alters or establishes rogue processes in an integration facility in order to insert maliciously altered components into the system. The attacker would then supply the malicious components. This would allow for malicious disruption or additional compromise when the system is deployed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/524.html> .
-
-:CAPEC-528 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "XML Flood" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-528" ;
-    :definition "An adversary may execute a flooding attack using XML messages with the intent to deny legitimate users access to a web service. These attacks are accomplished by sending a large number of XML based requests and letting the service attempt to parse each one. In many cases this type of an attack will result in a XML Denial of Service (XDoS) due to an application becoming unstable, freezing, or crashing." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/528.html> ;
-    :related :CWE-770,
-        :T1498.001,
-        :T1499.002 .
-
-:CAPEC-529 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malware-Directed Internal Reconnaissance" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-529" ;
-    :definition "Adversary uses malware or a similarly controlled application installed inside an organizational perimeter to gather information about the composition, configuration, and security mechanisms of a targeted application, system or network." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/529.html> .
-
-:CAPEC-530 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Provide Counterfeit Component" ;
-    rdfs:subClassOf :CAPEC-531 ;
-    :capec-id "CAPEC-530" ;
-    :definition "An attacker provides a counterfeit component during the procurement process of a lower-tier component supplier to a sub-system developer or integrator, which is then built into the system being upgraded or repaired by the victim, allowing the attacker to cause disruption or additional compromise." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/530.html> .
-
-:CAPEC-531 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hardware Component Substitution" ;
-    rdfs:subClassOf :CAPEC-534 ;
-    :capec-id "CAPEC-531" ;
-    :definition "An attacker substitutes out a tested and approved hardware component for a maliciously-altered hardware component. This type of attack is carried out directly on the system, enabling the attacker to then cause disruption or additional compromise." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/531.html> ;
-    :related :T1195.003 .
-
-:CAPEC-532 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Altered Installed BIOS" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-532" ;
-    :definition "An attacker with access to download and update system software sends a maliciously altered BIOS to the victim or victim supplier/integrator, which when installed allows for future exploitation." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/532.html> ;
-    :related :T1495,
-        :T1542.001 .
-
-:CAPEC-533 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Manual Software Update" ;
-    rdfs:subClassOf :CAPEC-186 ;
-    :capec-id "CAPEC-533" ;
-    :definition "An attacker introduces malicious code to the victim's system by altering the payload of a software update, allowing for additional compromise or site disruption at the victim location. These manual, or user-assisted attacks, vary from requiring the user to download and run an executable, to as streamlined as tricking the user to click a URL. Attacks which aim at penetrating a specific network infrastructure often rely upon secondary attack methods to achieve the desired impact. Spamming, for example, is a common method employed as an secondary attack vector. Thus the attacker has in their arsenal a choice of initial attack vectors ranging from traditional SMTP/POP/IMAP spamming and its varieties, to web-application mechanisms which commonly implement both chat and rich HTML messaging within the user interface." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/533.html> ;
-    :related :CWE-494 .
-
-:CAPEC-534 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Hardware Update" ;
-    rdfs:subClassOf :CAPEC-440 ;
-    :capec-id "CAPEC-534" ;
-    :definition "An adversary introduces malicious hardware during an update or replacement procedure, allowing for additional compromise or site disruption at the victim location. After deployment, it is not uncommon for upgrades and replacements to occur involving hardware and various replaceable parts. These upgrades and replacements are intended to correct defects, provide additional features, and to replace broken or worn-out parts. However, by forcing or tricking the replacement of a good component with a defective or corrupted component, an adversary can leverage known defects to obtain a desired malicious impact." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/534.html> .
-
-:CAPEC-535 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Gray Market Hardware" ;
-    rdfs:subClassOf :CAPEC-531 ;
-    :capec-id "CAPEC-535" ;
-    :definition "An attacker maliciously alters hardware components that will be sold on the gray market, allowing for victim disruption and compromise when the victim needs replacement hardware components for systems where the parts are no longer in regular supply from original suppliers, or where the hardware components from the attacker seems to be a great benefit from a cost perspective." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/535.html> .
-
-:CAPEC-536 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Data Injected During Configuration" ;
-    rdfs:subClassOf :CAPEC-176 ;
-    :capec-id "CAPEC-536" ;
-    :definition "An attacker with access to data files and processes on a victim's system injects malicious data into critical operational data during configuration or recalibration, causing the victim's system to perform in a suboptimal manner that benefits the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/536.html> ;
-    :related :CWE-284 .
-
-:CAPEC-537 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Infiltration of Hardware Development Environment" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-537" ;
-    :definition "An adversary, leveraging the ability to manipulate components of primary support systems and tools within the development and production environments, inserts malicious software within the hardware and/or firmware development environment. The infiltration purpose is to alter developed hardware components in a system destined for deployment at the victim's organization, for the purpose of disruption or further compromise." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/537.html> ;
-    :related :T1195.003 .
-
-:CAPEC-538 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Open-Source Library Manipulation" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-538" ;
-    :definition "Adversaries implant malicious code in open source software (OSS) libraries to have it widely distributed, as OSS is commonly downloaded by developers and other users to incorporate into software development projects. The adversary can have a particular system in mind to target, or the implantation can be the first stage of follow-on attacks on many systems." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/538.html> ;
-    :related :CWE-494,
-        :CWE-829,
-        :T1195.001 .
-
-:CAPEC-539 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "ASIC With Malicious Functionality" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-539" ;
-    :definition "An attacker with access to the development environment process of an application-specific integrated circuit (ASIC) for a victim system being developed or maintained after initial deployment can insert malicious functionality into the system for the purpose of disruption or further compromise." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/539.html> ;
-    :related :T1195.003 .
-
-:CAPEC-540 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Overread Buffers" ;
-    rdfs:subClassOf :CAPEC-123 ;
-    :capec-id "CAPEC-540" ;
-    :definition "An adversary attacks a target by providing input that causes an application to read beyond the boundary of a defined buffer. This typically occurs when a value influencing where to start or stop reading is set to reflect positions outside of the valid memory location of the buffer. This type of attack may result in exposure of sensitive information, a system crash, or arbitrary code execution." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/540.html> ;
-    :related :CWE-125 .
-
-:CAPEC-541 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Application Fingerprinting" ;
-    rdfs:subClassOf :CAPEC-224 ;
-    :capec-id "CAPEC-541" ;
-    :definition "An adversary engages in fingerprinting activities to determine the type or version of an application installed on a remote target." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/541.html> ;
-    :related :CWE-204,
-        :CWE-205,
-        :CWE-208,
-        :T1592.002 .
-
-:CAPEC-542 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Targeted Malware" ;
-    rdfs:subClassOf :CAPEC-549 ;
-    :capec-id "CAPEC-542" ;
-    :definition "An adversary develops targeted malware that takes advantage of a known vulnerability in an organizational information technology environment. The malware crafted for these attacks is based specifically on information gathered about the technology environment. Successfully executing the malware enables an adversary to achieve a wide variety of negative technical impacts." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/542.html> ;
-    :related :T1027,
-        :T1587.001 .
-
-:CAPEC-543 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Counterfeit Websites" ;
-    rdfs:subClassOf :CAPEC-194 ;
-    :capec-id "CAPEC-543" ;
-    :definition "Adversary creates duplicates of legitimate websites. When users visit a counterfeit site, the site can gather information or upload malware." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/543.html> ;
-    :related :T1036.005 .
-
-:CAPEC-544 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Counterfeit Organizations" ;
-    rdfs:subClassOf :CAPEC-194 ;
-    :capec-id "CAPEC-544" ;
-    :definition "An adversary creates a false front organizations with the appearance of a legitimate supplier in the critical life cycle path that then injects corrupted/malicious information system components into the organizational supply chain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/544.html> .
-
-:CAPEC-545 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Pull Data from System Resources" ;
-    rdfs:subClassOf :CAPEC-116 ;
-    :capec-id "CAPEC-545" ;
-    :definition "An adversary who is authorized or has the ability to search known system resources, does so with the intention of gathering useful information. System resources include files, memory, and other aspects of the target system. In this pattern of attack, the adversary does not necessarily know what they are going to find when they start pulling data. This is different than CAPEC-150 where the adversary knows what they are looking for due to the common location." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/545.html> ;
-    :related :CWE-1239,
-        :CWE-1243,
-        :CWE-1258,
-        :CWE-1266,
-        :CWE-1272,
-        :CWE-1278,
-        :CWE-1323,
-        :CWE-1330,
-        :T1005,
-        :T1555.001 .
-
-:CAPEC-546 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Incomplete Data Deletion in a Multi-Tenant Environment" ;
-    rdfs:subClassOf :CAPEC-545 ;
-    :capec-id "CAPEC-546" ;
-    :definition "An adversary obtains unauthorized information due to insecure or incomplete data deletion in a multi-tenant environment. If a cloud provider fails to completely delete storage and data from former cloud tenants' systems/resources, once these resources are allocated to new, potentially malicious tenants, the latter can probe the provided resources for sensitive information still there." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/546.html> ;
-    :related :CWE-284,
-        :CWE-1266,
-        :CWE-1272 .
-
-:CAPEC-547 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Physical Destruction of Device or Component" ;
-    rdfs:subClassOf :CAPEC-607 ;
-    :capec-id "CAPEC-547" ;
-    :definition "An adversary conducts a physical attack a device or component, destroying it such that it no longer functions as intended." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/547.html> .
-
-:CAPEC-548 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Contaminate Resource" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-548" ;
-    :definition "An adversary contaminates organizational information systems (including devices and networks) by causing them to handle information of a classification/sensitivity for which they have not been authorized. When this happens, the contaminated information system, device, or network must be brought offline to investigate and mitigate the data spill, which denies availability of the system until the investigation is complete." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/548.html> .
-
-:CAPEC-549 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Local Execution of Code" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-549" ;
-    :definition "An adversary installs and executes malicious code on the target system in an effort to achieve a negative technical impact. Examples include rootkits, ransomware, spyware, adware, and others." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/549.html> ;
-    :related :CWE-829 .
-
-:CAPEC-550 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Install New Service" ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-550" ;
-    :definition "When an operating system starts, it also starts programs called services or daemons. Adversaries may install a new service which will be executed at startup (on a Windows system, by modifying the registry). The service name may be disguised by using a name from a related operating system or benign software. Services are usually run with elevated privileges." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/550.html> ;
-    :related :CWE-284,
-        :T1543 .
-
-:CAPEC-551 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Modify Existing Service" ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-551" ;
-    :definition "When an operating system starts, it also starts programs called services or daemons. Modifying existing services may break existing services or may enable services that are disabled/not commonly used." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/551.html> ;
-    :related :CWE-284,
-        :CWE-522,
-        :T1543 .
-
-:CAPEC-552 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Install Rootkit " ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-552" ;
-    :definition "An adversary exploits a weakness in authentication to install malware that alters the functionality and information provide by targeted operating system API calls. Often referred to as rootkits, it is often used to hide the presence of programs, files, network connections, services, drivers, and other system components." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/552.html> ;
-    :related :CWE-284,
-        :T1014,
-        :T1542.003,
-        :T1547.006 .
-
-:CAPEC-554 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Functionality Bypass" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-554" ;
-    :definition "An adversary attacks a system by bypassing some or all functionality intended to protect it. Often, a system user will think that protection is in place, but the functionality behind those protections has been disabled by the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/554.html> ;
-    :related :CWE-424,
-        :CWE-1299 .
-
-:CAPEC-555 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Remote Services with Stolen Credentials" ;
-    rdfs:subClassOf :CAPEC-560 ;
-    :capec-id "CAPEC-555" ;
-    :definition "This pattern of attack involves an adversary that uses stolen credentials to leverage remote services such as RDP, telnet, SSH, and VNC to log into a system. Once access is gained, any number of malicious activities could be performed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/555.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-294,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-522,
-        :T1021,
-        :T1114.002,
-        :T1133 .
-
-:CAPEC-556 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Replace File Extension Handlers" ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-556" ;
-    :definition "When a file is opened, its file handler is checked to determine which program opens the file. File handlers are configuration properties of many operating systems. Applications can modify the file handler for a given file extension to call an arbitrary program when a file with the given extension is opened." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/556.html> ;
-    :related :CWE-284,
-        :T1546.001 .
-
-:CAPEC-557 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Schedule Software To Run" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This CAPEC has been deprecated because it is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
-    :capec-id "CAPEC-557" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/557.html> .
-
-:CAPEC-558 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Replace Trusted Executable" ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-558" ;
-    :definition "An adversary exploits weaknesses in privilege management or access control to replace a trusted executable with a malicious version and enable the execution of malware when that trusted executable is called." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/558.html> ;
-    :related :CWE-284,
-        :T1505.005,
-        :T1546.008 .
-
-:CAPEC-559 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Orbital Jamming" ;
-    rdfs:subClassOf :CAPEC-601 ;
-    :capec-id "CAPEC-559" ;
-    :definition "In this attack pattern, the adversary sends disruptive signals at a target satellite using a rogue uplink station to disrupt the intended transmission. Those within the satellite's footprint are prevented from reaching the satellite's targeted or neighboring channels. The satellite's footprint size depends upon its position in the sky; higher orbital satellites cover multiple continents." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/559.html> .
-
-:CAPEC-560 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Use of Known Domain Credentials" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-560" ;
-    :definition "An adversary guesses or obtains (i.e. steals or purchases) legitimate credentials (e.g. userID/password) to achieve authentication and to perform authorized actions under the guise of an authenticated user or service." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/560.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-307,
-        :CWE-308,
-        :CWE-309,
-        :CWE-522,
-        :CWE-654,
-        :CWE-1273,
-        :T1078 .
-
-:CAPEC-561 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Windows Admin Shares with Stolen Credentials" ;
-    rdfs:subClassOf :CAPEC-653 ;
-    :capec-id "CAPEC-561" ;
-    :definition "An adversary guesses or obtains (i.e. steals or purchases) legitimate Windows administrator credentials (e.g. userID/password) to access Windows Admin Shares on a local machine or within a Windows domain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/561.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-294,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-522,
-        :T1021.002 .
-
-:CAPEC-562 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Modify Shared File" ;
-    rdfs:subClassOf :CAPEC-17 ;
-    :capec-id "CAPEC-562" ;
-    :definition "An adversary manipulates the files in a shared location by adding malicious programs, scripts, or exploit code to valid content. Once a user opens the shared content, the tainted content is executed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/562.html> ;
-    :related :CWE-284,
-        :T1080 .
-
-:CAPEC-563 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Add Malicious File to Shared Webroot" ;
-    rdfs:subClassOf :CAPEC-17 ;
-    :capec-id "CAPEC-563" ;
-    :definition "An adversaries may add malicious content to a website through the open file share and then browse to that content with a web browser to cause the server to execute the content. The malicious content will typically run under the context and permissions of the web server process, often resulting in local system or administrative privileges depending on how the web server is configured." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/563.html> ;
-    :related :CWE-284 .
-
-:CAPEC-564 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Run Software at Logon" ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-564" ;
-    :definition "Operating system allows logon scripts to be run whenever a specific user or users logon to a system. If adversaries can access these scripts, they may insert additional code into the logon script. This code can allow them to maintain persistence or move laterally within an enclave because it is executed every time the affected user or users logon to a computer. Modifying logon scripts can effectively bypass workstation and enclave firewalls. Depending on the access configuration of the logon scripts, either local credentials or a remote administrative account may be necessary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/564.html> ;
-    :related :CWE-284,
-        :T1037,
-        :T1543.001,
-        :T1543.004,
-        :T1547 .
-
-:CAPEC-565 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Password Spraying" ;
-    rdfs:subClassOf :CAPEC-49 ;
-    :capec-id "CAPEC-565" ;
-    :definition "In a Password Spraying attack, an adversary tries a small list (e.g. 3-5) of common or expected passwords, often matching the target's complexity policy, against a known list of user accounts to gain valid credentials. The adversary tries a particular password for each user account, before moving onto the next password in the list. This approach assists the adversary in remaining undetected by avoiding rapid or frequent account lockouts. The adversary may then reattempt the process with additional passwords, once enough time has passed to prevent inducing a lockout." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/565.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-307,
-        :CWE-308,
-        :CWE-309,
-        :CWE-521,
-        :CWE-654,
-        :T1110.003 .
-
-:CAPEC-566 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Dump Password Hashes" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This CAPEC has been deprecated because of is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
-    :capec-id "CAPEC-566" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/566.html> .
-
-:CAPEC-567 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Obtain Data via Utilities" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This CAPEC has been deprecated because it is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
-    :capec-id "CAPEC-567" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/567.html> .
-
-:CAPEC-568 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Capture Credentials via Keylogger" ;
-    rdfs:subClassOf :CAPEC-569 ;
-    :capec-id "CAPEC-568" ;
-    :definition "An adversary deploys a keylogger in an effort to obtain credentials directly from a system's user. After capturing all the keystrokes made by a user, the adversary can analyze the data and determine which string are likely to be passwords or other credential related information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/568.html> ;
-    :related :T1056.001 .
-
-:CAPEC-569 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Collect Data as Provided by Users" ;
-    rdfs:subClassOf :CAPEC-116 ;
-    :capec-id "CAPEC-569" ;
-    :definition "An attacker leverages a tool, device, or program to obtain specific information as provided by a user of the target system. This information is often needed by the attacker to launch a follow-on attack. This attack is different than Social Engineering as the adversary is not tricking or deceiving the user. Instead the adversary is putting a mechanism in place that captures the information that a user legitimately enters into a system. Deploying a keylogger, performing a UAC prompt, or wrapping the Windows default credential provider are all examples of such interactions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/569.html> ;
-    :related :T1056 .
-
-:CAPEC-570 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Signature-Based Avoidance" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This CAPEC has been deprecated because it is not directly related to a weakness, social engineering, supply chains, or a physical-based attack." ;
-    :capec-id "CAPEC-570" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/570.html> .
-
-:CAPEC-571 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Block Logging to Central Repository" ;
-    rdfs:subClassOf :CAPEC-161 ;
-    :capec-id "CAPEC-571" ;
-    :definition "An adversary prevents host-generated logs being delivered to a central location in an attempt to hide indicators of compromise." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/571.html> ;
-    :related :T1562.002,
-        :T1562.006,
-        :T1562.008 .
-
-:CAPEC-572 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Artificially Inflate File Sizes" ;
-    rdfs:subClassOf :CAPEC-165 ;
-    :capec-id "CAPEC-572" ;
-    :definition "An adversary modifies file contents by adding data to files for several reasons. Many different attacks could “follow” this pattern resulting in numerous outcomes. Adding data to a file could also result in a Denial of Service condition for devices with limited storage capacity." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/572.html> ;
-    :related :T1027.001 .
-
-:CAPEC-573 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Process Footprinting" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-573" ;
-    :definition "An adversary exploits functionality meant to identify information about the currently running processes on the target system to an authorized user. By knowing what processes are running on the target system, the adversary can learn about the target environment as a means towards further malicious behavior." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/573.html> ;
-    :related :CWE-200,
-        :T1057 .
-
-:CAPEC-574 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Services Footprinting" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-574" ;
-    :definition "An adversary exploits functionality meant to identify information about the services on the target system to an authorized user. By knowing what services are registered on the target system, the adversary can learn about the target environment as a means towards further malicious behavior. Depending on the operating system, commands that can obtain services information include \"sc\" and \"tasklist/svc\" using Tasklist, and \"net start\" using Net." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/574.html> ;
-    :related :CWE-200,
-        :T1007 .
-
-:CAPEC-575 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Account Footprinting" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-575" ;
-    :definition "An adversary exploits functionality meant to identify information about the domain accounts and their permissions on the target system to an authorized user. By knowing what accounts are registered on the target system, the adversary can inform further and more targeted malicious behavior. Example Windows commands which can acquire this information are: \"net user\" and \"dsquery\"." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/575.html> ;
-    :related :CWE-200,
-        :T1087 .
-
-:CAPEC-576 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Group Permission Footprinting" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-576" ;
-    :definition "An adversary exploits functionality meant to identify information about user groups and their permissions on the target system to an authorized user. By knowing what users/permissions are registered on the target system, the adversary can inform further and more targeted malicious behavior. An example Windows command which can list local groups is \"net localgroup\"." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/576.html> ;
-    :related :CWE-200,
-        :T1069,
-        :T1615 .
-
-:CAPEC-577 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Owner Footprinting" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-577" ;
-    :definition "An adversary exploits functionality meant to identify information about the primary users on the target system to an authorized user. They may do this, for example, by reviewing logins or file modification times. By knowing what owners use the target system, the adversary can inform further and more targeted malicious behavior. An example Windows command that may accomplish this is \"dir /A ntuser.dat\". Which will display the last modified time of a user's ntuser.dat file when run within the root folder of a user. This time is synonymous with the last time that user was logged in." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/577.html> ;
-    :related :CWE-200,
-        :T1033 .
-
-:CAPEC-578 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Disable Security Software" ;
-    rdfs:subClassOf :CAPEC-176 ;
-    :capec-id "CAPEC-578" ;
-    :definition "An adversary exploits a weakness in access control to disable security tools so that detection does not occur. This can take the form of killing processes, deleting registry keys so that tools do not start at run time, deleting log files, or other methods." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/578.html> ;
-    :related :CWE-284,
-        :T1556.006,
-        :T1562.001,
-        :T1562.002,
-        :T1562.004,
-        :T1562.007,
-        :T1562.008,
-        :T1562.009 .
-
-:CAPEC-579 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Replace Winlogon Helper DLL" ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-579" ;
-    :definition "Winlogon is a part of Windows that performs logon actions. In Windows systems prior to Windows Vista, a registry key can be modified that causes Winlogon to load a DLL on startup. Adversaries may take advantage of this feature to load adversarial code at startup." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/579.html> ;
-    :related :CWE-15,
-        :T1547.004 .
-
-:CAPEC-580 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "System Footprinting" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-580" ;
-    :definition "An adversary engages in active probing and exploration activities to determine security information about a remote target system. Often times adversaries will rely on remote applications that can be probed for system configurations." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/580.html> ;
-    :related :CWE-204,
-        :CWE-205,
-        :CWE-208,
-        :T1082 .
-
-:CAPEC-581 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Security Software Footprinting" ;
-    rdfs:subClassOf :CAPEC-580 ;
-    :capec-id "CAPEC-581" ;
-    :definition "Adversaries may attempt to get a listing of security tools that are installed on the system and their configurations. This may include security related system features (such as a built-in firewall or anti-spyware) as well as third-party security software." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/581.html> ;
-    :related :T1518.001 .
-
-:CAPEC-582 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Route Disabling" ;
-    rdfs:subClassOf :CAPEC-607 ;
-    :capec-id "CAPEC-582" ;
-    :definition "An adversary disables the network route between two targets. The goal is to completely sever the communications channel between two entities. This is often the result of a major error or the use of an \"Internet kill switch\" by those in control of critical infrastructure. This attack pattern differs from most other obstruction patterns by targeting the route itself, as opposed to the data passed over the route." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/582.html> .
-
-:CAPEC-583 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Disabling Network Hardware" ;
-    rdfs:subClassOf :CAPEC-582 ;
-    :capec-id "CAPEC-583" ;
-    :definition "In this attack pattern, an adversary physically disables networking hardware by powering it down or disconnecting critical equipment. Disabling or shutting off critical system resources prevents them from performing their service as intended, which can have direct and indirect consequences on other systems. This attack pattern is considerably less technical than the selective blocking used in most obstruction attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/583.html> .
-
-:CAPEC-584 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "BGP Route Disabling" ;
-    rdfs:subClassOf :CAPEC-582 ;
-    :capec-id "CAPEC-584" ;
-    :definition "An adversary suppresses the Border Gateway Protocol (BGP) advertisement for a route so as to render the underlying network inaccessible. The BGP protocol helps traffic move throughout the Internet by selecting the most efficient route between Autonomous Systems (AS), or routing domains. BGP is the basis for interdomain routing infrastructure, providing connections between these ASs. By suppressing the intended AS routing advertisements and/or forcing less effective routes for traffic to ASs, the adversary can deny availability for the target network." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/584.html> .
-
-:CAPEC-585 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DNS Domain Seizure" ;
-    rdfs:subClassOf :CAPEC-582 ;
-    :capec-id "CAPEC-585" ;
-    :definition "In this attack pattern, an adversary influences a target's web-hosting company to disable a target domain. The goal is to prevent access to the targeted service provided by that domain. It usually occurs as the result of civil or criminal legal interventions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/585.html> .
-
-:CAPEC-586 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Object Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-586" ;
-    :definition "An adversary attempts to exploit an application by injecting additional, malicious content during its processing of serialized objects. Developers leverage serialization in order to convert data or state into a static, binary format for saving to disk or transferring over a network. These objects are then deserialized when needed to recover the data/state. By injecting a malformed object into a vulnerable application, an adversary can potentially compromise the application by manipulating the deserialization process. This can result in a number of unwanted outcomes, including remote code execution." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/586.html> ;
-    :related :CWE-502 .
-
-:CAPEC-587 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cross Frame Scripting (XFS)" ;
-    rdfs:subClassOf :CAPEC-103 ;
-    :capec-id "CAPEC-587" ;
-    :definition "This attack pattern combines malicious Javascript and a legitimate webpage loaded into a concealed iframe. The malicious Javascript is then able to interact with a legitimate webpage in a manner that is unknown to the user. This attack usually leverages some element of social engineering in that an attacker must convinces a user to visit a web page that the attacker controls." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/587.html> ;
-    :related :CWE-1021 .
-
-:CAPEC-588 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DOM-Based XSS" ;
-    rdfs:subClassOf :CAPEC-63 ;
-    :capec-id "CAPEC-588" ;
-    :definition "This type of attack is a form of Cross-Site Scripting (XSS) where a malicious script is inserted into the client-side HTML being parsed by a web browser. Content served by a vulnerable web application includes script code used to manipulate the Document Object Model (DOM). This script code either does not properly validate input, or does not perform proper output encoding, thus creating an opportunity for an adversary to inject a malicious script launch a XSS attack. A key distinction between other XSS attacks and DOM-based attacks is that in other XSS attacks, the malicious script runs when the vulnerable web page is initially loaded, while a DOM-based attack executes sometime after the page loads. Another distinction of DOM-based attacks is that in some cases, the malicious script is never sent to the vulnerable web server at all. An attack like this is guaranteed to bypass any server-side filtering attempts to protect users." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/588.html> ;
-    :related :CWE-20,
-        :CWE-79,
-        :CWE-83 .
-
-:CAPEC-589 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DNS Blocking" ;
-    rdfs:subClassOf :CAPEC-603 ;
-    :capec-id "CAPEC-589" ;
-    :definition "An adversary intercepts traffic and intentionally drops DNS requests based on content in the request. In this way, the adversary can deny the availability of specific services or content to the user even if the IP address is changed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/589.html> ;
-    :related :CWE-300 .
-
-:CAPEC-590 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "IP Address Blocking" ;
-    rdfs:subClassOf :CAPEC-603 ;
-    :capec-id "CAPEC-590" ;
-    :definition "An adversary performing this type of attack drops packets destined for a target IP address. The aim is to prevent access to the service hosted at the target IP address." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/590.html> ;
-    :related :CWE-300 .
-
-:CAPEC-591 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Reflected XSS" ;
-    rdfs:subClassOf :CAPEC-63 ;
-    :capec-id "CAPEC-591" ;
-    :definition "This type of attack is a form of Cross-Site Scripting (XSS) where a malicious script is \"reflected\" off a vulnerable web application and then executed by a victim's browser. The process starts with an adversary delivering a malicious script to a victim and convincing the victim to send the script to the vulnerable web application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/591.html> ;
-    :related :CWE-79 .
-
-:CAPEC-592 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Stored XSS" ;
-    rdfs:subClassOf :CAPEC-63 ;
-    :capec-id "CAPEC-592" ;
-    :definition "An adversary utilizes a form of Cross-site Scripting (XSS) where a malicious script is persistently \"stored\" within the data storage of a vulnerable web application as valid input." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/592.html> ;
-    :related :CWE-79 .
-
-:CAPEC-593 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Session Hijacking" ;
-    rdfs:subClassOf :CAPEC-21 ;
-    :capec-id "CAPEC-593" ;
-    :definition "This type of attack involves an adversary that exploits weaknesses in an application's use of sessions in performing authentication. The adversary is able to steal or manipulate an active session and use it to gain unathorized access to the application." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/593.html> ;
-    :related :CWE-287,
-        :T1185,
-        :T1550.001,
-        :T1563 .
-
-:CAPEC-594 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Traffic Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-594" ;
-    :definition "An adversary injects traffic into the target's network connection. The adversary is therefore able to degrade or disrupt the connection, and potentially modify the content. This is not a flooding attack, as the adversary is not focusing on exhausting resources. Instead, the adversary is crafting a specific input to affect the system in a particular way." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/594.html> ;
-    :related :CWE-940 .
-
-:CAPEC-595 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Connection Reset" ;
-    rdfs:subClassOf :CAPEC-594 ;
-    :capec-id "CAPEC-595" ;
-    :definition "In this attack pattern, an adversary injects a connection reset packet to one or both ends of a target's connection. The attacker is therefore able to have the target and/or the destination server sever the connection without having to directly filter the traffic between them." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/595.html> ;
-    :related :CWE-940 .
-
-:CAPEC-596 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TCP RST Injection" ;
-    rdfs:subClassOf :CAPEC-595 ;
-    :capec-id "CAPEC-596" ;
-    :definition "An adversary injects one or more TCP RST packets to a target after the target has made a HTTP GET request. The goal of this attack is to have the target and/or destination web server terminate the TCP connection." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/596.html> ;
-    :related :CWE-940 .
-
-:CAPEC-597 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Absolute Path Traversal" ;
-    rdfs:subClassOf :CAPEC-126 ;
-    :capec-id "CAPEC-597" ;
-    :definition "An adversary with access to file system resources, either directly or via application logic, will use various file absolute paths and navigation mechanisms such as \"..\" to extend their range of access to inappropriate areas of the file system. The goal of the adversary is to access directories and files that are intended to be restricted from their access." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/597.html> ;
-    :related :CWE-36 .
-
-:CAPEC-598 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DNS Spoofing" ;
-    rdfs:subClassOf :CAPEC-194 ;
-    :capec-id "CAPEC-598" ;
-    :definition "An adversary sends a malicious (\"NXDOMAIN\" (\"No such domain\") code, or DNS A record) response to a target's route request before a legitimate resolver can. This technique requires an On-path or In-path device that can monitor and respond to the target's DNS requests. This attack differs from BGP Tampering in that it directly responds to requests made by the target instead of polluting the routing the target's infrastructure uses." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/598.html> .
-
-:CAPEC-599 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Terrestrial Jamming" ;
-    rdfs:subClassOf :CAPEC-195 ;
-    :capec-id "CAPEC-599" ;
-    :definition "In this attack pattern, the adversary transmits disruptive signals in the direction of the target's consumer-level satellite dish (as opposed to the satellite itself). The transmission disruption occurs in a more targeted range. Portable terrestrial jammers have a range of 3-5 kilometers in urban areas and 20 kilometers in rural areas. This technique requires a terrestrial jammer that is more powerful than the frequencies sent from the satellite." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/599.html> .
-
-:CAPEC-600 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Credential Stuffing" ;
-    rdfs:subClassOf :CAPEC-560 ;
-    :capec-id "CAPEC-600" ;
-    :definition "An adversary tries known username/password combinations against different systems, applications, or services to gain additional authenticated access. Credential Stuffing attacks rely upon the fact that many users leverage the same username/password combination for multiple systems, applications, and services." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/600.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-307,
-        :CWE-308,
-        :CWE-309,
-        :CWE-522,
-        :CWE-654,
-        :T1110.004 .
-
-:CAPEC-601 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Jamming" ;
-    rdfs:subClassOf :CAPEC-607 ;
-    :capec-id "CAPEC-601" ;
-    :definition "An adversary uses radio noise or signals in an attempt to disrupt communications. By intentionally overwhelming system resources with illegitimate traffic, service is denied to the legitimate traffic of authorized users." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/601.html> .
-
-:CAPEC-602 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Degradation" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated." ;
-    :capec-id "CAPEC-602" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/602.html> .
-
-:CAPEC-603 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Blockage" ;
-    rdfs:subClassOf :CAPEC-607 ;
-    :capec-id "CAPEC-603" ;
-    :definition "An adversary blocks the delivery of an important system resource causing the system to fail or stop working." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/603.html> .
-
-:CAPEC-604 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Wi-Fi Jamming" ;
-    rdfs:subClassOf :CAPEC-601 ;
-    :capec-id "CAPEC-604" ;
-    :definition "In this attack scenario, the attacker actively transmits on the Wi-Fi channel to prevent users from transmitting or receiving data from the targeted Wi-Fi network. There are several known techniques to perform this attack – for example: the attacker may flood the Wi-Fi access point (e.g. the retransmission device) with deauthentication frames. Another method is to transmit high levels of noise on the RF band used by the Wi-Fi network." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/604.html> .
-
-:CAPEC-605 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cellular Jamming" ;
-    rdfs:subClassOf :CAPEC-601 ;
-    :capec-id "CAPEC-605" ;
-    :definition "In this attack scenario, the attacker actively transmits signals to overpower and disrupt the communication between a cellular user device and a cell tower. Several existing techniques are known in the open literature for this attack for 2G, 3G, and 4G LTE cellular technology. For example, some attacks target cell towers by overwhelming them with false status messages, while others introduce high levels of noise on signaling channels." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/605.html> .
-
-:CAPEC-606 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Weakening of Cellular Encryption" ;
-    rdfs:subClassOf :CAPEC-620 ;
-    :capec-id "CAPEC-606" ;
-    :definition "An attacker, with control of a Cellular Rogue Base Station or through cooperation with a Malicious Mobile Network Operator can force the mobile device (e.g., the retransmission device) to use no encryption (A5/0 mode) or to use easily breakable encryption (A5/1 or A5/2 mode)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/606.html> ;
-    :related :CWE-757 .
-
-:CAPEC-607 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Obstruction" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-607" ;
-    :definition "An attacker obstructs the interactions between system components. By interrupting or disabling these interactions, an adversary can often force the system into a degraded state or cause the system to stop working as intended. This can cause the system components to be unavailable until the obstruction mitigated." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/607.html> .
-
-:CAPEC-608 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cryptanalysis of Cellular Encryption" ;
-    rdfs:subClassOf :CAPEC-97 ;
-    :capec-id "CAPEC-608" ;
-    :definition "The use of cryptanalytic techniques to derive cryptographic keys or otherwise effectively defeat cellular encryption to reveal traffic content. Some cellular encryption algorithms such as A5/1 and A5/2 (specified for GSM use) are known to be vulnerable to such attacks and commercial tools are available to execute these attacks and decrypt mobile phone conversations in real-time. Newer encryption algorithms in use by UMTS and LTE are stronger and currently believed to be less vulnerable to these types of attacks. Note, however, that an attacker with a Cellular Rogue Base Station can force the use of weak cellular encryption even by newer mobile devices." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/608.html> ;
-    :related :CWE-327 .
-
-:CAPEC-609 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cellular Traffic Intercept" ;
-    rdfs:subClassOf :CAPEC-157 ;
-    :capec-id "CAPEC-609" ;
-    :definition "Cellular traffic for voice and data from mobile devices and retransmission devices can be intercepted via numerous methods. Malicious actors can deploy their own cellular tower equipment and intercept cellular traffic surreptitiously. Additionally, government agencies of adversaries and malicious actors can intercept cellular traffic via the telecommunications backbone over which mobile traffic is transmitted." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/609.html> ;
-    :related :CWE-311,
-        :T1111 .
-
-:CAPEC-610 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cellular Data Injection" ;
-    rdfs:subClassOf :CAPEC-240 ;
-    :capec-id "CAPEC-610" ;
-    :definition "Adversaries inject data into mobile technology traffic (data flows or signaling data) to disrupt communications or conduct additional surveillance operations." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/610.html> .
-
-:CAPEC-611 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "BitSquatting" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-611" ;
-    :definition "An adversary registers a domain name one bit different than a trusted domain. A BitSquatting attack leverages random errors in memory to direct Internet traffic to adversary-controlled destinations. BitSquatting requires no exploitation or complicated reverse engineering, and is operating system and architecture agnostic. Experimental observations show that BitSquatting popular websites could redirect non-trivial amounts of Internet traffic to a malicious entity." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/611.html> .
-
-:CAPEC-612 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "WiFi MAC Address Tracking" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-612" ;
-    :definition "In this attack scenario, the attacker passively listens for WiFi messages and logs the associated Media Access Control (MAC) addresses. These addresses are intended to be unique to each wireless device (although they can be configured and changed by software). Once the attacker is able to associate a MAC address with a particular user or set of users (for example, when attending a public event), the attacker can then scan for that MAC address to track that user in the future." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/612.html> ;
-    :related :CWE-201,
-        :CWE-300 .
-
-:CAPEC-613 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "WiFi SSID Tracking" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-613" ;
-    :definition "In this attack scenario, the attacker passively listens for WiFi management frame messages containing the Service Set Identifier (SSID) for the WiFi network. These messages are frequently transmitted by WiFi access points (e.g., the retransmission device) as well as by clients that are accessing the network (e.g., the handset/mobile device). Once the attacker is able to associate an SSID with a particular user or set of users (for example, when attending a public event), the attacker can then scan for this SSID to track that user in the future." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/613.html> ;
-    :related :CWE-201,
-        :CWE-300 .
-
-:CAPEC-614 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Rooting SIM Cards" ;
-    rdfs:subClassOf :CAPEC-186 ;
-    :capec-id "CAPEC-614" ;
-    :definition "SIM cards are the de facto trust anchor of mobile devices worldwide. The cards protect the mobile identity of subscribers, associate devices with phone numbers, and increasingly store payment credentials, for example in NFC-enabled phones with mobile wallets. This attack leverages over-the-air (OTA) updates deployed via cryptographically-secured SMS messages to deliver executable code to the SIM. By cracking the DES key, an attacker can send properly signed binary SMS messages to a device, which are treated as Java applets and are executed on the SIM. These applets are allowed to send SMS, change voicemail numbers, and query the phone location, among many other predefined functions. These capabilities alone provide plenty of potential for abuse." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/614.html> ;
-    :related :CWE-327 .
-
-:CAPEC-615 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Evil Twin Wi-Fi Attack" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-615" ;
-    :definition "Adversaries install Wi-Fi equipment that acts as a legitimate Wi-Fi network access point. When a device connects to this access point, Wi-Fi data traffic is intercepted, captured, and analyzed. This also allows the adversary to use \"adversary-in-the-middle\" (CAPEC-94) for all communications." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/615.html> ;
-    :related :CWE-300 .
-
-:CAPEC-616 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Establish Rogue Location" ;
-    rdfs:subClassOf :CAPEC-154 ;
-    :capec-id "CAPEC-616" ;
-    :definition "An adversary provides a malicious version of a resource at a location that is similar to the expected location of a legitimate resource. After establishing the rogue location, the adversary waits for a victim to visit the location and access the malicious resource." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/616.html> ;
-    :related :CWE-200,
-        :T1036.005 .
-
-:CAPEC-617 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cellular Rogue Base Station" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-617" ;
-    :definition "In this attack scenario, the attacker imitates a cellular base station with their own \"rogue\" base station equipment. Since cellular devices connect to whatever station has the strongest signal, the attacker can easily convince a targeted cellular device (e.g. the retransmission device) to talk to the rogue base station." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/617.html> .
-
-:CAPEC-618 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Cellular Broadcast Message Request" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-618" ;
-    :definition "In this attack scenario, the attacker uses knowledge of the target’s mobile phone number (i.e., the number associated with the SIM used in the retransmission device) to cause the cellular network to send broadcast messages to alert the mobile device. Since the network knows which cell tower the target’s mobile device is attached to, the broadcast messages are only sent in the Location Area Code (LAC) where the target is currently located. By triggering the cellular broadcast message and then listening for the presence or absence of that message, an attacker could verify that the target is in (or not in) a given location." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/618.html> ;
-    :related :CWE-201 .
-
-:CAPEC-619 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Signal Strength Tracking" ;
-    rdfs:subClassOf :CAPEC-292 ;
-    :capec-id "CAPEC-619" ;
-    :definition "In this attack scenario, the attacker passively monitors the signal strength of the target’s cellular RF signal or WiFi RF signal and uses the strength of the signal (with directional antennas and/or from multiple listening points at once) to identify the source location of the signal. Obtaining the signal of the target can be accomplished through multiple techniques such as through Cellular Broadcast Message Request or through the use of IMSI Tracking or WiFi MAC Address Tracking." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/619.html> ;
-    :related :CWE-201 .
-
-:CAPEC-620 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Drop Encryption Level" ;
-    rdfs:subClassOf :CAPEC-212 ;
-    :capec-id "CAPEC-620" ;
-    :definition "An attacker forces the encryption level to be lowered, thus enabling a successful attack against the encrypted data." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/620.html> ;
-    :related :CWE-757,
-        :T1600 .
-
-:CAPEC-621 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Analysis of Packet Timing and Sizes" ;
-    rdfs:subClassOf :CAPEC-189 ;
-    :capec-id "CAPEC-621" ;
-    :definition "An attacker may intercept and log encrypted transmissions for the purpose of analyzing metadata such as packet timing and sizes. Although the actual data may be encrypted, this metadata may reveal valuable information to an attacker. Note that this attack is applicable to VOIP data as well as application data, especially for interactive apps that require precise timing and low-latency (e.g. thin-clients)." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/621.html> ;
-    :related :CWE-201 .
-
-:CAPEC-622 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Electromagnetic Side-Channel Attack" ;
-    rdfs:subClassOf :CAPEC-189 ;
-    :capec-id "CAPEC-622" ;
-    :definition "In this attack scenario, the attacker passively monitors electromagnetic emanations that are produced by the targeted electronic device as an unintentional side-effect of its processing. From these emanations, the attacker derives information about the data that is being processed (e.g. the attacker can recover cryptographic keys by monitoring emanations associated with cryptographic processing). This style of attack requires proximal access to the device, however attacks have been demonstrated at public conferences that work at distances of up to 10-15 feet. There have not been any significant studies to determine the maximum practical distance for such attacks. Since the attack is passive, it is nearly impossible to detect and the targeted device will continue to operate as normal after a successful attack." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/622.html> ;
-    :related :CWE-201 .
-
-:CAPEC-623 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Compromising Emanations Attack" ;
-    rdfs:subClassOf :CAPEC-189 ;
-    :capec-id "CAPEC-623" ;
-    :definition "Compromising Emanations (CE) are defined as unintentional signals which an attacker may intercept and analyze to disclose the information processed by the targeted equipment. Commercial mobile devices and retransmission devices have displays, buttons, microchips, and radios that emit mechanical emissions in the form of sound or vibrations. Capturing these emissions can help an adversary understand what the device is doing." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/623.html> ;
-    :related :CWE-201 .
-
-:CAPEC-624 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hardware Fault Injection" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-624" ;
-    :definition "The adversary uses disruptive signals or events, or alters the physical environment a device operates in, to cause faulty behavior in electronic devices. This can include electromagnetic pulses, laser pulses, clock glitches, ambient temperature extremes, and more. When performed in a controlled manner on devices performing cryptographic operations, this faulty behavior can be exploited to derive secret key information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/624.html> ;
-    :related :CWE-1247,
-        :CWE-1248,
-        :CWE-1256,
-        :CWE-1319,
-        :CWE-1332,
-        :CWE-1334,
-        :CWE-1338,
-        :CWE-1351 .
-
-:CAPEC-625 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Mobile Device Fault Injection" ;
-    rdfs:subClassOf :CAPEC-624 ;
-    :capec-id "CAPEC-625" ;
-    :definition "Fault injection attacks against mobile devices use disruptive signals or events (e.g. electromagnetic pulses, laser pulses, clock glitches, etc.) to cause faulty behavior. When performed in a controlled manner on devices performing cryptographic operations, this faulty behavior can be exploited to derive secret key information. Although this attack usually requires physical control of the mobile device, it is non-destructive, and the device can be used after the attack without any indication that secret keys were compromised." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/625.html> ;
-    :related :CWE-1247,
-        :CWE-1248,
-        :CWE-1256,
-        :CWE-1319,
-        :CWE-1332,
-        :CWE-1334,
-        :CWE-1338,
-        :CWE-1351 .
-
-:CAPEC-626 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Smudge Attack" ;
-    rdfs:subClassOf :CAPEC-395 ;
-    :capec-id "CAPEC-626" ;
-    :definition "Attacks that reveal the password/passcode pattern on a touchscreen device by detecting oil smudges left behind by the user’s fingers." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/626.html> .
-
-:CAPEC-627 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Counterfeit GPS Signals" ;
-    rdfs:subClassOf :CAPEC-148 ;
-    :capec-id "CAPEC-627" ;
-    :definition "An adversary attempts to deceive a GPS receiver by broadcasting counterfeit GPS signals, structured to resemble a set of normal GPS signals. These spoofed signals may be structured in such a way as to cause the receiver to estimate its position to be somewhere other than where it actually is, or to be located where it is but at a different time, as determined by the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/627.html> .
-
-:CAPEC-628 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Carry-Off GPS Attack" ;
-    rdfs:subClassOf :CAPEC-627 ;
-    :capec-id "CAPEC-628" ;
-    :definition "A common form of a GPS spoofing attack, commonly termed a carry-off attack begins with an adversary broadcasting signals synchronized with the genuine signals observed by the target receiver. The power of the counterfeit signals is then gradually increased and drawn away from the genuine signals. Over time, the adversary can carry the target away from their intended destination and toward a location chosen by the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/628.html> .
-
-:CAPEC-629 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    owl:deprecated true ;
-    rdfs:label "DEPRECATED: Unauthorized Use of Device Resources" ;
-    rdfs:subClassOf :CommonAttackPattern ;
-    rdfs:comment "This attack pattern has been deprecated." ;
-    :capec-id "CAPEC-629" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/629.html> .
-
-:CAPEC-630 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "TypoSquatting" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-630" ;
-    :definition "An adversary registers a domain name with at least one character different than a trusted domain. A TypoSquatting attack takes advantage of instances where a user mistypes a URL (e.g. www.goggle.com) or not does visually verify a URL before clicking on it (e.g. phishing attack). As a result, the user is directed to an adversary-controlled destination. TypoSquatting does not require an attack against the trusted domain or complicated reverse engineering." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/630.html> ;
-    :related :CAPEC-691 .
-
-:CAPEC-631 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "SoundSquatting" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-631" ;
-    :definition "An adversary registers a domain name that sounds the same as a trusted domain, but has a different spelling. A SoundSquatting attack takes advantage of a user's confusion of the two words to direct Internet traffic to adversary-controlled destinations. SoundSquatting does not require an attack against the trusted domain or complicated reverse engineering." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/631.html> .
-
-:CAPEC-632 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Homograph Attack via Homoglyphs" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-632" ;
-    :definition "An adversary registers a domain name containing a homoglyph, leading the registered domain to appear the same as a trusted domain. A homograph attack leverages the fact that different characters among various character sets look the same to the user. Homograph attacks must generally be combined with other attacks, such as phishing attacks, in order to direct Internet traffic to the adversary-controlled destinations." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/632.html> ;
-    :related :CWE-1007 .
-
-:CAPEC-633 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Token Impersonation" ;
-    rdfs:subClassOf :CAPEC-194 ;
-    :capec-id "CAPEC-633" ;
-    :definition "An adversary exploits a weakness in authentication to create an access token (or equivalent) that impersonates a different entity, and then associates a process/thread to that that impersonated token. This action causes a downstream user to make a decision or take action that is based on the assumed identity, and not the response that blocks the adversary." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/633.html> ;
-    :related :CWE-287,
-        :CWE-1270,
-        :T1134 .
-
-:CAPEC-634 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Probe Audio and Video Peripherals" ;
-    rdfs:subClassOf :CAPEC-545,
-        :CAPEC-651 ;
-    :capec-id "CAPEC-634" ;
-    :definition "The adversary exploits the target system's audio and video functionalities through malware or scheduled tasks. The goal is to capture sensitive information about the target for financial, personal, political, or other gains which is accomplished by collecting communication data between two parties via the use of peripheral devices (e.g. microphones and webcams) or applications with audio and video capabilities (e.g. Skype) on a system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/634.html> ;
-    :related :CWE-267,
-        :T1123,
-        :T1125 .
-
-:CAPEC-635 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Alternative Execution Due to Deceptive Filenames" ;
-    rdfs:subClassOf :CAPEC-165 ;
-    :capec-id "CAPEC-635" ;
-    :definition "The extension of a file name is often used in various contexts to determine the application that is used to open and use it. If an attacker can cause an alternative application to be used, it may be able to execute malicious code, cause a denial of service or expose sensitive information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/635.html> ;
-    :related :CWE-162,
-        :T1036.007 .
-
-:CAPEC-636 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hiding Malicious Data or Code within Files" ;
-    rdfs:subClassOf :CAPEC-165 ;
-    :capec-id "CAPEC-636" ;
-    :definition "Files on various operating systems can have a complex format which allows for the storage of other data, in addition to its contents. Often this is metadata about the file, such as a cached thumbnail for an image file. Unless utilities are invoked in a particular way, this data is not visible during the normal use of the file. It is possible for an attacker to store malicious data or code using these facilities, which would be difficult to discover." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/636.html> ;
-    :related :CWE-506,
-        :T1001.002,
-        :T1027.003,
-        :T1027.004,
-        :T1218.001,
-        :T1221 .
-
-:CAPEC-637 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Collect Data from Clipboard" ;
-    rdfs:subClassOf :CAPEC-150 ;
-    :capec-id "CAPEC-637" ;
-    :definition "The adversary exploits an application that allows for the copying of sensitive data or information by collecting information copied to the clipboard. Data copied to the clipboard can be accessed by other applications, such as malware built to exfiltrate or log clipboard contents on a periodic basis. In this way, the adversary aims to garner information to which they are unauthorized." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/637.html> ;
-    :related :CWE-267,
-        :T1115 .
-
-:CAPEC-638 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Altered Component Firmware" ;
-    rdfs:subClassOf :CAPEC-452 ;
-    :capec-id "CAPEC-638" ;
-    :definition "An adversary exploits systems features and/or improperly protected firmware of hardware components, such as Hard Disk Drives (HDD), with the goal of executing malicious code from within the component's Master Boot Record (MBR). Conducting this type of attack entails the adversary infecting the target with firmware altering malware, using known tools, and a payload. Once this malware is executed, the MBR is modified to include instructions to execute the payload at desired intervals and when the system is booted up. A successful attack will obtain persistence within the victim system even if the operating system is reinstalled and/or if the component is formatted or has its data erased." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/638.html> ;
-    :related :T1542.002 .
-
-:CAPEC-639 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Probe System Files" ;
-    rdfs:subClassOf :CAPEC-545 ;
-    :capec-id "CAPEC-639" ;
-    :definition "An adversary obtains unauthorized information due to improperly protected files. If an application stores sensitive information in a file that is not protected by proper access control, then an adversary can access the file and search for sensitive information." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/639.html> ;
-    :related :CWE-552,
-        :T1039,
-        :T1552.001,
-        :T1552.003,
-        :T1552.004,
-        :T1552.006 .
-
-:CAPEC-640 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Inclusion of Code in Existing Process" ;
-    rdfs:subClassOf :CAPEC-251 ;
-    :capec-id "CAPEC-640" ;
-    :definition "The adversary takes advantage of a bug in an application failing to verify the integrity of the running process to execute arbitrary code in the address space of a separate live process. The adversary could use running code in the context of another process to try to access process's memory, system/network resources, etc. The goal of this attack is to evade detection defenses and escalate privileges by masking the malicious code under an existing legitimate process. Examples of approaches include but not limited to: dynamic-link library (DLL) injection, portable executable injection, thread execution hijacking, ptrace system calls, VDSO hijacking, function hooking, reflective code loading, and more." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/640.html> ;
-    :related :CWE-114,
-        :CWE-829,
-        :T1505.005,
-        :T1574.006,
-        :T1574.013,
-        :T1620 .
-
-:CAPEC-641 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DLL Side-Loading" ;
-    rdfs:subClassOf :CAPEC-159 ;
-    :capec-id "CAPEC-641" ;
-    :definition "An adversary places a malicious version of a Dynamic-Link Library (DLL) in the Windows Side-by-Side (WinSxS) directory to trick the operating system into loading this malicious DLL instead of a legitimate DLL. Programs specify the location of the DLLs to load via the use of WinSxS manifests or DLL redirection and if they aren't used then Windows searches in a predefined set of directories to locate the file. If the applications improperly specify a required DLL or WinSxS manifests aren't explicit about the characteristics of the DLL to be loaded, they can be vulnerable to side-loading." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/641.html> ;
-    :related :CWE-706,
-        :T1574.002 .
-
-:CAPEC-642 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Replace Binaries" ;
-    rdfs:subClassOf :CAPEC-17 ;
-    :capec-id "CAPEC-642" ;
-    :definition "Adversaries know that certain binaries will be regularly executed as part of normal processing. If these binaries are not protected with the appropriate file system permissions, it could be possible to replace them with malware. This malware might be executed at higher system permission levels. A variation of this pattern is to discover self-extracting installation packages that unpack binaries to directories with weak file permissions which it does not clean up appropriately. These binaries can be replaced by malware, which can then be executed." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/642.html> ;
-    :related :CWE-732,
-        :T1505.005,
-        :T1554,
-        :T1574.005 .
-
-:CAPEC-643 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Identify Shared Files/Directories on System" ;
-    rdfs:subClassOf :CAPEC-309 ;
-    :capec-id "CAPEC-643" ;
-    :definition "An adversary discovers connections between systems by exploiting the target system's standard practice of revealing them in searchable, common areas. Through the identification of shared folders/drives between systems, the adversary may further their goals of locating and collecting sensitive information/files, or map potential routes for lateral movement within the network." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/643.html> ;
-    :related :CWE-200,
-        :CWE-267,
-        :T1135 .
-
-:CAPEC-644 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Use of Captured Hashes (Pass The Hash)" ;
-    rdfs:subClassOf :CAPEC-653 ;
-    :capec-id "CAPEC-644" ;
-    :definition "An adversary obtains (i.e. steals or purchases) legitimate Windows domain credential hash values to access systems within the domain that leverage the Lan Man (LM) and/or NT Lan Man (NTLM) authentication protocols." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/644.html> ;
-    :related :CWE-294,
-        :CWE-308,
-        :CWE-522,
-        :CWE-836,
-        :T1550.002 .
-
-:CAPEC-645 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Use of Captured Tickets (Pass The Ticket)" ;
-    rdfs:subClassOf :CAPEC-652 ;
-    :capec-id "CAPEC-645" ;
-    :definition "An adversary uses stolen Kerberos tickets to access systems/resources that leverage the Kerberos authentication protocol. The Kerberos authentication protocol centers around a ticketing system which is used to request/grant access to services and to then access the requested services. An adversary can obtain any one of these tickets (e.g. Service Ticket, Ticket Granting Ticket, Silver Ticket, or Golden Ticket) to authenticate to a system/resource without needing the account's credentials. Depending on the ticket obtained, the adversary may be able to access a particular resource or generate TGTs for any account within an Active Directory Domain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/645.html> ;
-    :related :CWE-294,
-        :CWE-308,
-        :CWE-522,
-        :T1550.003 .
-
-:CAPEC-646 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Peripheral Footprinting" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-646" ;
-    :definition "Adversaries may attempt to obtain information about attached peripheral devices and components connected to a computer system. Examples may include discovering the presence of iOS devices by searching for backups, analyzing the Windows registry to determine what USB devices have been connected, or infecting a victim system with malware to report when a USB device has been connected. This may allow the adversary to gain additional insight about the system or network environment, which may be useful in constructing further attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/646.html> ;
-    :related :CWE-200,
-        :T1120 .
-
-:CAPEC-647 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Collect Data from Registries" ;
-    rdfs:subClassOf :CAPEC-150 ;
-    :capec-id "CAPEC-647" ;
-    :definition "An adversary exploits a weakness in authorization to gather system-specific data and sensitive information within a registry (e.g., Windows Registry, Mac plist). These contain information about the system configuration, software, operating system, and security. The adversary can leverage information gathered in order to carry out further attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/647.html> ;
-    :related :CWE-285,
-        :T1005,
-        :T1012,
-        :T1552.002 .
-
-:CAPEC-648 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Collect Data from Screen Capture" ;
-    rdfs:subClassOf :CAPEC-150 ;
-    :capec-id "CAPEC-648" ;
-    :definition "An adversary gathers sensitive information by exploiting the system's screen capture functionality. Through screenshots, the adversary aims to see what happens on the screen over the course of an operation. The adversary can leverage information gathered in order to carry out further attacks." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/648.html> ;
-    :related :CWE-267,
-        :T1113,
-        :T1513 .
-
-:CAPEC-649 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Adding a Space to a File Extension" ;
-    rdfs:subClassOf :CAPEC-635 ;
-    :capec-id "CAPEC-649" ;
-    :definition "An adversary adds a space character to the end of a file extension and takes advantage of an application that does not properly neutralize trailing special elements in file names. This extra space, which can be difficult for a user to notice, affects which default application is used to operate on the file and can be leveraged by the adversary to control execution." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/649.html> ;
-    :related :CWE-46,
-        :T1036.006 .
-
-:CAPEC-650 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Upload a Web Shell to a Web Server" ;
-    rdfs:subClassOf :CAPEC-17 ;
-    :capec-id "CAPEC-650" ;
-    :definition "By exploiting insufficient permissions, it is possible to upload a web shell to a web server in such a way that it can be executed remotely. This shell can have various capabilities, thereby acting as a \"gateway\" to the underlying web server. The shell might execute at the higher permission level of the web server, providing the ability the execute malicious code at elevated levels." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/650.html> ;
-    :related :CWE-287,
-        :CWE-553,
-        :T1505.003 .
-
-:CAPEC-651 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Eavesdropping" ;
-    rdfs:subClassOf :CAPEC-117 ;
-    :capec-id "CAPEC-651" ;
-    :definition "An adversary intercepts a form of communication (e.g. text, audio, video) by way of software (e.g., microphone and audio recording application), hardware (e.g., recording equipment), or physical means (e.g., physical proximity). The goal of eavesdropping is typically to gain unauthorized access to sensitive information about the target for financial, personal, political, or other gains. Eavesdropping is different from a sniffing attack as it does not take place on a network-based communication channel (e.g., IP traffic). Instead, it entails listening in on the raw audio source of a conversation between two or more parties." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/651.html> ;
-    :related :CWE-200,
-        :T1111 .
-
-:CAPEC-652 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Use of Known Kerberos Credentials" ;
-    rdfs:subClassOf :CAPEC-560 ;
-    :capec-id "CAPEC-652" ;
-    :definition "An adversary obtains (i.e. steals or purchases) legitimate Kerberos credentials (e.g. Kerberos service account userID/password or Kerberos Tickets) with the goal of achieving authenticated access to additional systems, applications, or services within the domain." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/652.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-294,
-        :CWE-307,
-        :CWE-308,
-        :CWE-309,
-        :CWE-522,
-        :CWE-654,
-        :CWE-836,
-        :T1558 .
-
-:CAPEC-653 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Use of Known Operating System Credentials" ;
-    rdfs:subClassOf :CAPEC-560 ;
-    :capec-id "CAPEC-653" ;
-    :definition "An adversary guesses or obtains (i.e. steals or purchases) legitimate operating system credentials (e.g. userID/password) to achieve authentication and to perform authorized actions on the system, under the guise of an authenticated user or service. This applies to any Operating System." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/653.html> ;
-    :related :CWE-262,
-        :CWE-263,
-        :CWE-307,
-        :CWE-308,
-        :CWE-309,
-        :CWE-522,
-        :CWE-654 .
-
-:CAPEC-654 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Credential Prompt Impersonation" ;
-    rdfs:subClassOf :CAPEC-504 ;
-    :capec-id "CAPEC-654" ;
-    :definition "An adversary, through a previously installed malicious application, impersonates a credential prompt in an attempt to steal a user's credentials." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/654.html> ;
-    :related :CWE-1021,
-        :T1056,
-        :T1548.004 .
-
-:CAPEC-655 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Avoid Security Tool Identification by Adding Data" ;
-    rdfs:subClassOf :CAPEC-572 ;
-    :capec-id "CAPEC-655" ;
-    :definition "An adversary adds data to a file to increase the file size beyond what security tools are capable of handling in an attempt to mask their actions." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/655.html> ;
-    :related :T1027.001 .
-
-:CAPEC-656 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Voice Phishing" ;
-    rdfs:subClassOf :CAPEC-98 ;
-    :capec-id "CAPEC-656" ;
-    :definition "An adversary targets users with a phishing attack for the purpose of soliciting account passwords or sensitive information from the user. Voice Phishing is a variation of the Phishing social engineering technique where the attack is initiated via a voice call, rather than email. The user is enticed to provide sensitive information by the adversary, who masquerades as a legitimate employee of the alleged organization. Voice Phishing attacks deviate from standard Phishing attacks, in that a user doesn't typically interact with a compromised website to provide sensitive information and instead provides this information verbally. Voice Phishing attacks can also be initiated by either the adversary in the form of a \"cold call\" or by the victim if calling an illegitimate telephone number." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/656.html> .
-
-:CAPEC-657 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Automated Software Update via Spoofing" ;
-    rdfs:subClassOf :CAPEC-186 ;
-    :capec-id "CAPEC-657" ;
-    :definition "An attackers uses identify or content spoofing to trick a client into performing an automated software update from a malicious source. A malicious automated software update that leverages spoofing can include content or identity spoofing as well as protocol spoofing. Content or identity spoofing attacks can trigger updates in software by embedding scripted mechanisms within a malicious web page, which masquerades as a legitimate update source. Scripting mechanisms communicate with software components and trigger updates from locations specified by the attackers' server. The result is the client believing there is a legitimate software update available but instead downloading a malicious update from the attacker." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/657.html> ;
-    :related :CWE-494,
-        :T1072 .
-
-:CAPEC-660 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Root/Jailbreak Detection Evasion via Hooking" ;
-    rdfs:subClassOf :CAPEC-251 ;
-    :capec-id "CAPEC-660" ;
-    :definition "An adversary forces a non-restricted mobile application to load arbitrary code or code files, via Hooking, with the goal of evading Root/Jailbreak detection. Mobile device users often Root/Jailbreak their devices in order to gain administrative control over the mobile operating system and/or to install third-party mobile applications that are not provided by authorized application stores (e.g. Google Play Store and Apple App Store). Adversaries may further leverage these capabilities to escalate privileges or bypass access control on legitimate applications. Although many mobile applications check if a mobile device is Rooted/Jailbroken prior to authorized use of the application, adversaries may be able to \"hook\" code in order to circumvent these checks. Successfully evading Root/Jailbreak detection allows an adversary to execute administrative commands, obtain confidential data, impersonate legitimate users of the application, and more." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/660.html> ;
-    :related :CWE-829,
-        :T1055 .
-
-:CAPEC-661 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Root/Jailbreak Detection Evasion via Debugging" ;
-    rdfs:subClassOf :CAPEC-121 ;
-    :capec-id "CAPEC-661" ;
-    :definition "An adversary inserts a debugger into the program entry point of a mobile application to modify the application binary, with the goal of evading Root/Jailbreak detection. Mobile device users often Root/Jailbreak their devices in order to gain administrative control over the mobile operating system and/or to install third-party mobile applications that are not provided by authorized application stores (e.g. Google Play Store and Apple App Store). Rooting/Jailbreaking a mobile device also provides users with access to system debuggers and disassemblers, which can be leveraged to exploit applications by dumping the application's memory at runtime in order to remove or bypass signature verification methods. This further allows the adversary to evade Root/Jailbreak detection mechanisms, which can result in execution of administrative commands, obtaining confidential data, impersonating legitimate users of the application, and more." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/661.html> ;
-    :related :CWE-489 .
-
-:CAPEC-662 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Adversary in the Browser (AiTB)" ;
-    rdfs:subClassOf :CAPEC-94 ;
-    :capec-id "CAPEC-662" ;
-    :definition "An adversary exploits security vulnerabilities or inherent functionalities of a web browser, in order to manipulate traffic between two endpoints." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/662.html> ;
-    :related :CWE-300,
-        :CWE-494,
-        :T1185 .
-
 :CAPEC-663 a :CommonAttackPattern,
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Exploitation of Transient Instruction Execution" ;
-    rdfs:subClassOf :CAPEC-74,
-        :CAPEC-184 ;
-    :capec-id "CAPEC-663" ;
-    :definition "An adversary exploits a hardware design flaw in a CPU implementation of transient instruction execution to expose sensitive data and bypass/subvert access control over restricted resources. Typically, the adversary conducts a covert channel attack to target non-discarded microarchitectural changes caused by transient executions such as speculative execution, branch prediction, instruction pipelining, and/or out-of-order execution. The transient execution results in a series of instructions (gadgets) which construct covert channel and access/transfer the secret data." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/663.html> ;
-    :related :CAPEC-124,
-        :CAPEC-180,
-        :CAPEC-212,
-        :CWE-1037,
-        :CWE-1264,
-        :CWE-1303 .
-
-:CAPEC-664 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Server Side Request Forgery" ;
-    rdfs:subClassOf :CAPEC-115 ;
-    :capec-id "CAPEC-664" ;
-    :definition "An adversary exploits improper input validation by submitting maliciously crafted input to a target application running on a server, with the goal of forcing the server to make a request either to itself, to web services running in the server’s internal network, or to external third parties. If successful, the adversary’s request will be made with the server’s privilege level, bypassing its authentication controls. This ultimately allows the adversary to access sensitive data, execute commands on the server’s network, and make external requests with the stolen identity of the server. Server Side Request Forgery attacks differ from Cross Site Request Forgery attacks in that they target the server itself, whereas CSRF attacks exploit an insecure user authentication mechanism to perform unauthorized actions on the user's behalf." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/664.html> ;
-    :related :CWE-20,
-        :CWE-918 .
-
-:CAPEC-665 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploitation of Thunderbolt Protection Flaws" ;
-    rdfs:subClassOf :CAPEC-276 ;
-    :capec-id "CAPEC-665" ;
-    :definition "An adversary leverages a firmware weakness within the Thunderbolt protocol, on a computing device to manipulate Thunderbolt controller firmware in order to exploit vulnerabilities in the implementation of authorization and verification schemes within Thunderbolt protection mechanisms. Upon gaining physical access to a target device, the adversary conducts high-level firmware manipulation of the victim Thunderbolt controller SPI (Serial Peripheral Interface) flash, through the use of a SPI Programing device and an external Thunderbolt device, typically as the target device is booting up. If successful, this allows the adversary to modify memory, subvert authentication mechanisms, spoof identities and content, and extract data and memory from the target device. Currently 7 major vulnerabilities exist within Thunderbolt protocol with 9 attack vectors as noted in the Execution Flow." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/665.html> ;
-    :related :CAPEC-148,
-        :CAPEC-151,
-        :CAPEC-458,
-        :CWE-288,
-        :CWE-345,
-        :CWE-353,
-        :CWE-862,
-        :CWE-1188,
-        :T1211,
-        :T1542.002,
-        :T1556 .
-
-:CAPEC-666 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "BlueSmacking" ;
-    rdfs:subClassOf :CAPEC-125 ;
-    :capec-id "CAPEC-666" ;
-    :definition "An adversary uses Bluetooth flooding to transfer large packets to Bluetooth enabled devices over the L2CAP protocol with the goal of creating a DoS. This attack must be carried out within close proximity to a Bluetooth enabled device." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/666.html> ;
-    :related :CWE-404,
-        :T1498.001,
-        :T1499.001 .
-
-:CAPEC-667 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Bluetooth Impersonation AttackS (BIAS)" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-667" ;
-    :definition "An adversary disguises the MAC address of their Bluetooth enabled device to one for which there exists an active and trusted connection and authenticates successfully. The adversary can then perform malicious actions on the target Bluetooth device depending on the target’s capabilities." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/667.html> ;
-    :related :CWE-290 .
-
-:CAPEC-668 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Key Negotiation of Bluetooth Attack (KNOB)" ;
-    rdfs:subClassOf :CAPEC-115 ;
-    :capec-id "CAPEC-668" ;
-    :definition "An adversary can exploit a flaw in Bluetooth key negotiation allowing them to decrypt information sent between two devices communicating via Bluetooth. The adversary uses an Adversary in the Middle setup to modify packets sent between the two devices during the authentication process, specifically the entropy bits. Knowledge of the number of entropy bits will allow the attacker to easily decrypt information passing over the line of communication." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/668.html> ;
-    :related :CWE-285,
-        :CWE-425,
-        :CWE-693,
-        :T1565.002 .
-
-:CAPEC-669 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Alteration of a Software Update" ;
-    rdfs:subClassOf :CAPEC-184 ;
-    :capec-id "CAPEC-669" ;
-    :definition "An adversary with access to an organization’s software update infrastructure inserts malware into the content of an outgoing update to fielded systems where a wide range of malicious effects are possible. With the same level of access, the adversary can alter a software update to perform specific malicious acts including granting the adversary control over the software’s normal functionality." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/669.html> ;
-    :related :T1195.002 .
-
-:CAPEC-670 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Software Development Tools Maliciously Altered" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-670" ;
-    :definition "An adversary with the ability to alter tools used in a development environment causes software to be developed with maliciously modified tools. Such tools include requirements management and database tools, software design tools, configuration management tools, compilers, system build tools, and software performance testing and load testing tools. The adversary then carries out malicious acts once the software is deployed including malware infection of other systems to support further compromises." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/670.html> ;
-    :related :T1127,
-        :T1195.001 .
-
-:CAPEC-671 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Requirements for ASIC Functionality Maliciously Altered" ;
-    rdfs:subClassOf :CAPEC-447 ;
-    :capec-id "CAPEC-671" ;
-    :definition "An adversary with access to functional requirements for an application specific integrated circuit (ASIC), a chip designed/customized for a singular particular use, maliciously alters requirements derived from originating capability needs. In the chip manufacturing process, requirements drive the chip design which, when the chip is fully manufactured, could result in an ASIC which may not meet the user’s needs, contain malicious functionality, or exhibit other anomalous behaviors thereby affecting the intended use of the ASIC." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/671.html> ;
-    :related :T1195.003 .
-
-:CAPEC-672 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Malicious Code Implanted During Chip Programming" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-672" ;
-    :definition "During the programming step of chip manufacture, an adversary with access and necessary technical skills maliciously alters a chip’s intended program logic to produce an effect intended by the adversary when the fully manufactured chip is deployed and in operational use. Intended effects can include the ability of the adversary to remotely control a host system to carry out malicious acts." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/672.html> ;
-    :related :T1195.003 .
-
-:CAPEC-673 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Developer Signing Maliciously Altered Software" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-673" ;
-    :definition "Software produced by a reputable developer is clandestinely infected with malicious code and then digitally signed by the unsuspecting developer, where the software has been altered via a compromised software development or build process prior to being signed. The receiver or user of the software has no reason to believe that it is anything but legitimate and proceeds to deploy it to organizational systems." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/673.html> ;
-    :related :T1195.002 .
-
-:CAPEC-674 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Design for FPGA Maliciously Altered" ;
-    rdfs:subClassOf :CAPEC-447 ;
-    :capec-id "CAPEC-674" ;
-    :definition "An adversary alters the functionality of a field-programmable gate array (FPGA) by causing an FPGA configuration memory chip reload in order to introduce a malicious function that could result in the FPGA performing or enabling malicious functions on a host system. Prior to the memory chip reload, the adversary alters the program for the FPGA by adding a function to impact system operation." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/674.html> ;
-    :related :T1195.003 .
-
-:CAPEC-675 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Retrieve Data from Decommissioned Devices" ;
-    rdfs:subClassOf :CAPEC-116 ;
-    :capec-id "CAPEC-675" ;
-    :definition "An adversary obtains decommissioned, recycled, or discarded systems and devices that can include an organization’s intellectual property, employee data, and other types of controlled information. Systems and devices that have reached the end of their lifecycles may be subject to recycle or disposal where they can be exposed to adversarial attempts to retrieve information from internal memory chips and storage devices that are part of the system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/675.html> ;
-    :related :CWE-1266,
-        :T1052 .
-
-:CAPEC-676 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "NoSQL Injection" ;
-    rdfs:subClassOf :CAPEC-248 ;
-    :capec-id "CAPEC-676" ;
-    :definition "An adversary targets software that constructs NoSQL statements based on user input or with parameters vulnerable to operator replacement in order to achieve a variety of technical impacts such as escalating privileges, bypassing authentication, and/or executing code." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/676.html> ;
-    :related :CWE-943,
-        :CWE-1286 .
-
-:CAPEC-677 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Server Motherboard Compromise" ;
-    rdfs:subClassOf :CAPEC-534 ;
-    :capec-id "CAPEC-677" ;
-    :definition "Malware is inserted in a server motherboard (e.g., in the flash memory) in order to alter server functionality from that intended. The development environment or hardware/software support activity environment is susceptible to an adversary inserting malicious software into hardware components during development or update." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/677.html> ;
-    :related :T1195.003 .
-
-:CAPEC-678 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "System Build Data Maliciously Altered" ;
-    rdfs:subClassOf :CAPEC-444 ;
-    :capec-id "CAPEC-678" ;
-    :definition "During the system build process, the system is deliberately misconfigured by the alteration of the build data. Access to system configuration data files and build processes is susceptible to deliberate misconfiguration of the system." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/678.html> ;
-    :related :T1195.002 .
-
-:CAPEC-679 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploitation of Improperly Configured or Implemented Memory Protections" ;
-    rdfs:subClassOf :CAPEC-1,
-        :CAPEC-180 ;
-    :capec-id "CAPEC-679" ;
-    :definition "An adversary takes advantage of missing or incorrectly configured access control within memory to read/write data or inject malicious code into said memory." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/679.html> ;
-    :related :CWE-1222,
-        :CWE-1252,
-        :CWE-1257,
-        :CWE-1260,
-        :CWE-1274,
-        :CWE-1282,
-        :CWE-1312,
-        :CWE-1316,
-        :CWE-1326 .
-
-:CAPEC-680 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploitation of Improperly Controlled Registers" ;
-    rdfs:subClassOf :CAPEC-1,
-        :CAPEC-180 ;
-    :capec-id "CAPEC-680" ;
-    :definition "An adversary exploits missing or incorrectly configured access control within registers to read/write data that is not meant to be obtained or modified by a user." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/680.html> ;
-    :related :CWE-1224,
-        :CWE-1231,
-        :CWE-1233,
-        :CWE-1262,
-        :CWE-1283 .
-
-:CAPEC-681 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploitation of Improperly Controlled Hardware Security Identifiers" ;
-    rdfs:subClassOf :CAPEC-1,
-        :CAPEC-180 ;
-    :capec-id "CAPEC-681" ;
-    :definition "An adversary takes advantage of missing or incorrectly configured security identifiers (e.g., tokens), which are used for access control within a System-on-Chip (SoC), to read/write data or execute a given action." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/681.html> ;
-    :related :CWE-1259,
-        :CWE-1267,
-        :CWE-1270,
-        :CWE-1294,
-        :CWE-1302 .
-
-:CAPEC-682 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploitation of Firmware or ROM Code with Unpatchable Vulnerabilities" ;
-    rdfs:subClassOf :CAPEC-212 ;
-    :capec-id "CAPEC-682" ;
-    :definition "An adversary may exploit vulnerable code (i.e., firmware or ROM) that is unpatchable. Unpatchable devices exist due to manufacturers intentionally or inadvertently designing devices incapable of updating their software. Additionally, with updatable devices, the manufacturer may decide not to support the device and stop making updates to their software." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/682.html> ;
-    :related :CWE-1277,
-        :CWE-1310 .
-
-:CAPEC-690 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Metadata Spoofing" ;
     rdfs:subClassOf :CommonAttackPattern ;
-    :capec-id "CAPEC-690" ;
-    :definition "An adversary alters the metadata of a resource (e.g., file, directory, repository, etc.) to present a malicious resource as legitimate/credible." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/690.html> .
-
-:CAPEC-691 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Spoof Open-Source Software Metadata" ;
-    rdfs:subClassOf :CAPEC-690 ;
-    :capec-id "CAPEC-691" ;
-    :definition "An adversary spoofs open-source software metadata in an attempt to masquerade malicious software as popular, maintained, and trusted." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/691.html> ;
-    :related :CAPEC-630,
-        :CWE-494,
-        :T1195.001,
-        :T1195.002 .
-
-:CAPEC-692 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Spoof Version Control System Commit Metadata" ;
-    rdfs:subClassOf :CAPEC-691 ;
-    :capec-id "CAPEC-692" ;
-    :definition "An adversary spoofs metadata pertaining to a Version Control System (VCS) (e.g., Git) repository's commits to deceive users into believing that the maliciously provided software is frequently maintained and originates from a trusted source." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/692.html> ;
-    :related :CWE-494 .
-
-:CAPEC-693 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "StarJacking" ;
-    rdfs:subClassOf :CAPEC-691 ;
-    :capec-id "CAPEC-693" ;
-    :definition "An adversary spoofs software popularity metadata to deceive users into believing that a maliciously provided package is widely used and originates from a trusted source." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/693.html> ;
-    :related :CWE-494 .
-
-:CAPEC-694 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "System Location Discovery" ;
-    rdfs:subClassOf :CAPEC-169 ;
-    :capec-id "CAPEC-694" ;
-    :definition "An adversary collects information about the target system in an attempt to identify the system's geographical location." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/694.html> ;
-    :related :CWE-497,
-        :T1614 .
-
-:CAPEC-695 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Repo Jacking" ;
-    rdfs:subClassOf :CAPEC-616 ;
-    :capec-id "CAPEC-695" ;
-    :definition "An adversary takes advantage of the redirect property of directly linked Version Control System (VCS) repositories to trick users into incorporating malicious code into their applications." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/695.html> ;
-    :related :CWE-494,
-        :CWE-829,
-        :T1195.001 .
-
-:CAPEC-696 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Load Value Injection" ;
-    rdfs:subClassOf :CAPEC-663 ;
-    :capec-id "CAPEC-696" ;
-    :definition "An adversary exploits a hardware design flaw in a CPU implementation of transient instruction execution in which a faulting or assisted load instruction transiently forwards adversary-controlled data from microarchitectural buffers. By inducing a page fault or microcode assist during victim execution, an adversary can force legitimate victim execution to operate on the adversary-controlled data which is stored in the microarchitectural buffers. The adversary can then use existing code gadgets and side channel analysis to discover victim secrets that have not yet been flushed from microarchitectural state or hijack the system control flow." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/696.html> ;
-    :related :CWE-1342 .
-
-:CAPEC-697 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "DHCP Spoofing" ;
-    rdfs:subClassOf :CAPEC-194 ;
-    :capec-id "CAPEC-697" ;
-    :definition "An adversary masquerades as a legitimate Dynamic Host Configuration Protocol (DHCP) server by spoofing DHCP traffic, with the goal of redirecting network traffic or denying service to DHCP." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/697.html> ;
-    :related :CWE-923,
-        :T1557.003 .
-
-:CAPEC-698 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Install Malicious Extension" ;
-    rdfs:subClassOf :CAPEC-542 ;
-    :capec-id "CAPEC-698" ;
-    :definition "An adversary directly installs or tricks a user into installing a malicious extension into existing trusted software, with the goal of achieving a variety of negative technical impacts." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/698.html> ;
-    :related :CWE-507,
-        :CWE-829,
-        :T1176,
-        :T1505.004 .
-
-:CAPEC-699 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Eavesdropping on a Monitor" ;
-    rdfs:subClassOf :CAPEC-651 ;
-    :capec-id "CAPEC-699" ;
-    :definition "An Adversary can eavesdrop on the content of an external monitor through the air without modifying any cable or installing software, just capturing this signal emitted by the cable or video port, with this the attacker will be able to impact the confidentiality of the data without being detected by traditional security tools" ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/699.html> ;
-    :related :CWE-1300 .
-
-:CAPEC-700 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Network Boundary Bridging" ;
-    rdfs:subClassOf :CAPEC-161 ;
-    :capec-id "CAPEC-700" ;
-    :definition "An adversary which has gained elevated access to network boundary devices may use these devices to create a channel to bridge trusted and untrusted networks. Boundary devices do not necessarily have to be on the network’s edge, but rather must serve to segment portions of the target network the adversary wishes to cross into." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/700.html> ;
-    :related :T1599 .
-
-:CAPEC-701 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Browser in the Middle (BiTM)" ;
-    rdfs:subClassOf :CAPEC-94 ;
-    :capec-id "CAPEC-701" ;
-    :definition "An adversary exploits the inherent functionalities of a web browser, in order to establish an unnoticed remote desktop connection in the victim's browser to the adversary's system. The adversary must deploy a web client with a remote desktop session that the victim can access." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/701.html> ;
-    :related :CWE-294,
-        :CWE-345 .
-
-:CAPEC-702 a :CommonAttackPattern,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Exploiting Incorrect Chaining or Granularity of Hardware Debug Components" ;
-    rdfs:subClassOf :CAPEC-180 ;
-    :capec-id "CAPEC-702" ;
-    :definition "An adversary exploits incorrect chaining or granularity of hardware debug components in order to gain unauthorized access to debug functionality on a chip. This happens when authorization is not checked on a per function basis and is assumed for a chain or group of debug functionality." ;
-    rdfs:seeAlso <https://capec.mitre.org/data/definitions/702.html> ;
-    :related :CWE-1296 .
+    rdfs:isDefinedBy <https://capec.mitre.org/data/definitions/663.html> ;
+    :capec-id "CAPEC-553" .
 
 :CAPECThing a owl:Class ;
     rdfs:label "CAPEC Thing" ;
@@ -10217,12 +3296,6 @@ DHHS, National Health Security Review 2010- 2014, Terms, Jan 17""" ;
     :definition "The CART algorithm is a type of classification algorithm that is required to build a decision tree on the basis of Gini’s impurity index." ;
     :kb-article """## References
 Classification and Regression Tree (CART) Algorithm. Analytics Steps. [Link](https://www.analyticssteps.com/blogs/classification-and-regression-tree-cart-algorithm).""" .
-
-:Catalog a owl:Class ;
-    rdfs:label "Catalog" ;
-    rdfs:subClassOf :InformationContentEntity ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/06499734-n" ;
-    :definition "A catalog is a complete list of things; usually arranged systematically." .
 
 :CCIControl a owl:Class ;
     rdfs:label "CCI Control" ;
@@ -10252,7 +3325,7 @@ Classification and Regression Tree (CART) Algorithm. Analytics Steps. [Link](htt
         [ a owl:Restriction ;
             owl:onProperty :may-contain ;
             owl:someValuesFrom :MemoryProtectionUnit ] ;
-    rdfs:isDefinedBy "https://en.wikipedia.org/wiki/Central_processing_unit" ;
+    rdfs:isDefinedBy <https://en.wikipedia.org/wiki/Central_processing_unit> ;
     :definition "A central processing unit (CPU), also called a central processor, main processor or just processor, is the electronic circuitry that executes instructions comprising a computer program. The CPU performs basic arithmetic, logic, controlling, and input/output (I/O) operations specified by the instructions in the program. This contrasts with external components such as main memory and I/O circuitry, and specialized processors such as graphics" ;
     :synonym "Central Processor",
         "CPU",
@@ -10290,16 +3363,32 @@ Google Developers. (n.d.). Clustering Algorithms. [Link](https://developers.goog
             owl:someValuesFrom :PublicKey ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Public_key_certificate> ;
     :definition "In cryptography, a public key certificate, also known as a digital certificate or identity certificate, is an electronic document used to prove the ownership of a public key. The certificate includes information about the key, information about the identity of its owner (called the subject), and the digital signature of an entity that has verified the certificate's contents (called the issuer). If the signature is valid, and the software examining the certificate trusts the issuer, then it can use that key to communicate securely with the certificate's subject. In email encryption, code signing, and e-signature systems, a certificate's subject is typically a person or organization. However, in Transport Layer Security (TLS) a certificate's subject is typically a computer or other device." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/certificate" ;
+    rdfs:seeAlso <https://schema.ocsf.io/objects/certificate> ;
     :todo "Since we say it contains a PK, must be PKC.  Rewire certificate hierarchy to include attribute/authorization certificates more generally.  Push this down to specifically represent PKCs.  Also key and authority issues may require parallel adjustments http://dbpedia.org/resource/Authorization_certificate" .
 
 :Certificate-basedAuthentication a :Certificate-basedAuthentication,
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Certificate-based Authentication" ;
-    rdfs:subClassOf :CredentialHardening ;
+    rdfs:subClassOf :CredentialHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :authenticates ;
+            owl:someValuesFrom :User ],
+        [ a owl:Restriction ;
+            owl:onProperty :reads ;
+            owl:someValuesFrom :Certificate ] ;
     :d3fend-id "D3-CBAN" ;
-    :definition "Requiring a digital certificate in order to authenticate a user." .
+    :definition "Requiring a digital certificate in order to authenticate a user." ;
+    :kb-article """## How it works
+
+Certificate-based authentication is a security mechanism that uses digital certificates to verify the identity of a user, device, or server before granting access to a network or system. This method relies on a pair of cryptographic keys: a public key and a private key.
+
+## Considerations
+
+* Private Key Protection: Ensure that private keys are securely stored and protected against unauthorized access.
+* Certificate Revocation: Implement a robust process for revoking certificates if they are compromised or no longer needed.
+* Man-in-the Middle Attacks: Use mutual authentication to mitigate the risk of these attacks.""" ;
+    :kb-reference :Reference-FederalPublicKeyInfrastructure101 .
 
 :CertificateAnalysis a :CertificateAnalysis,
         owl:Class,
@@ -10560,7 +3649,7 @@ Profiling request and response payloads across multiple clients to a single serv
     rdfs:subClassOf :Application ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Client_(computing)> ;
     :definition "A client application is software that accesses a service made available by a server. The server is often (but not always) on another computer system, in which case the client accesses the service by way of a network. The term applies to the role that programs or devices play in the client-server model" ;
-    rdfs:seeAlso "http://attackguidev.mitre.org/techniques/T1554/ \"Compromise Client Software Binary\"" .
+    rdfs:seeAlso :T1554 .
 
 :ClientComputer a owl:Class ;
     rdfs:label "Client Computer" ;
@@ -10579,7 +3668,7 @@ Profiling request and response payloads across multiple clients to a single serv
     rdfs:label "Cloud Configuration" ;
     skos:altLabel "Cloud Configuration Information" ;
     rdfs:subClassOf :ConfigurationResource ;
-    :definition "Information used to configure the services, parameters, and initial settings for a virtual server instance running in a cloud service.." .
+    :definition "Information used to configure the services, parameters, and initial settings for a virtual server instance running in a cloud service." .
 
 :CloudInstanceMetadata a owl:Class ;
     rdfs:label "Cloud Instance Metadata" ;
@@ -10597,6 +3686,11 @@ Profiling request and response payloads across multiple clients to a single serv
     rdfs:subClassOf :Authorization ;
     :definition "Cloud authorization is the function of specifying access rights to cloud resources." .
 
+:CloudServiceProvider a owl:Class ;
+    rdfs:label "Cloud Service Provider" ;
+    rdfs:subClassOf :ServiceProvider ;
+    :definition "A cloud service provider delivers scalable and distributed computing resources over a network, enabling clients to access infrastructure, platforms, and applications remotely." .
+
 :CloudServiceSensor a owl:Class ;
     rdfs:label "Cloud Service Sensor" ;
     rdfs:subClassOf :CyberSensor,
@@ -10608,7 +3702,8 @@ Profiling request and response payloads across multiple clients to a single serv
             owl:someValuesFrom :CloudServiceAuthorization ] ;
     :definition "Senses data from cloud service platforms. Including data from cloud service  authentications, authorizations, and other activities." .
 
-:CloudStorage a owl:Class ;
+:CloudStorage a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Cloud Storage" ;
     rdfs:subClassOf :SecondaryStorage ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Cloud_storage> ;
@@ -10633,7 +3728,8 @@ Cluster analysis. (n.d.). Wikipedia. [Link](https://en.wikipedia.org/wiki/Cluste
     rdfs:label "Clustering" ;
     rdfs:subClassOf :Summarizing .
 
-:CodeAnalyzer a owl:Class ;
+:CodeAnalyzer a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Code Analyzer" ;
     skos:altLabel "Program Analysis Tool" ;
     rdfs:subClassOf :DeveloperApplication ;
@@ -10687,8 +3783,7 @@ Wikipedia. (n.d.). Coefficient of variation. [Link](https://en.wikipedia.org/wik
 
 :Command a owl:Class ;
     rdfs:label "Command" ;
-    rdfs:subClassOf :DigitalEvent,
-        :DigitalInformation ;
+    rdfs:subClassOf :DigitalInformation ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Command_(computing)> ;
     :definition "In computing, a command is a directive to a computer program acting as an interpreter of some kind, in order to perform a specific task. Most commonly a command is either a directive to some kind of command-line interface, such as a shell, or an event in a graphical user interface triggered by the user selecting an option in a menu." .
 
@@ -10704,7 +3799,7 @@ Wikipedia. (n.d.). Coefficient of variation. [Link](https://en.wikipedia.org/wik
     rdfs:label "Command History Log" ;
     rdfs:subClassOf :EventLog ;
     :definition "A log of commands run in an operating system shell." ;
-    rdfs:seeAlso "d3f:CommandLineInterface",
+    rdfs:seeAlso :CommandLineInterface,
         <http://dbpedia.org/resource/Command_history> .
 
 :CommandHistoryLogFile a owl:Class ;
@@ -10744,16 +3839,63 @@ Wikipedia. (n.d.). Coefficient of variation. [Link](https://en.wikipedia.org/wik
     rdfs:subClassOf :ApplicationConfigurationFile ;
     :definition "A file containing Information used to configure the parameters and initial settings for a compiler." .
 
-:CompositeTechnique a owl:Class ;
-    rdfs:label "Composite Technique" ;
-    rdfs:subClassOf :D3FENDThing ;
-    :definition "A commonly applied series of techniques which induce a greater effect than each individual technique. The techniques are applied in a strict sequence." .
+:ComputeDeviceEvent a owl:Class ;
+    rdfs:label "Compute Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Processor ] ;
+    :definition "An event capturing the operation, state, or performance of computational hardware, such as CPUs, GPUs, or accelerators. These events reflect processing capacity changes, utilization anomalies, or device health." .
+
+:ComputerNetworkNode a owl:Class ;
+    rdfs:label "Computer Network Node" ;
+    rdfs:subClassOf :ComputerPlatform,
+        :NetworkNode ;
+    :definition "A network node running on a computer platform." .
+
+:ComputerPlatform a owl:Class ;
+    rdfs:label "Computer Platform" ;
+    skos:altLabel "Computer Platform" ;
+    rdfs:subClassOf :DigitalInformationBearer,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :Firmware ],
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :HardwareDevice ],
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :OperatingSystem ] ;
+    :definition "Platform includes the hardware and OS. The term computing platform can refer to different abstraction levels, including a certain hardware architecture, an operating system (OS), and runtime libraries. In total it can be said to be the stage on which computer programs can run." ;
+    rdfs:seeAlso <http://dbpedia.org/resource/Computing_platform> ;
+    :synonym "Computing Platform" ;
+    :todo "Future work might identify an application platform like Chrome, however Chrome OS would be considered a platform with respect to cybersecurity architects." .
+
+:ComputingImage a owl:Class ;
+    rdfs:label "Computing Image" ;
+    rdfs:subClassOf :DigitalInformationBearer ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/System_image#Process_images> ;
+    :definition "A computing image captures the full state or contents of a computing entity, such as a process or volume." .
 
 :ComputingServer a owl:Class ;
     rdfs:label "Computing Server" ;
     rdfs:subClassOf :Server ;
     rdfs:isDefinedBy <https://www.encyclopedia.com/computing/dictionaries-thesauruses-pictures-and-press-releases/compute-server> ;
     :definition "A compute server is a system specifically designed to undertake large amounts of computation, usually but not necessarily in a client/server environment." .
+
+:ComputingSnapshot a owl:Class ;
+    rdfs:label "Computing Snapshot" ;
+    skos:altLabel "Snapshot" ;
+    rdfs:subClassOf :DigitalInformationBearer ;
+    rdfs:isDefinedBy <https://dbpedia.org/resource/Snapshot_(computer_storage)> ;
+    :definition "In computer systems, a snapshot is the state of a system at a particular point in time. " .
+
+:Condition a owl:Class ;
+    rdfs:label "Condition" ;
+    rdfs:subClassOf :D3FENDCore ;
+    rdfs:comment "Less common usage versus state, meant to superclass precondition, postcondition, and effect." ;
+    rdfs:isDefinedBy "n-06768279" ;
+    :definition "An assumption on which rests the validity or effect of something else." .
 
 :ConferencePaper a owl:Class ;
     rdfs:label "Conference Paper" ;
@@ -10799,11 +3941,11 @@ The organization retrieves configuration information through means of SNMP (MIB 
 :ConfigurationManagementDatabase a owl:Class ;
     rdfs:label "Configuration Management Database" ;
     rdfs:subClassOf :ConfigurationDatabase ;
-    rdfs:isDefinedBy "https://web.archive.org/web/20111201040529/http://www.best-management-practice.com/gempdf/itil_glossary_v3_1_24.pdf" ;
+    rdfs:isDefinedBy <https://web.archive.org/web/20111201040529/http://www.best-management-practice.com/gempdf/itil_glossary_v3_1_24.pdf> ;
     :definition "A database used to store configuration records throughout their lifecycle. The Configuration Management System (CMS) maintains one or more CMDBs, and each CMDB stores attributes of configuration items (CIs), and relationships with other CIs." ;
-    rdfs:seeAlso "https://dbpedia.org/resource/Configuration_management_database",
-        "https://wiki.en.it-processmaps.com/index.php/ITIL_Glossary/_ITIL_Terms_C#Config_Management_Database_.28CMDB.29",
-        "https://www.dmtf.org/standards/cmdbf" .
+    rdfs:seeAlso <https://dbpedia.org/resource/Configuration_management_database>,
+        <https://wiki.en.it-processmaps.com/index.php/ITIL_Glossary/_ITIL_Terms_C#Config_Management_Database_.28CMDB.29>,
+        <https://www.dmtf.org/standards/cmdbf> .
 
 :ConfigurationResource a owl:Class ;
     rdfs:label "Configuration Resource" ;
@@ -10875,13 +4017,15 @@ Another approach passively inspects network traffic with application protocol an
 
 :ContainerImage a owl:Class ;
     rdfs:label "Container Image" ;
-    rdfs:subClassOf :File,
+    rdfs:subClassOf :ComputingImage,
         :SoftwarePackage ;
     rdfs:isDefinedBy <https://www.docker.com/resources/what-container> ;
     :definition """A container is a standard unit of software that packages up code and all its dependencies so the application runs quickly and reliably from one computing environment to another. A Docker container image is a lightweight, standalone, executable package of software that includes everything needed to run an application: code, runtime, system tools, system libraries and settings.
 
+:S
+
 Container images become containers at runtime and in the case of Docker containers - images become containers when they run on Docker Engine. Available for both Linux and Windows-based applications, containerized software will always run the same, regardless of the infrastructure. Containers isolate software from its environment and ensure that it works uniformly despite differences for instance between development and staging.""" ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/image" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/image> .
 
 :ContainerImageAnalysis a :ContainerImageAnalysis,
         owl:Class,
@@ -10950,18 +4094,9 @@ This admission controller
             owl:someValuesFrom :ContainerImage ] ;
     :definition "A software layer between d3f:ContainerProcess and d3f:Kernel which often mediates the invocation of d3f:SystemCall" .
 
-:Contribution a owl:Class ;
-    rdfs:subClassOf :D3FENDThing,
-        [ a owl:Restriction ;
-            owl:onProperty :created ;
-            owl:someValuesFrom xsd:dateTime ],
-        [ a owl:Restriction ;
-            owl:onProperty :has-contributor ;
-            owl:someValuesFrom :Agent ] .
-
 :ControlCatalog a owl:Class ;
     rdfs:label "Control Catalog" ;
-    rdfs:subClassOf :Catalog,
+    rdfs:subClassOf :ExternalControlThing,
         [ a owl:Restriction ;
             owl:onProperty :has-member ;
             owl:someValuesFrom :ExternalControl ],
@@ -10971,7 +4106,8 @@ This admission controller
                     owl:unionOf (
                             xsd:integer
                             xsd:string ) ] ] ;
-    :definition "A control catalog is a complete list of protective measures for systems, organizations, or individuals for subject domains (e.g., security and privacy.)" .
+    :definition "A control catalog is a complete list of protective measures for systems, organizations, or individuals for subject domains (e.g., security and privacy.)" ;
+    rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/06499734-n> .
 
 :ControlCorrelationIdentifierCatalog a owl:Class ;
     rdfs:label "Control Correlation Identifier Catalog" ;
@@ -10980,7 +4116,7 @@ This admission controller
             owl:onProperty :has-member ;
             owl:someValuesFrom :CCIControl ] ;
     :definition "A control correlation identifier (CCI) catalog provides a catalog of CCIs for a given release date." ;
-    rdfs:seeAlso "https://public.cyber.mil/stigs/cci/" .
+    rdfs:seeAlso <https://public.cyber.mil/stigs/cci/> .
 
 :ConvolutionalNeuralNetwork a owl:Class,
         owl:NamedIndividual ;
@@ -11059,12 +4195,12 @@ Wikipedia. (n.d.). Cramér's V. [Link](https://en.wikipedia.org/wiki/Cram%C3%A9r
     :definition "A process spawn refers to a function that loads and executes a new child process.The current process may wait for the child to terminate or may continue to execute asynchronously. Creating a new subprocess requires enough memory in which both the child process and the current program can execute. There is a family of spawn functions in DOS, inherited by Microsoft Windows. There is also a different family of spawn functions in an optional extension of the POSIX standards.  Fork-exec is another technique combining two Unix system calls, which can effect a process spawn.",
         "Creates a process.",
         "Executes a process." ;
-    rdfs:seeAlso "https://dbpedia.org/page/Fork%E2%80%93exec",
-        "https://dbpedia.org/page/Spawn_(computing)",
-        "https://learn.microsoft.com/en-us/windows/win32/procthread/creating-processes",
-        <http://dbpedia.org/resource/Fork%E2%80%93exec>,
+    rdfs:seeAlso <http://dbpedia.org/resource/Fork%E2%80%93exec>,
         <http://dbpedia.org/resource/Spawn_(computing)>,
-        <https://docs.microsoft.com/en-us/windows/win32/procthread/creating-processes> .
+        <https://dbpedia.org/page/Fork%E2%80%93exec>,
+        <https://dbpedia.org/page/Spawn_(computing)>,
+        <https://docs.microsoft.com/en-us/windows/win32/procthread/creating-processes>,
+        <https://learn.microsoft.com/en-us/windows/win32/procthread/creating-processes> .
 
 :CreateSocket a owl:Class ;
     rdfs:label "Create Socket" ;
@@ -11164,7 +4300,7 @@ Effective implementation requires identifying any location that could end up con
             owl:someValuesFrom :Evict ] ;
     :d3fend-id "D3-CE" ;
     :definition "Credential Eviction techniques disable or remove compromised credentials from a computer network." ;
-    :enables :Evict .
+    :kb-reference :Reference-AccountMonitoring_ForescoutTechnologies .
 
 :CredentialHardening a :CredentialHardening,
         owl:Class,
@@ -11184,10 +4320,10 @@ Effective implementation requires identifying any location that could end up con
     rdfs:isDefinedBy <http://dbpedia.org/resource/Credential_Management> ;
     :definition "Credential Management, also referred to as a Credential Management System (CMS), is an established form of software that is used for issuing and managing credentials as part of public key infrastructure (PKI)." .
 
-:CredentialRevoking a :CredentialRevoking,
+:CredentialRevocation a :CredentialRevocation,
         owl:Class,
         owl:NamedIndividual ;
-    rdfs:label "Credential Revoking" ;
+    rdfs:label "Credential Revocation" ;
     rdfs:subClassOf :CredentialEviction,
         [ a owl:Restriction ;
             owl:onProperty :deletes ;
@@ -11219,6 +4355,27 @@ Management servers with enterprise policies for account management provide the a
 - If proactively rotating credentials periodically, several factors should be considered to determine the frequency. Also introduces some risk including promoting the creation of weak passwords and poor storage practices for employees and presents challenges in proper tracking.""" ;
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-EvictionGuidanceforNetworksAffectedbytheSolarWindsandActiveDirectory/M365Compromise-CISA>,
         :Reference-PasswordandKeyRotation-SSH .
+
+:CredentialScrubbing a :CredentialScrubbing,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Credential Scrubbing" ;
+    rdfs:subClassOf :SourceCodeHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :Subroutine ] ;
+    :d3fend-id "D3-CS" ;
+    :definition "The systematic removal of hard-coded credentials from source code to prevent accidental exposure and unauthorized access." ;
+    :kb-article """## How it Works
+Credential Scrubbing involves identifying and eliminating hard-coded credentials such as usernames, passwords, API keys, and tokens from source code repositories. These credentials should be managed securely using environment variables, secret management tools, or secure vaults where they can be safely accessed when needed.
+
+## Considerations
+* Developers should conduct regular audits of source code to ensure credentials are not hard-coded.
+* Exposed credentials found in version control history must be disabled and replaced promptly.
+* Adopt role-based access controls and credential rotation policies to minimize security risks.""" ;
+    :kb-reference :Reference-SecretsManagementCheatSheet-OWASP ;
+    rdfs:seeAlso :CWE-798,
+        <https://capec.mitre.org/data/definitions/191.html> .
 
 :CredentialTransmissionScoping a :CredentialTransmissionScoping,
         owl:Class,
@@ -13157,7 +6314,10 @@ Management servers with enterprise policies for account management provide the a
     rdfs:label "Double Free" ;
     rdfs:subClassOf :CWE-666,
         :CWE-825,
-        :CWE-1341 ;
+        :CWE-1341,
+        [ a owl:Restriction ;
+            owl:onProperty :weakness-of ;
+            owl:someValuesFrom :MemoryFreeFunction ] ;
     :cwe-id "CWE-415" .
 
 :CWE-416 a owl:Class ;
@@ -13927,7 +7087,10 @@ Management servers with enterprise policies for account management provide the a
 
 :CWE-590 a owl:Class ;
     rdfs:label "Free of Memory not on the Heap" ;
-    rdfs:subClassOf :CWE-762 ;
+    rdfs:subClassOf :CWE-762,
+        [ a owl:Restriction ;
+            owl:onProperty :weakness-of ;
+            owl:someValuesFrom :MemoryFreeFunction ] ;
     :cwe-id "CWE-590" .
 
 :CWE-591 a owl:Class ;
@@ -14492,7 +7655,10 @@ Management servers with enterprise policies for account management provide the a
 
 :CWE-761 a owl:Class ;
     rdfs:label "Free of Pointer not at Start of Buffer" ;
-    rdfs:subClassOf :CWE-763 ;
+    rdfs:subClassOf :CWE-763,
+        [ a owl:Restriction ;
+            owl:onProperty :weakness-of ;
+            owl:someValuesFrom :MemoryFreeFunction ] ;
     :cwe-id "CWE-761" .
 
 :CWE-762 a owl:Class ;
@@ -14729,7 +7895,10 @@ Management servers with enterprise policies for account management provide the a
 
 :CWE-822 a owl:Class ;
     rdfs:label "Untrusted Pointer Dereference" ;
-    rdfs:subClassOf :CWE-119 ;
+    rdfs:subClassOf :CWE-119,
+        [ a owl:Restriction ;
+            owl:onProperty :weakness-of ;
+            owl:someValuesFrom :PointerDereferencingFunction ] ;
     :cwe-id "CWE-822" .
 
 :CWE-823 a owl:Class ;
@@ -14739,13 +7908,19 @@ Management servers with enterprise policies for account management provide the a
 
 :CWE-824 a owl:Class ;
     rdfs:label "Access of Uninitialized Pointer" ;
-    rdfs:subClassOf :CWE-119 ;
+    rdfs:subClassOf :CWE-119,
+        [ a owl:Restriction ;
+            owl:onProperty :weakness-of ;
+            owl:someValuesFrom :PointerDereferencingFunction ] ;
     :cwe-id "CWE-824" .
 
 :CWE-825 a owl:Class ;
     rdfs:label "Expired Pointer Dereference" ;
     rdfs:subClassOf :CWE-119,
-        :CWE-672 ;
+        :CWE-672,
+        [ a owl:Restriction ;
+            owl:onProperty :weakness-of ;
+            owl:someValuesFrom :UserInputFunction ] ;
     :cwe-id "CWE-825" .
 
 :CWE-826 a owl:Class ;
@@ -16135,9 +9310,20 @@ Management servers with enterprise policies for account management provide the a
     rdfs:subClassOf :CWE-657 ;
     :cwe-id "CWE-1395" .
 
+:CyberAction a owl:Class ;
+    rdfs:label "Cyber Action" ;
+    rdfs:subClassOf :Action .
+
 :CyberSensor a owl:Class ;
     rdfs:label "Cyber Sensor" ;
     rdfs:subClassOf :Sensor .
+
+:CyberTechnique a owl:Class ;
+    rdfs:label "Cyber Technique" ;
+    rdfs:subClassOf :Technique,
+        [ a owl:Restriction ;
+            owl:onProperty :implemented-by ;
+            owl:someValuesFrom :Procedure ] .
 
 :CycleGAN a owl:Class,
         owl:NamedIndividual ;
@@ -16151,18 +9337,17 @@ Esri. (n.d.). How CycleGAN Works. [Link](https://developers.arcgis.com/python/gu
 :D3FENDCatalogThing a owl:Class ;
     rdfs:label "D3FEND Catalog Thing" ;
     skos:altLabel "D3FEND Vendor Registry Thing" ;
-    rdfs:subClassOf :D3FENDThing .
+    rdfs:subClassOf :D3FENDKBThing .
 
 :D3FENDCore a owl:Class ;
     rdfs:label "D3FEND Core" .
 
-:D3FENDThing a owl:Class ;
-    rdfs:label "D3FEND Thing" ;
-    :definition "D3FEND things are concepts defined in the core D3FEND Framework." .
+:D3FENDKBThing a owl:Class ;
+    rdfs:label "D3FEND KB Thing" .
 
 :D3FENDUseCase a owl:Class ;
     rdfs:label "D3FEND Use Case" ;
-    rdfs:subClassOf :D3FENDUseCaseThing,
+    rdfs:subClassOf :UseCase,
         [ a owl:Restriction ;
             owl:onProperty :has-audience ;
             owl:someValuesFrom :TargetAudience ],
@@ -16175,10 +9360,6 @@ Esri. (n.d.). How CycleGAN Works. [Link](https://developers.arcgis.com/python/gu
         [ a owl:Restriction ;
             owl:onProperty :has-procedure ;
             owl:someValuesFrom :UseCaseProcedure ] .
-
-:D3FENDUseCaseThing a owl:Class ;
-    rdfs:label "D3FEND Use Case Thing" ;
-    rdfs:subClassOf :D3FENDThing .
 
 :DataArtifactServer a owl:Class ;
     rdfs:label "Data Artifact Server" ;
@@ -16276,7 +9457,7 @@ Some capabilities sanitize queries before permitting them to be transmitted to t
     rdfs:label "Data Link Link" ;
     rdfs:subClassOf :LogicalLink ;
     :definition "A communication link between two network devices connected directly at the physical layer and on the same network segment; i.e., an OSI Layer 2 link." ;
-    rdfs:seeAlso "https://dbpedia.org/resource/Link_layer" ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Link_layer> ;
     :synonym "Data Link Layer Link",
         "Layer-2 Link",
         "Link Layer Link" .
@@ -16713,9 +9894,13 @@ Q-learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Q-learning#Deep_Q-l
             owl:onProperty :enables ;
             owl:someValuesFrom :TA0005 ] .
 
+:DefensiveAction a owl:Class ;
+    rdfs:label "Defensive Action" ;
+    rdfs:subClassOf :CyberAction .
+
 :DefensiveTactic a owl:Class ;
     rdfs:label "Defensive Tactic" ;
-    rdfs:subClassOf :D3FENDThing,
+    rdfs:subClassOf :Goal,
         [ a owl:Restriction ;
             owl:onProperty :enabled-by ;
             owl:someValuesFrom :DefensiveTechnique ] ;
@@ -16726,10 +9911,8 @@ Q-learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Q-learning#Deep_Q-l
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Defensive Technique" ;
-    rdfs:subClassOf :Action,
-        :CapabilityFeature,
-        :D3FENDThing,
-        :Technique,
+    rdfs:subClassOf :CapabilityFeature,
+        :CyberTechnique,
         [ a owl:Restriction ;
             owl:onProperty :d3fend-id ;
             owl:someValuesFrom xsd:string ],
@@ -16839,13 +10022,13 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
     rdfs:subClassOf :DigitalInformationBearer,
         [ a owl:Restriction ;
             owl:onProperty :dependent ;
-            owl:someValuesFrom :D3FENDThing ],
+            owl:someValuesFrom :D3FENDCore ],
         [ a owl:Restriction ;
             owl:onProperty :provider ;
-            owl:someValuesFrom :D3FENDThing ] ;
+            owl:someValuesFrom :D3FENDCore ] ;
     :definition "A dependency is the relationship of relying on or being controlled by someone or something else.  This class reifies dependencies that correspond to the object property depends-on." ;
-    rdfs:seeAlso "http://wordnet-rdf.princeton.edu/id/14024833-n",
-        "https://www.cisa.gov/what-are-dependencies" .
+    rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/14024833-n>,
+        <https://www.cisa.gov/what-are-dependencies> .
 
 :DescriptionLogic a owl:Class,
         owl:NamedIndividual ;
@@ -16890,6 +10073,14 @@ Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/
     :display-order 1 ;
     :display-priority 0 .
 
+:DetectionEvent a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Detection Event" ;
+    rdfs:subClassOf :SecurityEvent ;
+    :definition "An event capturing the identification of a potential security issue, such as unauthorized access attempts, policy violations, or anomalous activities. Detection events form the foundation of cybersecurity monitoring and response." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/categories/findings> ;
+    :related :Detect .
+
 :DeveloperApplication a owl:Class ;
     rdfs:label "Developer Application" ;
     rdfs:subClassOf :UserApplication ;
@@ -16897,10 +10088,68 @@ Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/
     rdfs:seeAlso <http://dbpedia.org/resource/Application_development>,
         <http://dbpedia.org/resource/Application_software> .
 
+:DHCPAckEvent a owl:Class ;
+    rdfs:label "DHCP Ack Event" ;
+    skos:altLabel "DHCPACK" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event where a DHCP server sends an ACK message to acknowledge a client's REQUEST, confirming the allocation of an IP address and associated network settings." .
+
+:DHCPDiscoverEvent a owl:Class ;
+    rdfs:label "DHCP Discover Event" ;
+    skos:altLabel "DHCPDISCOVER" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event where a DHCP client broadcasts a DISCOVER message to identify available DHCP servers capable of providing IP configuration." .
+
+:DHCPEvent a owl:Class ;
+    rdfs:label "DHCP Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        :UDPEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :DHCPNetworkTraffic ] ;
+    :definition "An event involving the Dynamic Host Configuration Protocol (DHCP), a UDP-based protocol used to dynamically assign IP addresses and configure network parameters, enabling devices to communicate efficiently on a network." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/dhcp_activity> .
+
+:DHCPInformEvent a owl:Class ;
+    rdfs:label "DHCP Inform Event" ;
+    skos:altLabel "DHCPINFORM" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event where a DHCP client sends an INFORM message to request configuration parameters, such as DNS or gateway information, without requiring IP address assignment." .
+
+:DHCPLeaseExpireEvent a owl:Class ;
+    rdfs:label "DHCP Lease Expire Event" ;
+    skos:altLabel "DHCPLEASEEXPIRE" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event indicating that a DHCP lease has expired, rendering the previously assigned IP address available for reassignment to other devices." .
+
+:DHCPNakEvent a owl:Class ;
+    rdfs:label "DHCP Nak Event" ;
+    skos:altLabel "DHCPNAK" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event where a DHCP server sends a NAK message to reject a client's REQUEST, indicating that the requested configuration cannot be granted." .
+
 :DHCPNetworkTraffic a owl:Class ;
     rdfs:label "DHCP Network Traffic" ;
     rdfs:subClassOf :NetworkTraffic ;
     :definition "DHCP Network Traffic is network traffic related to the DHCP protocol, used by network nodes to negotiate and configure either IPv4 or IPv6 addresses." .
+
+:DHCPOfferEvent a owl:Class ;
+    rdfs:label "DHCP Offer Event" ;
+    skos:altLabel "DHCPOFFER" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event where a DHCP server sends an OFFER message to a client in response to a DISCOVER request, proposing an IP address and associated configuration parameters." .
+
+:DHCPReleaseEvent a owl:Class ;
+    rdfs:label "DHCP Release Event" ;
+    skos:altLabel "DHCPRELEASE" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event where a DHCP client sends a RELEASE message to relinquish its assigned IP address and cancel any remaining lease duration." .
+
+:DHCPRequestEvent a owl:Class ;
+    rdfs:label "DHCP Request Event" ;
+    skos:altLabel "DHCPREQUEST" ;
+    rdfs:subClassOf :DHCPEvent ;
+    :definition "An event where a DHCP client sends a REQUEST message to confirm or renew its desired IP configuration with a specific DHCP server." .
 
 :DHCPServer a owl:Class ;
     rdfs:label "DHCP Server" ;
@@ -16914,28 +10163,41 @@ Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/
     rdfs:isDefinedBy <http://dbpedia.org/resource/Modem#Dial-up> ;
     :definition "A dial-up modem transmits computer data over an ordinary switched telephone line that has not been designed for data use. This contrasts with leased line modems, which also operate over lines provided by a telephone company, but ones which are intended for data use and do not impose the same signaling constraints. The modulated data must fit the frequency constraints of a normal voice audio signal, and the modem must be able to perform the actions needed to connect a call through a telephone exchange, namely: picking up the line, dialing, understanding signals sent back by phone company equipment (dial tone, ringing, busy signal,) and on the far end of the call, the second modem in the connection must be able to recognize the incoming ring signal and answer the line." .
 
+:DifferentialVolumeSnapshot a owl:Class ;
+    rdfs:label "Differential Volume Snapshot" ;
+    rdfs:subClassOf :VolumeSnapshot ;
+    :definition "A differential volume snapshot is a point-in-time capture of the files and directories that were changed since the last full snapshot." ;
+    rdfs:seeAlso <https://aws.amazon.com/compare/the-difference-between-incremental-differential-and-other-backups/> .
+
 :DigitalArtifact a owl:Class ;
     rdfs:label "Digital Artifact" ;
-    rdfs:subClassOf :Artifact,
-        :D3FENDCore,
-        :DigitalObject ;
+    rdfs:subClassOf :Artifact ;
     :definition "An information-bearing artifact (object) that is, or is encoded to be used with, a digital computer system. This concept is broad to include the literal instances of an artifact, or an implicit summarization of changes to or properties of other artifacts." ;
     :display-baseurl "/dao/artifact/" ;
-    rdfs:seeAlso "https://www.iso.org/obp/ui/#iso:std:iso-iec:19770:-1:ed-3:v1:en",
-        <http://dbpedia.org/resource/Digital_artifactual_value>,
-        <http://dbpedia.org/resource/Virtual_artifact> ;
+    rdfs:seeAlso <http://dbpedia.org/resource/Digital_artifactual_value>,
+        <http://dbpedia.org/resource/Virtual_artifact>,
+        <https://www.iso.org/obp/ui/#iso:std:iso-iec:19770:-1:ed-3:v1:en> ;
     :synonym "Digital Asset" .
 
 :DigitalEvent a owl:Class ;
     rdfs:label "Digital Event" ;
-    rdfs:subClassOf :D3FENDThing .
+    rdfs:subClassOf :Event ;
+    :definition "A digital event represents an observable occurrence, action, or state change within digital systems, networks, or their interactions. These events are characterized by their impact on the confidentiality, integrity, availability, or functionality of digital resources, processes, identities, or communications. Digital events are essential units of information in cybersecurity, serving as the basis for detecting threats, analyzing anomalies, and orchestrating responses in complex, interconnected environments." .
+
+:DigitalEventRecord a owl:Class ;
+    rdfs:label "Digital Event Record" ;
+    rdfs:subClassOf :Record,
+        [ a owl:Restriction ;
+            owl:onProperty :records ;
+            owl:someValuesFrom :DigitalEvent ] ;
+    :definition "A digital event record is a structured representation of a digital event, encapsulating all relevant details about the occurrence for storage, analysis, and response. These records serve as the primary artifacts for cybersecurity operations, enabling threat detection, forensic investigations, and compliance reporting. Digital event records include metadata such as timestamps, origin, context, and associated resources, ensuring traceability and actionable intelligence in digital ecosystems." .
 
 :DigitalFingerprint a owl:Class ;
     rdfs:label "Digital Fingerprint" ;
     rdfs:subClassOf :Identifier ;
-    rdfs:isDefinedBy "https://csrc.nist.gov/glossary/term/digital_fingerprint" ;
+    rdfs:isDefinedBy <https://csrc.nist.gov/glossary/term/digital_fingerprint> ;
     :definition "A digital signature uniquely identifies data and has the property that changing a single bit in the data will cause a completely different message digest to be generated." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/fingerprint" ;
+    rdfs:seeAlso <https://schema.ocsf.io/objects/fingerprint> ;
     :todo "Create relationship 'identifies some data' once data ontology implemented" .
 
 :DigitalInformation a owl:Class ;
@@ -16945,13 +10207,6 @@ Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/
 :DigitalInformationBearer a owl:Class ;
     rdfs:label "Digital Information Bearer" ;
     rdfs:subClassOf :DigitalArtifact .
-
-:DigitalObject a owl:Class ;
-    rdfs:label "Digital Object" ;
-    rdfs:subClassOf :D3FENDThing ;
-    :definition "A digital object is the top-level class for an object that exists in a digital environment. The digital object may be virtual or physical." ;
-    rdfs:seeAlso <http://dbpedia.org/resource/Digital_artifactual_value>,
-        <http://dbpedia.org/resource/Virtual_artifact> .
 
 :DigitalSystem a owl:Class ;
     rdfs:label "Digital System" ;
@@ -16984,6 +10239,26 @@ O'Reilly Media. (n.d.). Chapter 7. Machine Learning and Security: Protecting Sys
     rdfs:isDefinedBy <http://dbpedia.org/resource/Directory_service> ;
     :definition "In computing, directory service or name service maps the names of network resources to their respective network addresses. It is a shared information infrastructure for locating, managing, administering and organizing everyday items and network resources, which can include volumes, folders, files, printers, users, groups, devices, telephone numbers and other objects. A directory service is a critical component of a network operating system. A directory server or name server is a server which provides such a service. Each resource on the network is considered an object by the directory server. Information about a particular resource is stored as a collection of attributes associated with that resource or object." .
 
+:DirectPhysicalLinkMapping a :DirectPhysicalLinkMapping,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Direct Physical Link Mapping" ;
+    rdfs:subClassOf :PhysicalLinkMapping ;
+    :d3fend-id "D3-DPLM" ;
+    :definition "Direct physical link mapping creates a physical link map by direct observation and recording of the physical network links." ;
+    :kb-article """## How it works
+
+Direct Physical Link Mapping involves a manual process where a network engineer or administrator physically observes and documents the physical connections within the network infrastructure.
+
+## Considerations
+
+* Constructing and maintaining physical topologies for extensive networks can be challenging and time-consuming using manual methods. Therefore, where feasible, automated methods like active physical link mapping should be considered as a partial or complete solution for physical link mapping processes.
+
+* In scenarios where active physical link mapping is not an option, physical inspection of networks is necessary to accomplish physical link mapping. This is due to the lack of reliable techniques to accurately map physical links solely through passive network traffic monitoring.""" ;
+    :kb-reference :Reference-NetworkMapping ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Transmission_medium> ;
+    :synonym "Manual Physical Link Mapping" .
+
 :DiscoveryTechnique a owl:Class ;
     rdfs:label "Discovery Technique" ;
     rdfs:subClassOf :ATTACKEnterpriseTechnique,
@@ -17012,6 +10287,58 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     :d3fend-id "D3-DENCR" ;
     :definition "Encrypting a hard disk partition to prevent cleartext access to a file system." ;
     :kb-reference :Reference-LUKS1On-DiskFormatSpecificationVersion1.2.3 .
+
+:DiskErasure a :DiskErasure,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Disk Erasure" ;
+    rdfs:subClassOf :DiskFormatting,
+        [ a owl:Restriction ;
+            owl:onProperty :erases ;
+            owl:someValuesFrom :SecondaryStorage ] ;
+    :d3fend-id "D3-DKE" ;
+    :definition "Disk Erasure is the process of securely deleting all data on a disk to ensure that it cannot be recovered by any means." ;
+    :kb-article """### How it works
+
+Disk Erasure involves overwriting the existing data with random or specific patterns multiple times. Disk erasure is crucial for data sanitization, ensuring that sensitive information is completely removed from storage devices before they are repurposed, disposed of, or transferred to another party.""" ;
+    :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-Remembranceofdatapassed:Astudyofdisksanitizationpractices> .
+
+:DiskFormatting a :DiskFormatting,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Disk Formatting" ;
+    rdfs:subClassOf :ObjectEviction,
+        [ a owl:Restriction ;
+            owl:onProperty :modifies ;
+            owl:someValuesFrom :SecondaryStorage ] ;
+    :d3fend-id "D3-DKF" ;
+    :definition "Disk Formatting is the process of preparing a data storage device, such as a hard drive, solid-state drive, or USB flash drive, for initial use." ;
+    :kb-article """### How it works
+
+This process involves setting up an empty file system on the disk, which includes creating a directory structure and initializing metadata structures. In cybersecurity, disk formatting can be used to remove all existing data on a disk, making it a clean slate for new data storage or to prevent unauthorized access to previously stored data.""" ;
+    :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-Remembranceofdatapassed:Astudyofdisksanitizationpractices> .
+
+:DiskImage a owl:Class ;
+    rdfs:label "Disk Image" ;
+    rdfs:subClassOf :StorageImage ;
+    rdfs:isDefinedBy <https://en.wikipedia.org/wiki/Disk_image> ;
+    :definition "A disk image is a snapshot of a storage device's structure and data typically stored in one or more computer files on another storage device." ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Disk_image> .
+
+:DiskPartitioning a :DiskPartitioning,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Disk Partitioning" ;
+    rdfs:subClassOf :DiskFormatting,
+        [ a owl:Restriction ;
+            owl:onProperty :creates ;
+            owl:someValuesFrom :PartitionTable ] ;
+    :d3fend-id "D3-DKP" ;
+    :definition "Disk Partitioning is the process of dividing a disk into multiple distinct sections, known as partitions." ;
+    :kb-article """### How it works
+
+Each partition can be managed separately and can have its own file system. Disk partitioning can be used to segregate sensitive data from less critical data, improve system performance, and enhance data management and recovery processes. It can also help in isolating different operating systems or environments on the same physical disk.""" ;
+    :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-Remembranceofdatapassed:Astudyofdisksanitizationpractices> .
 
 :DisplayAdapter a owl:Class ;
     rdfs:label "Display Adapter" ;
@@ -17087,6 +10414,24 @@ OpenReview. (n.d.). Unsupervised Clustering using Pseudo Ensemble Models. [Link]
     :kb-reference :Reference-DNSWhitelist-DNSWL-EmailAuthenticationMethodExtension ;
     :synonym "DNS Whitelisting" .
 
+:DNSCacheEviction a :DNSCacheEviction,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "DNS Cache Eviction" ;
+    rdfs:subClassOf :ObjectEviction,
+        [ a owl:Restriction ;
+            owl:onProperty :deletes ;
+            owl:someValuesFrom :DNSRecord ] ;
+    :d3fend-id "D3-DNSCE" ;
+    :definition "Flushing DNS to clear any IP addresses or other DNS records from the cache." ;
+    :kb-article """# How it works
+
+Flushing the DNS Cache will clear the IP addresses of websites you have visited recently. This can help remediate DNS Cache Poisoning attacks, which is a type of cyber attack where corrupted DNS data is inserted into the cache, causing redirects to malicious websites.
+
+On windows, the DNS cache can be wiped by issuing the command `ipconfig /flushdns`.""" ;
+    :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-EvictionGuidanceforNetworksAffectedbytheSolarWindsandActiveDirectory/M365Compromise-CISA> ;
+    :synonym "Flush DNS Cache" .
+
 :DNSDenylisting a :DNSDenylisting,
         owl:Class,
         owl:NamedIndividual ;
@@ -17117,19 +10462,36 @@ For example, a DNS policy can be created for blocking DNS queries for FQDNs that
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "DNS Blacklisting" .
 
+:DNSEvent a owl:Class ;
+    rdfs:label "DNS Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        [ a owl:Class ;
+            owl:unionOf (
+                    :TCPEvent
+                    :UDPEvent ) ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :DNSNetworkTraffic ] ;
+    :definition "An event involving the Domain Name System (DNS), which translates domain names to IP addresses and operates over UDP and TCP." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/dns_activity> .
+
 :DNSLookup a owl:Class ;
     rdfs:label "DNS Lookup" ;
-    rdfs:subClassOf :DigitalEvent,
-        :DigitalInformationBearer ;
+    rdfs:subClassOf :DigitalInformationBearer ;
     :definition "A Domain Name System (DNS) lookup is a record returned from a DNS resolver after querying a DNS name server.  Typically considered an A or AAAA record, where a domain name is resolved to an IPv4 or IPv6 address, respectively." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/dns_query",
-        <http://dbpedia.org/resource/Domain_Name_System>,
-        <http://dbpedia.org/resource/List_of_DNS_record_types> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Domain_Name_System>,
+        <http://dbpedia.org/resource/List_of_DNS_record_types>,
+        <https://schema.ocsf.io/objects/dns_query> .
 
 :DNSNetworkTraffic a owl:Class ;
     rdfs:label "DNS Network Traffic" ;
     rdfs:subClassOf :NetworkTraffic ;
     :definition "DNS network traffic is network traffic related to queries and responses involving the Domain Name System. DNS traffic can involve clients, servers such as relays or resolvers. This includes only network traffic conforming to standard DNS protocol; not custom protocols." .
+
+:DNSQueryEvent a owl:Class ;
+    rdfs:label "DNS Query Event" ;
+    rdfs:subClassOf :DNSEvent ;
+    :definition "An event where a DNS query is made to resolve a domain name." .
 
 :DNSRecord a owl:Class ;
     rdfs:label "DNS Record" ;
@@ -17137,6 +10499,11 @@ For example, a DNS policy can be created for blocking DNS queries for FQDNs that
     :definition "A Domain Name System (DNS) record is a record of information returned to clients seeking to find computers, services, and other resources connected to the Internet or a private network.  Record information is stored on a domain name server so it can respond to DNS queries from clients.There are a variety of record types, depending on the client's information needs. Common types include Start of Authority, IP addresses, SMTP mail exchangers, name servers, reverse DNS lookup pointers, etc." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Domain_Name_System>,
         <http://dbpedia.org/resource/List_of_DNS_record_types> .
+
+:DNSResponseEvent a owl:Class ;
+    rdfs:label "DNS Response Event" ;
+    rdfs:subClassOf :DNSEvent ;
+    :definition "An event where a DNS server responds to a query with resolution data." .
 
 :DNSServer a owl:Class ;
     rdfs:label "DNS Server" ;
@@ -17237,6 +10604,35 @@ This technique does not check for content hosted at the domain.
     rdfs:seeAlso <http://dbpedia.org/resource/Domain_registration>,
         <http://dbpedia.org/resource/WHOIS> .
 
+:DomainRegistrationTakedown a :DomainRegistrationTakedown,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Domain Registration Takedown" ;
+    rdfs:subClassOf :ObjectEviction,
+        [ a owl:Restriction ;
+            owl:onProperty :deletes ;
+            owl:someValuesFrom :DomainRegistration ] ;
+    :d3fend-id "D3-DRT" ;
+    :definition "The process of performing a takedown of the attacker's domain registration infrastructure." ;
+    :kb-article """## How it works
+
+Most nameserver hosts and domain name registrars comply with internationally recognised standards and supply their services based on terms and conditions that provide users and organisations protection from abuse and trademark infringement. Performing a WHOIS query on the attacker's domain will provide a contact that can be notified in the case of abuse. Formal takedown processes should be initiated to suspend or disable the normal function of the domain name.
+
+## Considerations
+
+- Takedown notifications should clearly demonstrate (with evidence) that the nameserver or registrars Terms and Conditions have been breached.
+- Takedown processes are notoriously slow and sometimes unsuccessful.
+- Many government organisations will have takedown processes that should also be followed. They may use this for intelligence to assist other organisations suffering an attack.
+- Top level domain registrars will have takedown processes that can be followed, as an escalation path, when the nameserver host and/or registrar have not responded or complied timeously or inline with the TLD expectations.
+
+## Examples of Domain Registration Abuse
+
+Attackers will create infrastructure from which to carry out their operations and this may include registering domain names to be used in the various attacks. Known misuse cases include:
+
+- Registering domain names that are similar to the victim's. This is known as typosquatting or URL hijacking. Legitimate looking mails or URLs could be sent using this domain in phishing campaigns.
+- Registring domain names that are used in C2 beacons.""" ;
+    :kb-reference :Reference-UnderstandingtheDomainRegistrationBehaviorofSpammers .
+
 :DomainTrustPolicy a :DomainTrustPolicy,
         owl:Class,
         owl:NamedIndividual ;
@@ -17320,7 +10716,7 @@ Analyzing the interaction of a piece of code with a system while the code is bei
  * Sometimes the malware behavior is triggered only under certain conditions (on a specific system date, after a certain time, or after it is sent a specific command) and can't be detected through a short execution in a virtual environment.
 
 ## Implementations
-* [Cuckoo Sandbox](https://cuckoosandbox.org)""" ;
+* Cuckoo Sandbox""" ;
     :kb-reference :Reference-MalwareAnalysisSystem_PaloAltoNetworksInc,
         :Reference-UseOfAnApplicationControllerToMonitorAndControlSoftwareFileAndApplicationEnvironments_SophosLtd ;
     :synonym "Malware Detonation",
@@ -17343,8 +10739,8 @@ Analyzing the interaction of a piece of code with a system while the code is bei
             owl:onProperty :may-contain ;
             owl:someValuesFrom :URL ] ;
     :definition "An email, or email message, is a document that is sent between computer users across computer networks." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/email",
-        <http://dbpedia.org/resource/Email> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Email>,
+        <https://schema.ocsf.io/objects/email> .
 
 :EmailAttachment a owl:Class ;
     rdfs:label "Email Attachment" ;
@@ -17354,6 +10750,16 @@ Analyzing the interaction of a piece of code with a system while the code is bei
             owl:someValuesFrom :Email ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Email_attachment> ;
     :definition "An email attachment is a computer file sent along with an email message. One or more files can be attached to any email message, and be sent along with it to the recipient. This is typically used as a simple method to share documents and images." .
+
+:EmailEvent a owl:Class ;
+    rdfs:label "Email Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        :TCPEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :MailNetworkTraffic ] ;
+    :definition "An event involving email communication, including sending, receiving, and processing emails. Email events encapsulate activities essential to the transmission and analysis of email messages in a networked environment." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/email_activity> .
 
 :EmailFiltering a :EmailFiltering,
         owl:Class,
@@ -17375,11 +10781,16 @@ This technique is distinct from d3f:EmailDeletion because it prevents an email f
 * The effectiveness of mail filters depend on the completeness of the filter policies""" ;
     :kb-reference :Reference-SystemAndMethodForProvidingAnonymousRemailingAndFilteringOfElectronicMail_Nokia .
 
+:EmailReceiveEvent a owl:Class ;
+    rdfs:label "Email Receive Event" ;
+    rdfs:subClassOf :EmailEvent ;
+    :definition "An event where an email is delivered to a recipient's mail server or mailbox. This includes receiving messages from internal or external sources via protocols such as IMAP, POP3, or their secure variants." .
+
 :EmailRemoval a :EmailRemoval,
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Email Removal" ;
-    rdfs:subClassOf :FileRemoval,
+    rdfs:subClassOf :FileEviction,
         [ a owl:Restriction ;
             owl:onProperty :deletes ;
             owl:someValuesFrom :Email ],
@@ -17406,6 +10817,16 @@ Email files may propagate through many storage systems across the an organizatio
     rdfs:label "Email Rule" ;
     rdfs:subClassOf :ApplicationRule ;
     :definition "A configuration of an email application which is used to apply logical or data processing functions to data processed by the email  application." .
+
+:EmailScanEvent a owl:Class ;
+    rdfs:label "Email Scan Event" ;
+    rdfs:subClassOf :EmailEvent ;
+    :definition "An event where an email is inspected or analyzed for content, security, or compliance purposes. Scanning often involves identifying spam, detecting malware, or ensuring policy adherence before delivery or after reception." .
+
+:EmailSendEvent a owl:Class ;
+    rdfs:label "Email Send Event" ;
+    rdfs:subClassOf :EmailEvent ;
+    :definition "An event where an email is transmitted from a client to a recipient via a mail server. This process often involves protocols such as SMTP or its secure variants, with potential authentication and encryption for secure delivery." .
 
 :EmbeddedComputer a owl:Class ;
     rdfs:label "Embedded Computer" ;
@@ -17486,7 +10907,7 @@ Endpoints are configured to periodically generate and transmit a secure heartbea
     rdfs:label "Endpoint Sensor" ;
     rdfs:subClassOf :CyberSensor ;
     :definition "A sensor application installed on a endpoint (platform) to collect information on platform components." ;
-    rdfs:seeAlso "d3f:Platform" .
+    rdfs:seeAlso :ComputerPlatform .
 
 :EnsembleLearning a owl:Class,
         owl:NamedIndividual ;
@@ -17543,11 +10964,78 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
             owl:someValuesFrom :Subroutine ] ;
     :definition "Takes inputs of strings and evaluations them as expressions." .
 
+:Event a owl:Class ;
+    rdfs:label "Event" ;
+    rdfs:subClassOf :D3FENDCore .
+
 :EventLog a owl:Class ;
     rdfs:label "Event Log" ;
-    rdfs:subClassOf :Log ;
+    rdfs:subClassOf :Log,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :DigitalEventRecord ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Log_file#Event_logs> ;
-    :definition "Event logs record events taking place in the execution of a system in order to provide an audit trail that can be used to understand the activity of the system and to diagnose problems. They are essential to understand the activities of complex systems, particularly in the case of applications with little user interaction (such as server applications)." .
+    :definition "Event logs record events taking place in the execution of a system in order to provide an audit trail that can be used to understand the activity of the system and to diagnose problems. They are essential to understand the activities of complex systems, particularly in the case of applications with little user interaction (such as server applications)." ;
+    :synonym "Digital Event Log" .
+
+:EventLogArchiveEvent a owl:Class ;
+    rdfs:label "Event Log Archive Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event involving the archiving of event log data, typically to preserve historical records in a compressed or secure format." .
+
+:EventLogClearEvent a owl:Class ;
+    rdfs:label "Event Log Clear Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event where the event log data is cleared from the system, often as part of log maintenance or potentially to cover tracks." .
+
+:EventLogDeleteEvent a owl:Class ;
+    rdfs:label "Event Log Delete Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event where the event log database, file, or cache is deleted from the system, removing the log's historical records." .
+
+:EventLogDisableEvent a owl:Class ;
+    rdfs:label "Event Log Disable Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event indicating that the event logging service has been disabled, preventing it from collecting or recording logs." .
+
+:EventLogEnableEvent a owl:Class ;
+    rdfs:label "Event Log Enable Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event where the event logging service is enabled, allowing it to actively collect and record logs." .
+
+:EventLogEvent a owl:Class ;
+    rdfs:label "Event Log Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :EventLog ] ;
+    :definition "An event that captures actions or operations related to the management of system event logs, including modifications, access, and service state changes." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/event_log> .
+
+:EventLogExportEvent a owl:Class ;
+    rdfs:label "Event Log Export Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event representing the export of event log data to a file or external system for backup or analysis purposes." .
+
+:EventLogRestartEvent a owl:Class ;
+    rdfs:label "Event Log Restart Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event representing the restarting of the event logging service, often performed during system maintenance or troubleshooting." .
+
+:EventLogRotateEvent a owl:Class ;
+    rdfs:label "Event Log Rotate Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event where the event log is rotated, often as part of log rotation policies to manage storage and ensure continuity." .
+
+:EventLogStartEvent a owl:Class ;
+    rdfs:label "Event Log Start Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event where the event logging service is started, enabling the collection and recording of system events." .
+
+:EventLogStopEvent a owl:Class ;
+    rdfs:label "Event Log Stop Event" ;
+    rdfs:subClassOf :EventLogEvent ;
+    :definition "An event indicating that the event logging service has been stopped, halting the recording of system events." .
 
 :Evict a :DefensiveTactic,
         owl:Class,
@@ -17558,9 +11046,15 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
     :display-order 4 ;
     :display-priority 0 .
 
-:EvictionLatency a owl:Class ;
-    rdfs:label "Eviction Latency" ;
-    rdfs:subClassOf :Latency .
+:EvictionEvent a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Eviction Event" ;
+    rdfs:subClassOf :SecurityEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :preceded-by ;
+            owl:someValuesFrom :DetectionEvent ] ;
+    :definition "An event describing actions to remove adversaries or malicious resources from a system, re-establishing security and operational integrity." ;
+    :related :Evict .
 
 :ExactMatching a owl:Class,
         owl:NamedIndividual ;
@@ -17622,7 +11116,7 @@ SafeSEH might be applied only to some executable files or modules, allowing an a
         [ a owl:Restriction ;
             owl:onProperty :executes ;
             owl:someValuesFrom :ExecutableBinary ] ;
-    rdfs:seeAlso "https://dbpedia.org/page/Exec" .
+    rdfs:seeAlso <https://dbpedia.org/page/Exec> .
 
 :ExecutableAllowlisting a :ExecutableAllowlisting,
         owl:Class,
@@ -17804,7 +11298,7 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
 
 :ExternalControl a owl:Class ;
     rdfs:label "External Control" ;
-    rdfs:subClassOf :D3FENDThing,
+    rdfs:subClassOf :ExternalControlThing,
         [ a owl:Restriction ;
             owl:onProperty :member-of ;
             owl:someValuesFrom :ControlCatalog ],
@@ -17812,15 +11306,22 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
             owl:onProperty :semantic-relation ;
             owl:someValuesFrom :DefensiveTechnique ] .
 
+:ExternalControlThing a owl:Class ;
+    rdfs:label "External Control Thing" ;
+    rdfs:subClassOf :ExternalThing .
+
 :ExternalKnowledgeBase a owl:Class ;
     rdfs:label "External Knowledge Base" ;
-    rdfs:subClassOf :InformationContentEntity,
-        :TechniqueReference ;
+    rdfs:subClassOf :TechniqueReference ;
     :pref-label "External Knowledge Base" ;
     :todo "Consider working  on alias or new preferred name... meh on \"Knowledge Content Entity\",  not sure \"External\" is helpful in conveying core concept; examples would be DBPedia, ATT&CK, CAPEC, CVE, ..., we included CAR; maybe even STIG or are they better as Guidance?" .
 
+:ExternalThing a owl:Class ;
+    rdfs:label "External Thing" .
+
 :ExternalThreatModelThing a owl:Class ;
-    rdfs:label "External Threat Model Thing" .
+    rdfs:label "External Threat Model Thing" ;
+    rdfs:subClassOf :ExternalThing .
 
 :FastSymbolicLink a owl:Class ;
     rdfs:label "Fast Symbolic Link" ;
@@ -17850,6 +11351,11 @@ Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intr
             owl:someValuesFrom :URL ] ;
     :definition "A file maintained in computer-readable form." ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/06521201-n> .
+
+:FileAccessEvent a owl:Class ;
+    rdfs:label "File Access Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a file is accessed for operations such as reading, opening, or inspecting its contents or metadata, without necessarily modifying its state." .
 
 :FileAccessPatternAnalysis a :FileAccessPatternAnalysis,
         owl:Class,
@@ -17943,6 +11449,11 @@ Rules, often called signatures, are used for both generic and targeted malware d
     :synonym "File Content Signatures",
         "File Signatures" .
 
+:FileCopyEvent a owl:Class ;
+    rdfs:label "File Copy Event" ;
+    rdfs:subClassOf :FileCreationEvent ;
+    :definition "An event where a file is duplicated, creating a new file in a different location or under a different name while preserving the original file's content and attributes." .
+
 :FileCreationAnalysis a :FileCreationAnalysis,
         owl:Class,
         owl:NamedIndividual ;
@@ -17955,6 +11466,21 @@ Rules, often called signatures, are used for both generic and targeted malware d
     :definition "Analyzing the properties of file create system call invocations." ;
     :kb-reference :Reference-CAR-2020-09-001%3AScheduledTask-FileAccess_MITRE,
         :Reference-LsassProcessDumpViaProcdump_MITRE .
+
+:FileCreationEvent a owl:Class ;
+    rdfs:label "File Creation Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event representing the creation of a new file within the system, establishing its existence and initial attributes in the file system or storage medium." .
+
+:FileDecryptionEvent a owl:Class ;
+    rdfs:label "File Decryption Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a previously encrypted file is decoded, rendering its content accessible to authorized users or processes." .
+
+:FileDeletionEvent a owl:Class ;
+    rdfs:label "File Deletion Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a file is permanently removed from the file system or storage medium, potentially triggering actions related to data retention or recovery." .
 
 :FileEncryption a :FileEncryption,
         owl:Class,
@@ -17980,18 +11506,55 @@ Asymmetric encryption is typically accomplished using public and private key cer
 - Secure transfer of private keys between multiple devices.""" ;
     :kb-reference :Reference-MethodForFileEncryption .
 
+:FileEncryptionEvent a owl:Class ;
+    rdfs:label "File Encryption Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event involving the application of cryptographic techniques to a file, ensuring its content is securely encoded and inaccessible without proper decryption keys." .
+
+:FileEvent a owl:Class ;
+    rdfs:label "File Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :File ] ;
+    :definition "An event involving operations performed on digital files, encompassing actions such as creation, modification, deletion, access, and attribute or permission changes." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/file_activity> .
+
 :FileEviction a :FileEviction,
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "File Eviction" ;
-    rdfs:subClassOf :DefensiveTechnique,
+    rdfs:subClassOf :ObjectEviction,
         [ a owl:Restriction ;
-            owl:onProperty :enables ;
-            owl:someValuesFrom :Evict ] ;
+            owl:onProperty :deletes ;
+            owl:someValuesFrom :File ] ;
     :d3fend-id "D3-FEV" ;
-    :definition "File eviction techniques evict files from system storage." .
+    :definition "File eviction techniques delete files from system storage." ;
+    :kb-article """## How it works
 
-:FileHash a owl:Class ;
+Adversaries may place files or programs into a computer's file system to perform malicious actions. As part of the eviction process, these files and programs should be removed to prevent further compromise or reinfection. Examples of malicious types of files are malware which is directly harmful and content files with the intent to deceive users (e.g., phishing.)
+
+On Windows systems, antivirus (AV) software should be used to safely and permanently remove malicious files. AV software may first quarantine a suspected malicious file, which is the process of moving a file from its original location to a new location and makes changes so that it cannot be executed. Users can then verify that the file is not benign and then permanently delete it.
+
+## Considerations
+
+When it is determined that a file should be removed for security purposes, the organization--or systems implementing an organization's policies--may determine that the file should not simply be deleted from the enterprise's mission systems, but be quarantined to a secure system by an approved mechanism, so as to allow follow-up investigation by security staff.
+
+On Windows systems, deleting a file in File Explorer does not permanently delete a file - it sends it to the Recycle Bin instead. The Recycle Bin must be emptied, or alternative steps must be performed to remove files completely. Even then, in some cases the data may persist in disk, so data shredder tools may be needed to completely wipe a file. Thus, AV tools are recommended.""" ;
+    :kb-reference :Reference-HowDoesAntivirusQuarantineWork-SafetyDetectives .
+
+:FileGetAttributesEvent a owl:Class ;
+    rdfs:label "File Get Attributes Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a file's metadata attributes, such as size, creation date, or type, are queried or retrieved without altering its content." .
+
+:FileGetPermissionsEvent a owl:Class ;
+    rdfs:label "File Get Permissions Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a file's security settings or access control list (ACL) is retrieved, detailing permissions granted to users or processes." .
+
+:FileHash a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "File Hash" ;
     rdfs:subClassOf :DigitalFingerprint,
         [ a owl:Restriction ;
@@ -18046,6 +11609,11 @@ Files can change constantly due to the non-static nature of a computer system. F
     :kb-reference :Reference-FileIntegrityMonitoringinMicrosoftDefenderforCloud-Microsoft,
         :Reference-Tripwire .
 
+:FileMountEvent a owl:Class ;
+    rdfs:label "File Mount Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a file system or storage volume is mounted, making its files and directories accessible to the operating system or applications." .
+
 :FilePathOpenFunction a owl:Class ;
     rdfs:label "File Path Open Function" ;
     rdfs:subClassOf :Subroutine,
@@ -18057,32 +11625,10 @@ Files can change constantly due to the non-static nature of a computer system. F
             owl:someValuesFrom :OpenFile ] ;
     :definition "Has an input of a file path, and opens a file handle for reading or writing." .
 
-:FileRemoval a :FileRemoval,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "File Removal" ;
-    rdfs:subClassOf :FileEviction,
-        [ a owl:Restriction ;
-            owl:onProperty :deletes ;
-            owl:someValuesFrom :File ],
-        [ a owl:Restriction ;
-            owl:onProperty :may-access ;
-            owl:someValuesFrom :FileServer ] ;
-    :d3fend-id "D3-FR" ;
-    :definition "The file removal technique deletes malicious artifacts or programs from a computer system." ;
-    :kb-article """## How it works
-
-Adversaries may place files or programs into a computer's file system to perform malicious actions. As part of the eviction process, these files and programs should be removed to prevent further compromise or reinfection. Examples of malicious types of files are malware which is directly harmful and content files with the intent to deceive users (e.g., phishing.)
-
-On Windows systems, antivirus (AV) software should be used to safely and permanently remove malicious files. AV software may first quarantine a suspected malicious file, which is the process of moving a file from its original location to a new location and makes changes so that it cannot be executed. Users can then verify that the file is not benign and then permanently delete it.
-
-## Considerations
-
-When it is determined that a file should be removed for security purposes, the organization--or systems implementing an organization's policies--may determine that the file should not simply be deleted from the enterprise's mission systems, but be quarantined to a secure system by an approved mechanism, so as to allow follow-up investigation by security staff.
-
-On Windows systems, deleting a file in File Explorer does not permanently delete a file - it sends it to the Recycle Bin instead. The Recycle Bin must be emptied, or alternative steps must be performed to remove files completely. Even then, in some cases the data may persist in disk, so data shredder tools may be needed to completely wipe a file. Thus, AV tools are recommended.""" ;
-    :kb-reference :Reference-HowDoesAntivirusQuarantineWork-SafetyDetectives ;
-    :synonym "File Deletion" .
+:FileRenamingEvent a owl:Class ;
+    rdfs:label "File Renaming Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event representing the renaming of a file, modifying its identifier within the file system while retaining its content and metadata." .
 
 :FileSection a owl:Class ;
     rdfs:label "File Section" ;
@@ -18096,6 +11642,16 @@ On Windows systems, deleting a file in File Explorer does not permanently delete
     rdfs:subClassOf :Server ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/File_server> ;
     :definition "The term server highlights the role of the machine in the traditional client-server scheme, where the clients are the workstations using the storage. A file server does not normally perform computational tasks or run programs on behalf of its client workstations. File servers are commonly found in schools and offices, where users use a local area network to connect their client computers." .
+
+:FileSetAttributesEvent a owl:Class ;
+    rdfs:label "File Set Attributes Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a file's metadata attributes are modified, such as changing its timestamps, labels, or categorization within the system." .
+
+:FileSetPermissionsEvent a owl:Class ;
+    rdfs:label "File Set Permissions Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event involving the modification of a file's permissions or access control list (ACL), specifying which users or processes are granted or restricted access." .
 
 :FileShareService a owl:Class ;
     rdfs:label "File Share Service" ;
@@ -18127,7 +11683,8 @@ On Windows systems, deleting a file in File Explorer does not permanently delete
     rdfs:isDefinedBy <http://dbpedia.org/resource/Hard_link> ;
     :definition "A file system link associates a name with a file on a file system.  Most generally, this may be a direct reference (a hard link) or an indirect one (a soft link)." .
 
-:FileSystemMetadata a owl:Class ;
+:FileSystemMetadata a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "File System Metadata" ;
     rdfs:subClassOf :Metadata ;
     :definition "Metadata about the files and directories in a file system.  For example file name, file length, time modified, group and user ids, and other file attributes." ;
@@ -18144,7 +11701,17 @@ On Windows systems, deleting a file in File Explorer does not permanently delete
 :FileTransferNetworkTraffic a owl:Class ;
     rdfs:label "File Transfer Network Traffic" ;
     rdfs:subClassOf :NetworkTraffic ;
-    :definition "File transfer network traffic is network traffic related to file transfers between network nodes..This includes only network traffic conforming to standard file transfer protocols, not custom transfer protocols." .
+    :definition "File transfer network traffic is network traffic related to file transfers between network nodes. This includes only network traffic conforming to standard file transfer protocols, not custom transfer protocols." .
+
+:FileUnmountEvent a owl:Class ;
+    rdfs:label "File Unmount Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event where a file system or storage volume is unmounted, disconnecting its files and directories from the operating system or applications." .
+
+:FileUpdateEvent a owl:Class ;
+    rdfs:label "File Update Event" ;
+    rdfs:subClassOf :FileEvent ;
+    :definition "An event involving changes to the content or metadata of an existing file, reflecting updates that alter its state or properties." .
 
 :FingerPrintScannerInputDevice a owl:Class ;
     rdfs:label "Finger Print Scanner Input Device" ;
@@ -18153,10 +11720,11 @@ On Windows systems, deleting a file in File Explorer does not permanently delete
     rdfs:isDefinedBy <http://dbpedia.org/resource/Fingerprint#Fingerprint_sensors> ;
     :definition "A fingerprint sensor is an electronic device used to capture a digital image of the fingerprint pattern. The captured image is called a live scan. This live scan is digitally processed to create a biometric template (a collection of extracted features) which is stored and used for matching. Many technologies have been used including optical, capacitive, RF, thermal, piezoresistive, ultrasonic, piezoelectric, and MEMS." .
 
-:Firewall a owl:Class ;
+:Firewall a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Firewall" ;
     skos:altLabel "Network Firewall" ;
-    rdfs:subClassOf :NetworkNode ;
+    rdfs:subClassOf :ComputerNetworkNode ;
     :definition "In computing, a firewall is a network security system that monitors and controls incoming and outgoing network traffic based on predetermined security rules. A firewall typically establishes a barrier between a trusted internal network and untrusted external network, such as the Internet. Firewalls are often categorized as either network firewalls or host-based firewalls. Network firewalls filter traffic between two or more networks and run on network hardware. Host-based firewalls run on host computers and control network traffic in and out of those machines. This definition refers to network firewalls." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Firewall_(computing)> .
 
@@ -18306,7 +11874,7 @@ The term "first-order" distinguishes first-order logic from higher-order logic, 
 :FlashMemory a owl:Class ;
     rdfs:label "Flash Memory" ;
     rdfs:subClassOf :SecondaryStorage ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Flash_memory" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Flash_memory> ;
     :definition "Flash memory is an electronic non-volatile computer memory storage medium that can be electrically erased and reprogrammed." .
 
 :Forecasting a owl:Class ;
@@ -18375,6 +11943,52 @@ The DNS lookup can be blocked by either dropping the network traffic with an inl
         [ a owl:Restriction ;
             owl:onProperty :deletes ;
             owl:someValuesFrom :MemoryBlock ] .
+
+:FTPDeleteEvent a owl:Class ;
+    rdfs:label "FTP Delete Event" ;
+    rdfs:subClassOf :FTPEvent ;
+    :definition "An event where files or directories are removed from an FTP server, resulting in their permanent deletion from the remote system." .
+
+:FTPEvent a owl:Class ;
+    rdfs:label "FTP Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        :TCPEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :FileTransferNetworkTraffic ] ;
+    :definition "An event involving the File Transfer Protocol (FTP), a standard network protocol used to transfer files between a client and server over a TCP/IP network. FTP facilitates operations such as file uploads, downloads, directory listing, and remote file management." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/ftp_activity> .
+
+:FTPGetEvent a owl:Class ;
+    rdfs:label "FTP Get Event" ;
+    rdfs:subClassOf :FTPEvent ;
+    :definition "An event where a file is downloaded from an FTP server to a client, retrieving data from the remote system to the local destination." .
+
+:FTPListEvent a owl:Class ;
+    rdfs:label "FTP List Event" ;
+    rdfs:subClassOf :FTPEvent ;
+    :definition "An event where the contents of a directory on an FTP server are listed, providing metadata such as file names, sizes, and timestamps." .
+
+:FTPPollEvent a owl:Class ;
+    rdfs:label "FTP Poll Event" ;
+    rdfs:subClassOf :FTPEvent ;
+    :definition "An event where a client queries an FTP server to check for the presence of specific files or directories without initiating a transfer." .
+
+:FTPPutEvent a owl:Class ;
+    rdfs:label "FTP Put Event" ;
+    rdfs:subClassOf :FTPEvent ;
+    :definition "An event where a file is uploaded from a client to an FTP server, transferring data from the local system to the remote destination." .
+
+:FTPRenameEvent a owl:Class ;
+    rdfs:label "FTP Rename Event" ;
+    rdfs:subClassOf :FTPEvent ;
+    :definition "An event where files or directories on an FTP server are renamed, modifying their identifiers without altering their content or location." .
+
+:FullVolumeSnapshot a owl:Class ;
+    rdfs:label "Full Volume Snapshot" ;
+    rdfs:subClassOf :VolumeSnapshot ;
+    :definition "A full volume snapshot is a point-in-time copy of the complete contents of a volume." ;
+    rdfs:seeAlso <https://aws.amazon.com/compare/the-difference-between-incremental-differential-and-other-backups/> .
 
 :FuzzyLogic a owl:Class,
         owl:NamedIndividual ;
@@ -18448,7 +12062,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :reads ;
             owl:someValuesFrom :SystemConfigurationDatabaseRecord ] ;
-    rdfs:seeAlso "https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopenkeyexa" .
+    rdfs:seeAlso <https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopenkeyexa> .
 
 :GetSystemNetworkConfigValue a owl:Class ;
     rdfs:label "Get System Network Config Value" ;
@@ -18466,7 +12080,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :queries ;
             owl:someValuesFrom :Thread ] ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreadcontext" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreadcontext> .
 
 :GlobalUserAccount a owl:Class ;
     rdfs:label "Global User Account" ;
@@ -18482,7 +12096,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         owl:NamedIndividual ;
     rdfs:label "Goodman and Kruskal's Gamma" ;
     rdfs:subClassOf :RankCorrelationCoefficient ;
-    rdfs:isDefinedBy "https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html" ;
+    rdfs:isDefinedBy <https://reference.wolfram.com/language/ref/GoodmanKruskalGamma.html> ;
     :d3fend-id "D3A-GAKG" ;
     :definition "Goodman-Kruskal $\\\\gamma$ is a measure of rank correlation between x and y and is given by $(n_c -n_d) / (n_c + n_d)$, where $n_c$ is the number of concordant pairs of the observations and $n_d$ is the number of discordant pairs." ;
     :kb-article """## References
@@ -18543,7 +12157,7 @@ Yang, S., Pan, L., & Cheng, J. (2021). Graph-based Semi-Supervised Learning Meth
     skos:altLabel "Video Card Firmware" ;
     rdfs:subClassOf :PeripheralFirmware ;
     :definition "Firmware that is installed on computer graphics card." ;
-    rdfs:seeAlso "d3f:Firmware" .
+    rdfs:seeAlso :Firmware .
 
 :GraphicsProcessingUnit a owl:Class ;
     rdfs:label "Graphics Processing Unit" ;
@@ -18568,9 +12182,32 @@ TechVidvan. (n.d.). Clustering in Machine Learning Tutorial. [Link](https://tech
     :kb-article """## References
 Talukdar, P. (2020, June 10). Convolutional Neural Networks Explained. Towards Data Science. [Link](https://towardsdatascience.com/convolutional-neural-networks-explained-9cc5188c4939)""" .
 
+:Group a owl:Class ;
+    rdfs:label "Group" ;
+    rdfs:subClassOf :D3FENDCore .
+
+:GroupCreationEvent a owl:Class ;
+    rdfs:label "Group Creation Event" ;
+    rdfs:subClassOf :GroupManagementEvent ;
+    :definition "An event where a new group is established within the system, defining an entity to manage users and permissions collectively." .
+
+:GroupDeletionEvent a owl:Class ;
+    rdfs:label "Group Deletion Event" ;
+    rdfs:subClassOf :GroupManagementEvent ;
+    :definition "An event where an existing group is permanently removed from the system, dissolving its associated memberships and privileges." .
+
 :Grouping a owl:Class ;
     rdfs:label "Grouping" ;
     rdfs:subClassOf :Summarizing .
+
+:GroupManagementEvent a owl:Class ;
+    rdfs:label "Group Management Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :AccessControlGroup ] ;
+    :definition "An event involving the creation, modification, or deletion of a group, or changes to its membership and privileges. Group management events facilitate the enforcement of role-based access control by organizing users and permissions into logical units for streamlined administration and policy enforcement." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/group_management> .
 
 :GroupPolicy a owl:Class ;
     rdfs:label "Group Policy" ;
@@ -18601,6 +12238,13 @@ Talukdar, P. (2020, June 10). Convolutional Neural Networks Explained. Towards D
     :definition "The harden tactic is used to increase the opportunity cost of computer network exploitation. Hardening differs from Detection in that it generally is conducted before a system is online and operational." ;
     :display-order 0 ;
     :display-priority 0 .
+
+:HardeningEvent a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardening Event" ;
+    rdfs:subClassOf :SecurityEvent ;
+    :definition "An event involving actions to strengthen defenses, such as applying patches or implementing secure configurations, reducing attack surfaces, and increasing the difficulty of exploitation by adversaries." ;
+    :related :Harden .
 
 :HardLink a owl:Class ;
     rdfs:label "Hard Link" ;
@@ -18679,6 +12323,59 @@ Administrators collect information on hardware devices such as peripherals, NICs
     rdfs:isDefinedBy <http://dbpedia.org/resource/Computer_hardware> ;
     :definition "Hardware devices are the physical artifacts that constitute a network or computer system. Hardware devices are the physical parts or components of a computer, such as the monitor, keyboard, computer data storage, hard disk drive (HDD), graphic cards, sound cards, memory (RAM), motherboard, and so on, all of which are tangible physical objects. By contrast, software is instructions that can be stored and run by hardware. Hardware is directed by the software to execute any command or instruction. A combination of hardware and software forms a usable computing system." ;
     rdfs:seeAlso <https://schema.ocsf.io/objects/device_hw_info> .
+
+:HardwareDeviceBindEvent a owl:Class ;
+    rdfs:label "Hardware Device Bind Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event where a device is logically bound to a system or process, typically for exclusive use or integration with specific software components." .
+
+:HardwareDeviceConnectionEvent a owl:Class ;
+    rdfs:label "Hardware Device Connection Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event representing the physical or logical attachment of a device to a system, enabling its operational functionality." .
+
+:HardwareDeviceDisabledEvent a owl:Class ;
+    rdfs:label "Hardware Device Disabled Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event where a device transitions to an inactive or unavailable state, often due to deactivation, failure, or maintenance." .
+
+:HardwareDeviceDisconnectionEvent a owl:Class ;
+    rdfs:label "Hardware Device Disconnection Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event representing the removal of a device from a system, ceasing its operational functionality or availability." .
+
+:HardwareDeviceEnabledEvent a owl:Class ;
+    rdfs:label "Hardware Device Enabled Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event where a device becomes operational and available for use, typically following initialization, activation, or repair." .
+
+:HardwareDeviceEvent a owl:Class ;
+    rdfs:label "Hardware Device Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :HardwareDevice ] ;
+    :definition "An event capturing the existence, state, or interaction of hardware or virtual devices within a system. Device events encompass activities such as discovery, connection, disconnection, operational state changes, or configuration modifications, providing visibility into device behavior and health." .
+
+:HardwareDeviceMoveEvent a owl:Class ;
+    rdfs:label "Hardware Device Move Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event where a device is relocated or reassigned within a system or network, potentially affecting its operational scope or connectivity." .
+
+:HardwareDeviceStateEvent a owl:Class ;
+    rdfs:label "Hardware Device State Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent ;
+    :definition "An event involving a change to a device's state, such as connection, disconnection, modification, or operational state transitions (e.g., online or offline). Device state events provide visibility into device availability and operational conditions." .
+
+:HardwareDeviceUnbindEvent a owl:Class ;
+    rdfs:label "Hardware Device Unbind Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event where a device is logically unbound from a system or process, releasing it from exclusive use or integration." .
+
+:HardwareDeviceUpdateEvent a owl:Class ;
+    rdfs:label "Hardware Device Update Event" ;
+    rdfs:subClassOf :HardwareDeviceStateEvent ;
+    :definition "An event capturing updates or changes to a device's configuration, properties, or state, including firmware updates, reconfigurations, or optimizations." .
 
 :HardwareDriver a owl:Class ;
     rdfs:label "Hardware Driver" ;
@@ -18838,19 +12535,13 @@ A homoglyph, in this context, is a deceptive string or word which looks like a t
 :Host a owl:Class ;
     rdfs:label "Host" ;
     skos:altLabel "Network Host" ;
-    rdfs:subClassOf :NetworkNode,
+    rdfs:subClassOf :ComputerNetworkNode,
         [ a owl:Restriction ;
             owl:onProperty :contains ;
-            owl:someValuesFrom :Application ],
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :OperatingSystem ],
-        [ a owl:Restriction ;
-            owl:onProperty :runs ;
-            owl:someValuesFrom :OperatingSystem ] ;
+            owl:someValuesFrom :Application ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Host_(network)> ;
     :definition "A host is a computer or other device, typically connected to a computer network. A network host may offer information resources, services, and applications to users or other nodes on the network. A network host is a network node that is assigned a network layer host address. Network hosts that participate in applications that use the client-server model of computing, are classified as server or client systems. Network hosts may also function as nodes in peer-to-peer applications, in which all nodes share and consume resources in an equipotent manner." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/device" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/device> .
 
 :Host-basedFirewall a owl:Class ;
     rdfs:label "Host-based Firewall" ;
@@ -18939,6 +12630,66 @@ Host shutdown can either be initiated in the physical presence of the device usi
     rdfs:subClassOf :DocumentFile ;
     :definition "A document file encoded in HTML.The HyperText Markup Language, or HTML is the standard markup language for documents designed to be displayed in a web browser. It can be assisted by technologies such as Cascading Style Sheets (CSS) and scripting languages such as JavaScript. Web browsers receive HTML documents from a web server or from local storage and render the documents into multimedia web pages. HTML describes the structure of a web page semantically and originally included cues for the appearance of the document." ;
     rdfs:seeAlso <http://dbpedia.org/resource/HTML> .
+
+:HTTPConnectEvent a owl:Class ;
+    rdfs:label "HTTP CONNECT Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP CONNECT method is used to establish a tunnel to the server identified by the target resource." .
+
+:HTTPDeleteEvent a owl:Class ;
+    rdfs:label "HTTP DELETE Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP DELETE method is used to delete the specified resource." .
+
+:HTTPEvent a owl:Class ;
+    rdfs:label "HTTP Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        :TCPEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :WebNetworkTraffic ] ;
+    :definition "An event involving the Hypertext Transfer Protocol (HTTP), which operates over TCP to transmit hypermedia documents." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/http_activity> .
+
+:HTTPGetEvent a owl:Class ;
+    rdfs:label "HTTP GET Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP GET method is used to request a representation of the specified resource." .
+
+:HTTPHeadEvent a owl:Class ;
+    rdfs:label "HTTP HEAD Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP HEAD method is used to request metadata about the specified resource without the response body." .
+
+:HTTPOptionsEvent a owl:Class ;
+    rdfs:label "HTTP OPTIONS Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP OPTIONS method is used to describe the communication options for the target resource." .
+
+:HTTPPostEvent a owl:Class ;
+    rdfs:label "HTTP POST Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP POST method is used to submit data to the specified resource, often causing a change in state or side effects on the server." .
+
+:HTTPPutEvent a owl:Class ;
+    rdfs:label "HTTP PUT Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP PUT method is used to replace all current representations of the target resource with the request payload." .
+
+:HTTPRequestEvent a owl:Class ;
+    rdfs:label "HTTP Request Event" ;
+    rdfs:subClassOf :HTTPEvent ;
+    :definition "An event where an HTTP request is sent from a client to a server over an established TCP connection." .
+
+:HTTPResponseEvent a owl:Class ;
+    rdfs:label "HTTP Response Event" ;
+    rdfs:subClassOf :HTTPEvent ;
+    :definition "An event where an HTTP response is sent from a server to a client over an established TCP connection." .
+
+:HTTPTraceEvent a owl:Class ;
+    rdfs:label "HTTP TRACE Event" ;
+    rdfs:subClassOf :HTTPRequestEvent ;
+    :definition "An event where the HTTP TRACE method is used to perform a message loop-back test along the path to the target resource." .
 
 :HumanInputDeviceFirmware a owl:Class ;
     rdfs:label "Human Input Device Firmware" ;
@@ -19042,22 +12793,23 @@ Identifier activity data of interest for analysis with the identifier might incl
     :kb-article """## References
 MathWorks. (n.d.). Get Started with GANs for Image-to-Image Translation. [Link](https://www.mathworks.com/help/images/get-started-with-gans-for-image-to-image-translation.html)""" .
 
-:ImageCodeSegment a owl:Class ;
+:ImageCodeSegment a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Image Code Segment" ;
     rdfs:subClassOf :ImageSegment,
         [ a owl:Restriction ;
             owl:onProperty :contains ;
             owl:someValuesFrom :Subroutine ] ;
     :definition "An image code segment, also known as a text segment or simply as text, is a portion of an object file that contains executable instructions. The term \"segment\" comes from the memory segment, which is a historical approach to memory management that has been succeeded by paging. When a program is stored in an object file, the code segment is a part of this file; when the loader places a program into memory so that it may be executed, various memory regions are allocated (in particular, as pages), corresponding to both the segments in the object files and to segments only needed at run time. For example, the code segment of an object file is loaded into a corresponding code segment in memory." ;
-    rdfs:seeAlso "Process Code Segment",
-        <http://dbpedia.org/resource/Code_segment> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Code_segment>,
+        :ProcessCodeSegment .
 
 :ImageDataSegment a owl:Class ;
     rdfs:label "Image Data Segment" ;
     rdfs:subClassOf :ImageSegment ;
     :definition "An image data segment (often denoted .data) is a portion of an object file that contains initialized static variables, that is, global variables and static local variables. The size of this segment is determined by the size of the values in the program's source code, and does not change at run time. This segmenting of the memory space into discrete blocks with specific tasks carried over into the programming languages of the day and the concept is still widely in use within modern programming languages." ;
-    rdfs:seeAlso "Process Data Segment",
-        <http://dbpedia.org/resource/Data_segment> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Data_segment>,
+        :ProcessDataSegment .
 
 :ImageScannerInputDevice a owl:Class ;
     rdfs:label "Image Scanner Input Device" ;
@@ -19071,8 +12823,8 @@ MathWorks. (n.d.). Get Started with GANs for Image-to-Image Translation. [Link](
     rdfs:subClassOf :BinarySegment,
         :FileSection ;
     :definition "Image segments are distinct partitions of an object file.  Both data and code segments are examples of image segments." ;
-    rdfs:seeAlso "Object File",
-        <http://dbpedia.org/resource/Object_file> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Object_file>,
+        :ObjectFile .
 
 :ImageSynthesisGAN a owl:Class,
         owl:NamedIndividual ;
@@ -19259,7 +13011,8 @@ Wikipedia. (n.d.). Statistical inference. [Link](https://en.wikipedia.org/wiki/S
         [ a owl:Restriction ;
             owl:onProperty :archived-at ;
             owl:someValuesFrom xsd:anyURI ] ;
-    rdfs:isDefinedBy "BFO, Cyc equiv, SUMO equiv, [Ontology Works] equiv" .
+    rdfs:isDefinedBy <http://purl.obolibrary.org/obo/IAO_0000030> ;
+    :todo "Add Cyc equiv, SUMO equiv, and [Ontology Works] equiv to links." .
 
 :InitialAccessTechnique a owl:Class ;
     rdfs:label "Initial Access Technique" ;
@@ -19345,6 +13098,14 @@ Given some example of legitimate behavioral input patterns, attackers could mimi
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ContinuousAuthenticationByAnalysisOfKeyboardTypingCharacteristics_BradfordUniv.,UK>,
         :Reference-www.biometric-solutions.com_keystroke-dynamics .
 
+:InputDeviceEvent a owl:Class ;
+    rdfs:label "Input Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :InputDevice ] ;
+    :definition "An event involving human-machine interface devices, such as keyboards, mice, or touchscreens." .
+
 :InputFunction a owl:Class ;
     rdfs:label "Input Function" ;
     rdfs:subClassOf :Subroutine ;
@@ -19364,6 +13125,26 @@ Georgian Impact Blog. (n.d.). Transfer Learning Part 1. [Link](https://medium.co
     rdfs:subClassOf :CollaborativeSoftware ;
     rdfs:isDefinedBy <https://dbpedia.org/wiki/Instant_messaging> ;
     :definition "Client software used to engage in Instant Messaging, a type of online chat that offers real-time text transmission over the Internet. A LAN messenger operates in a similar way over a local area network. Short messages are typically transmitted between two parties, when each user chooses to complete a thought and select \"send\". Some IM applications can use push technology to provide real-time text, which transmits messages character by character, as they are composed. More advanced instant messaging can add file transfer, clickable hyperlinks, Voice over IP, or video chat." .
+
+:IntegerRangeValidation a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Integer Range Validation" ;
+    rdfs:subClassOf :SourceCodeHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :MathematicalFunction ] ;
+    :d3fend-id "D3-IRV" ;
+    :definition """Ensuring that an integer is within a valid range.
+""" ;
+    :kb-article """## How it Works
+Integer Range Validation can be done by programmatically checking the value of an integer before or after an operation to determine if the resulting value will be valid.
+Checking the value of an integer to ensure it is in a valid range helps prevent integer overflow, wraparound, and logical errors.
+
+## Considerations
+* A valid range can be defined by language, data-type, or logical constraints.
+* Take extra care when doing operations on integers that will result in a value close to the bounds of a valid range.
+* Note: This resource should not be considered a definitive or exhaustive coding guideline.""" ;
+    :kb-reference :Reference-IntegerRangeValidation_SEI .
 
 :IntegratedHoneynet a :IntegratedHoneynet,
         owl:Class,
@@ -19393,9 +13174,7 @@ If an attacker manages to stop the processes used to log an attack without setti
     :definition "An integration test execution tool automatically performs integration testing.  Integration testing (sometimes called integration and testing, abbreviated I&T) is the phase in software testing in which individual software modules are combined and tested as a group." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Integration_testing> .
 
-:InternetArticle a owl:Class,
-        owl:NamedIndividual,
-        :ReferenceType ;
+:InternetArticle a owl:Class ;
     rdfs:label "Internet Article" ;
     rdfs:subClassOf :NewsArticle .
 
@@ -19431,6 +13210,16 @@ If an attacker manages to stop the processes used to log an attack without setti
     rdfs:subClassOf :NetworkTraffic ;
     :definition "Internet network traffic is network traffic that crosses a boundary between networks. [This is the general sense of inter-networking; It may or may not cross to or from the Internet]" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Internetworking> .
+
+:InternetPersona a owl:Class ;
+    rdfs:label "Internet Persona" ;
+    skos:altLabel "Online Identity",
+        "Online Persona",
+        "Online Personality" ;
+    rdfs:subClassOf :DigitalInformationBearer ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Online_identity> ;
+    :definition "A social identity that an Internet user establishes in online communities and websites. It may also be an actively constructed presentation of oneself." ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Online_identity> .
 
 :InterprocessCommunication a owl:Class ;
     rdfs:label "Interprocess Communication" ;
@@ -19663,6 +13452,13 @@ IPC can occur within a single computer or between multiple computers remotely th
     :display-order 2 ;
     :display-priority 0 .
 
+:IsolationEvent a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Isolation Event" ;
+    rdfs:subClassOf :SecurityEvent ;
+    :definition "An event involving actions to create logical or physical barriers that isolate compromised components, preventing adversary movement and reducing attack surfaces." ;
+    :related :Isolate .
+
 :JavaArchive a owl:Class ;
     rdfs:label "Java Archive" ;
     rdfs:subClassOf :ArchiveFile,
@@ -19719,9 +13515,9 @@ Potential for false positives from anomalies that are not associated with malici
             owl:onProperty :modifies ;
             owl:someValuesFrom :ScheduledJob ] ;
     :definition "A job scheduler software is operating system software that when run executes scheduled tasks (time-scheduling in the sense of wall clock time; not operating system scheduling of processes for multitasking). Processes running such software are task scheduler processes. In Windows, Scheduled Tasks are created and managed by the Task Scheduler. In Unix-like OSes, the `cron` utitility serves a similar role." ;
-    rdfs:seeAlso "Scheduled Task",
-        <http://dbpedia.org/resource/Cron>,
-        <http://dbpedia.org/resource/Windows_Task_Scheduler> ;
+    rdfs:seeAlso <http://dbpedia.org/resource/Cron>,
+        <http://dbpedia.org/resource/Windows_Task_Scheduler>,
+        :ScheduledJob ;
     :synonym "Task Scheduler Software" .
 
 :JournalArticle a owl:Class ;
@@ -19886,7 +13682,7 @@ Unlike other algorithms that explicitly model the problem, such as linear regres
         owl:NamedIndividual ;
     rdfs:label "Kendall's Rank Correlation Coefficient" ;
     rdfs:subClassOf :RankCorrelationCoefficient ;
-    rdfs:isDefinedBy "https://reference.wolfram.com/language/ref/KendallTau.html" ;
+    rdfs:isDefinedBy <https://reference.wolfram.com/language/ref/KendallTau.html> ;
     :d3fend-id "D3A-KRCC" ;
     :definition "Kendall's $\\\\tau$ between and is given by $(n_c - n_d) / \\\\sqrt((n_c+n_d+n_x)(n_c+n_d+n_y)$, where is the number of concordant pairs of observations, is the number of discordant pairs, is the number of ties involving only the variable, and is the number of ties involving only the variable.\" ;" ;
     :kb-article """## References
@@ -19912,6 +13708,16 @@ Unlike other algorithms that explicitly model the problem, such as linear regres
     :definition "A ticket granting ticket issued by a Kerberos system; that is, a ticket that grants a user domain admin access." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Ticket_Granting_Ticket> .
 
+:KerberosTicketGrantingTicketAccount a owl:Class ;
+    rdfs:label "Kerberos Ticket Granting Ticket Account" ;
+    rdfs:subClassOf :ServiceAccount,
+        [ a owl:Restriction ;
+            owl:onProperty :creates ;
+            owl:someValuesFrom :KerberosTicketGrantingTicket ] ;
+    :definition "KRBTGT is an account used by Key Distribution Center (KDC) service to issue Ticket Granting Tickets (TGTs) as part of the Kerberos authentication protocol." ;
+    rdfs:seeAlso "https://blog.quest.com/what-is-krbtgt-and-why-should-you-change-the-password/" ;
+    :synonym "krbtgt" .
+
 :Kernel a owl:Class ;
     rdfs:label "Kernel" ;
     rdfs:subClassOf :SystemSoftware,
@@ -19935,7 +13741,7 @@ Unlike other algorithms that explicitly model the problem, such as linear regres
             owl:someValuesFrom :KernelModule ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Kernel_(operating_system)> ;
     :definition "The kernel is a computer program that constitutes the central core of a computer's operating system. It has complete control over everything that occurs in the system. As such, it is the first program loaded on startup, and then manages the remainder of the startup, as well as input/output requests from software, translating them into data processing instructions for the central processing unit. It is also responsible for managing memory, and for managing and communicating with computing peripherals, like printers, speakers, etc. The kernel is a fundamental part of a modern computer's operating system." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/kernel" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/kernel> .
 
 :Kernel-basedProcessIsolation a :Kernel-basedProcessIsolation,
         owl:Class,
@@ -19954,6 +13760,15 @@ Unlike other algorithms that explicitly model the problem, such as linear regres
             owl:someValuesFrom :SystemCall ] ;
     :definition "Monitors system calls (operating system api functions)." .
 
+:KernelEvent a owl:Class ;
+    rdfs:label "Kernel Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Kernel ] ;
+    :definition "An event involving operations at the kernel level of an operating system, encompassing interactions with core system resources such as drivers, modules, system calls, and other privileged processes. Kernel events are critical for understanding low-level system behavior and ensuring the integrity of the operating environment." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/kernel_activity> .
+
 :KernelModule a owl:Class ;
     rdfs:label "Kernel Module" ;
     skos:altLabel "LKM",
@@ -19963,7 +13778,29 @@ Unlike other algorithms that explicitly model the problem, such as linear regres
     :definition """A loadable kernel module (LKM) is an object file that contains code to extend the running kernel, or so-called base kernel, of an operating system. LKMs are typically used to add support for new hardware (as device drivers) and/or filesystems, or for adding system calls. When the functionality provided by a LKM is no longer required, it can be unloaded in order to free memory and other resources.
 
 Most current Unix-like systems and Microsoft Windows support loadable kernel modules, although they might use a different name for them, such as kernel loadable module (kld) in FreeBSD, kernel extension (kext) in macOS,[1] kernel extension module in AIX, kernel-mode driver in Windows NT[2] and downloadable kernel module (DKM) in VxWorks. They are also known as kernel loadable modules (or KLM), and simply as kernel modules (KMOD).""" ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/kernel_driver" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/kernel_driver> .
+
+:KernelModuleEvent a owl:Class ;
+    rdfs:label "Kernel Module Event" ;
+    rdfs:subClassOf :KernelEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :HardwareDriver ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :KernelModule ] ;
+    :definition "An event involving the management of kernel modules, such as the loading or unloading of device drivers, extensions, or other dynamically linked components essential for kernel functionality." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/kernel_extension> .
+
+:KernelModuleLoadEvent a owl:Class ;
+    rdfs:label "Kernel Module Load Event" ;
+    rdfs:subClassOf :KernelModuleEvent ;
+    :definition "An event representing the loading of a kernel module, such as a device driver or dynamically linked extension, into the operating system kernel to extend or modify its capabilities." .
+
+:KernelModuleUnloadEvent a owl:Class ;
+    rdfs:label "Kernel Module Unload Event" ;
+    rdfs:subClassOf :KernelModuleEvent ;
+    :definition "An event representing the removal of a kernel module from the operating system kernel, deallocating resources and potentially altering system functionality." .
 
 :KernelProcessTable a owl:Class ;
     rdfs:label "Kernel Process Table" ;
@@ -20005,11 +13842,6 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
     rdfs:isDefinedBy <http://dbpedia.org/resource/Laptop> ;
     :definition "A laptop computer (also laptop), is a small, portable personal computer (PC) with a \"clamshell\" form factor, typically having a thin LCD or LED computer screen mounted on the inside of the upper lid of the clamshell and an alphanumeric keyboard on the inside of the lower lid. The clamshell is opened up to use the computer. Laptops are folded shut for transportation, and thus are suitable for mobile use. Its name comes from lap, as it was deemed to be placed on a person's lap when being used. Although originally there was a distinction between laptops and notebooks (the former being bigger and heavier than the latter), as of 2014, there is often no longer any difference. Today, laptops are commonly used in a variety of settings, such as at work, in education, for playing games, web browsing" .
 
-:Latency a owl:Class ;
-    rdfs:label "Latency" ;
-    rdfs:subClassOf :D3FENDThing ;
-    :todo "Review for inclusion in d3fend.owl" .
-
 :LateralMovementTechnique a owl:Class ;
     rdfs:label "Lateral Movement Technique" ;
     rdfs:subClassOf :ATTACKEnterpriseTechnique,
@@ -20038,7 +13870,7 @@ Wikipedia. (n.d.). Probability distribution. [Link](https://en.wikipedia.org/wik
 :License a owl:Class ;
     rdfs:label "License" ;
     rdfs:subClassOf :InformationContentEntity ;
-    rdfs:seeAlso "http://dbpedia.org/resource/Software_license" .
+    rdfs:seeAlso <http://dbpedia.org/resource/Software_license> .
 
 :LinearClassifier a owl:Class,
         owl:NamedIndividual ;
@@ -20106,29 +13938,30 @@ Takes independent variables (i.e. covariate, features, predictors, input variabl
 - Nau, Robert. “Statistical Forecasting: Notes On Regression and Time Series Analysis.” Introduction to Linear Regression Analysis, Duke University Fuqua School of Business, 18 Aug. 2020, https://people.duke.edu/~rnau/regintro.htm.
 - Ng, Ritchie. “Evaluating a Linear Regression Model.” Ritchieng.github.io, 8 Jan. 2023, https://www.ritchieng.com/machine-learning-evaluate-linear-regression-model/.
 - Bochkarev, Alexei. "A New Typology Design of Performance Metrics to Measure Errors in Machine Learning Regression Algorithms", 2019, https://www.researchgate.net/publication/330661543_A_New_Typology_Design_of_Performance_Metrics_to_Measure_Errors_in_Machine_Learning_Regression_Algorithms.""" ;
-    rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#LinearRegression" .
+    rdfs:seeAlso :LinearRegression .
 
 :Link a owl:Class ;
     rdfs:label "Link" ;
-    rdfs:subClassOf :DigitalInformationBearer ;
-    rdfs:seeAlso "https://dbpedia.org/resource/Link" .
+    rdfs:subClassOf :D3FENDCore,
+        :DigitalInformationBearer ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Link> .
 
 :Linux_Exit a owl:Class ;
     rdfs:label "Linux _Exit" ;
     rdfs:subClassOf :OSAPITerminateProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/exit.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/exit.2.html> ;
     :definition "Terminate the calling process." .
 
 :LinuxClone a owl:Class ;
     rdfs:label "Linux Clone" ;
     rdfs:subClassOf :OSAPICreateProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/clone.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/clone.2.html> ;
     :definition "Creates a child process and provides more precise control over the data shared between the parent and child processes" .
 
 :LinuxClone3 a owl:Class ;
     rdfs:label "Linux Clone3" ;
     rdfs:subClassOf :OSAPICreateProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/clone3.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/clone3.2.html> ;
     :definition """Creates a child process and provides more precise control over the data shared between the parent and child processes.
 
 Newer system call.""" .
@@ -20136,25 +13969,25 @@ Newer system call.""" .
 :LinuxClone3ArgumentCLONE_THREAD a owl:Class ;
     rdfs:label "Linux Clone3 Argument CLONE_THREAD" ;
     rdfs:subClassOf :OSAPICreateThread ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/clone3.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/clone3.2.html> ;
     :definition "A flag parameter to the Clone3 syscall. If set, the child is placed in the same thread group as the calling process." .
 
 :LinuxCloneArgumentCLONE_THREAD a owl:Class ;
     rdfs:label "Linux Clone Argument CLONE_THREAD" ;
     rdfs:subClassOf :OSAPICreateThread ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/clone.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/clone.2.html> ;
     :definition "A flag parameter to the Clone syscall. If set, the child is placed in the same thread group as the calling process." .
 
 :LinuxConnect a owl:Class ;
     rdfs:label "Linux Connect" ;
     rdfs:subClassOf :OSAPIConnectSocket ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/connect.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/connect.2.html> ;
     :definition "Initiate a connection on a socket." .
 
 :LinuxCreat a owl:Class ;
     rdfs:label "Linux Creat" ;
     rdfs:subClassOf :OSAPICreateFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/creat.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/creat.2.html> ;
     :definition "Equivalent to calling Linux Open with flags equal to O_CREAT|O_WRONLY|O_TRUNC." .
 
 :LinuxDeleteModule a owl:Class ;
@@ -20166,19 +13999,19 @@ Newer system call.""" .
 :LinuxExecve a owl:Class ;
     rdfs:label "Linux Execve" ;
     rdfs:subClassOf :OSAPIExec ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/execve.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/execve.2.html> ;
     :definition "Executes a program by replacing the calling process with a new program, with newly initialized stack, heap, and (initialized and uninitialized) data segments. The PID stays the same." .
 
 :LinuxExecveat a owl:Class ;
     rdfs:label "Linux Execveat" ;
     rdfs:subClassOf :OSAPIExec ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/execveat.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/execveat.2.html> ;
     :definition "Execute program relative to a directory file descriptor. Behavior is similar to Linux Execve." .
 
 :LinuxFork a owl:Class ;
     rdfs:label "Linux Fork" ;
     rdfs:subClassOf :OSAPICreateProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/fork.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/fork.2.html> ;
     :definition "Creates a child process with unique PID but retains parent PID as Parent Process Identifier (PPID)" .
 
 :LinuxInitModule a owl:Class ;
@@ -20190,212 +14023,221 @@ Newer system call.""" .
 :LinuxKillArgumentSIGKILL a owl:Class ;
     rdfs:label "Linux Kill Argument SIGKILL" ;
     rdfs:subClassOf :OSAPITerminateProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/kill.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/kill.2.html> ;
     :definition "Send SIGKILL signal to a process." .
 
 :LinuxMmap a owl:Class ;
     rdfs:label "Linux Mmap" ;
     rdfs:subClassOf :OSAPIAllocateMemory ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/mmap.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/mmap.2.html> ;
     :definition "Map files or devices into memory." .
 
 :LinuxMmap2 a owl:Class ;
     rdfs:label "Linux Mmap2" ;
     rdfs:subClassOf :OSAPIAllocateMemory ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/mmap2.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/mmap2.2.html> ;
     :definition "Map files or devices into memory." .
 
 :LinuxMunmap a owl:Class ;
     rdfs:label "Linux Munmap" ;
     rdfs:subClassOf :OSAPIFreeMemory ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/munmap.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/munmap.2.html> ;
     :definition "Unmap files or devices from memory." .
 
 :LinuxOpenArgumentO_CREAT a owl:Class ;
     rdfs:label "Linux Open Argument O_CREAT" ;
     rdfs:subClassOf :OSAPICreateFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/open.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/open.2.html> ;
     :definition "Create a regular file." .
 
 :LinuxOpenArgumentO_RDONLY-O_WRONLY-O_RDWR a owl:Class ;
     rdfs:label "Linux Open Argument O_RDONLY, O_WRONLY, O_RDWR" ;
     rdfs:subClassOf :OSAPIOpenFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/open.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/open.2.html> ;
     :definition "Opens a file specified by pathname." .
 
 :LinuxOpenAt2ArgumentO_CREAT a owl:Class ;
     rdfs:label "Linux OpenAt2 Argument O_CREAT" ;
     rdfs:subClassOf :OSAPICreateFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/openat2.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/openat2.2.html> ;
     :definition "Create a regular file. Extension of Linux Openat." .
 
 :LinuxOpenAt2ArgumentO_RDONLY-O_WRONLY-O_RDWR a owl:Class ;
     rdfs:label "Linux OpenAt2 Argument O_RDONLY, O_WRONLY, O_RDWR" ;
     rdfs:subClassOf :OSAPIOpenFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/openat2.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/openat2.2.html> ;
     :definition "Extension of Linux Openat." .
 
 :LinuxOpenAtArgumentO_CREAT a owl:Class ;
     rdfs:label "Linux OpenAt Argument O_CREAT" ;
     rdfs:subClassOf :OSAPICreateFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/openat.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/openat.2.html> ;
     :definition "Create a regular file. Same functionality as Linux Open but slight differences in parameter." .
 
 :LinuxOpenAtArgumentO_RDONLY-O_WRONLY-O_RDWR a owl:Class ;
     rdfs:label "Linux OpenAt Argument O_RDONLY, O_WRONLY, O_RDWR" ;
     rdfs:subClassOf :OSAPIOpenFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/openat.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/openat.2.html> ;
     :definition "Same functionality as Linux Open but slight differences in parameter." .
 
 :LinuxPauseProcess a owl:Class ;
     rdfs:label "Linux Pause Process" ;
     rdfs:subClassOf :OSAPISuspendProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/pause.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/pause.2.html> ;
     :definition "Causes the calling process to sleep until a signal is delivered that either terminates the process or causes the invocation of a signal-catching function." .
 
 :LinuxPauseThread a owl:Class ;
     rdfs:label "Linux Pause Thread" ;
     rdfs:subClassOf :OSAPISuspendThread ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/pause.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/pause.2.html> ;
     :definition "Causes the calling thread to sleep until a signal is delivered that either terminates the thread or causes the invocation of a signal-catching function." .
 
 :LinuxPtraceArgumentPTRACE_DETACH a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_DETACH" ;
     rdfs:subClassOf :OSAPIResumeProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Restart the stopped tracee as for PTRACE_CONT, but first detach from it." .
 
 :LinuxPtraceArgumentPTRACE_TRACEME a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_TRACEME" ;
     rdfs:subClassOf :OSAPITraceProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Indicates that the process is to be traced by its parent." .
 
 :LinuxPtraceArgumentPTRACEATTACH a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_ATTACH" ;
     rdfs:subClassOf :OSAPIAccessProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Attach to the process specified in pid, making it a tracee of the calling process." .
 
 :LinuxPtraceArgumentPTRACECONT a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_CONT" ;
     rdfs:subClassOf :OSAPIResumeProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Restart the stopped tracee process." .
 
 :LinuxPtraceArgumentPTRACEGETREGS a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_GETREGS" ;
     rdfs:subClassOf :OSAPISaveRegisters ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Copy the tracee's general-purpose or floating-point registers, respectively, to the address data in the tracer." .
 
 :LinuxPtraceArgumentPTRACEINTERRUPT a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_INTERRUPT" ;
     rdfs:subClassOf :OSAPISuspendProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Stops a tracee." .
 
 :LinuxPtraceArgumentPTRACEPEEKTEXT a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_PEEKTEXT" ;
     rdfs:subClassOf :OSAPIReadMemory ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Read a word at the address addr in the tracee's memory, returning the word as the result of the ptrace() call." .
 
 :LinuxPtraceArgumentPTRACEPOKETEXT a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_POKETEXT" ;
     rdfs:subClassOf :OSAPIWriteMemory ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Copy the word data to the address addr in the tracee's memory." .
 
 :LinuxPtraceArgumentPTRACESETREGS a owl:Class ;
     rdfs:label "Linux Ptrace Argument PTRACE_SETREGS" ;
     rdfs:subClassOf :OSAPISetRegisters ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/ptrace.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/ptrace.2.html> ;
     :definition "Modify the tracee's general-purpose or floating-point registers, respectively, from the address data in the tracer." .
 
 :LinuxRead a owl:Class ;
     rdfs:label "Linux Read" ;
     rdfs:subClassOf :OSAPIReadFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/read.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/read.2.html> ;
     :definition "Read from a file descriptor." .
 
 :LinuxReadv a owl:Class ;
     rdfs:label "Linux Readv" ;
     rdfs:subClassOf :OSAPIReadFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/readv.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/readv.2.html> ;
     :definition "Read data into multiple buffers." .
 
 :LinuxRename a owl:Class ;
     rdfs:label "Linux Rename" ;
     rdfs:subClassOf :OSAPIMoveFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/rename.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/rename.2.html> ;
     :definition "Change the name or location of a file" .
 
 :LinuxRenameat a owl:Class ;
     rdfs:label "Linux Renameat" ;
     rdfs:subClassOf :OSAPIMoveFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/renameat.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/renameat.2.html> ;
     :definition "Change the name or location of a file. Different parameter handling than Linux Rename." .
 
 :LinuxRenameat2 a owl:Class ;
     rdfs:label "Linux Renameat2" ;
     rdfs:subClassOf :OSAPIMoveFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/renameat2.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/renameat2.2.html> ;
     :definition "Change the name or location of a file. Additional flags argument." .
 
 :LinuxSocket a owl:Class ;
     rdfs:label "Linux Socket" ;
     rdfs:subClassOf :OSAPICreateSocket ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/socket.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/socket.2.html> ;
     :definition "Create an endpoint for communication." .
 
 :LinuxSocketcallArgumentSYS_CONNECT a owl:Class ;
     rdfs:label "Linux Socketcall Argument SYS_CONNECT" ;
     rdfs:subClassOf :OSAPIConnectSocket ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/socketcall.2.html" .
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/socketcall.2.html> .
 
 :LinuxSocketcallArgumentSYS_SOCKET a owl:Class ;
     rdfs:label "Linux Socketcall Argument SYS_SOCKET" ;
     rdfs:subClassOf :OSAPICreateSocket ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/socketcall.2.html" .
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/socketcall.2.html> .
 
 :LinuxTime a owl:Class ;
     rdfs:label "Linux Time" ;
     rdfs:subClassOf :OSAPIGetSystemTime ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/time.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/time.2.html> ;
     :definition "Get time in seconds." .
 
 :LinuxUnlink a owl:Class ;
     rdfs:label "Linux Unlink" ;
     rdfs:subClassOf :OSAPIDeleteFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/unlink.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/unlink.2.html> ;
     :definition "Delete a name and possibly the file it refers to." .
 
 :LinuxUnlinkat a owl:Class ;
     rdfs:label "Linux Unlinkat" ;
     rdfs:subClassOf :OSAPIDeleteFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/unlinkat.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/unlinkat.2.html> ;
     :definition "Delete a name and possibly the file it refers to. Different parameter handling than Linux Unlink" .
 
 :LinuxVfork a owl:Class ;
     rdfs:label "Linux Vfork" ;
     rdfs:subClassOf :OSAPICreateProcess ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/vfork.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/vfork.2.html> ;
     :definition "Create child process that temp suspends parent process until it terminates" .
 
 :LinuxWrite a owl:Class ;
     rdfs:label "Linux Write" ;
     rdfs:subClassOf :OSAPIWriteFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/write.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/write.2.html> ;
     :definition "Write to a file descriptor." .
 
 :LinuxWritev a owl:Class ;
     rdfs:label "Linux Writev" ;
     rdfs:subClassOf :OSAPIWriteFile ;
-    rdfs:isDefinedBy "https://man7.org/linux/man-pages/man2/writev.2.html" ;
+    rdfs:isDefinedBy <https://man7.org/linux/man-pages/man2/writev.2.html> ;
     :definition "Write data into multiple buffers." .
 
+:LoadLibraryEvent a owl:Class ;
+    rdfs:label "Load Library Event" ;
+    rdfs:subClassOf :ProcessEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :SharedLibraryFile ] ;
+    :definition "An event where a process dynamically loads a library or module into its memory space, extending its capabilities." .
+
 :LoadModule a owl:Class ;
+    rdfs:label "Load Module" ;
     rdfs:subClassOf :SystemCall,
         [ a owl:Restriction ;
             owl:onProperty :loads ;
@@ -20483,7 +14325,8 @@ Newer system call.""" .
     rdfs:subClassOf :UserAccount ;
     :definition "A user account on a given host is a local user account for that specific host." .
 
-:Log a owl:Class ;
+:Log a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Log" ;
     skos:altLabel "Chronology" ;
     rdfs:subClassOf :D3FENDCore,
@@ -20563,11 +14406,14 @@ H :- B_1, ..., B_n.
 ## References
 1. Logic programming. (2023, May 29). In _Wikipedia_. [Link]( https://en.wikipedia.org/wiki/Logic_programming)""" .
 
-:LoginSession a owl:Class ;
+:LoginSession a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Login Session" ;
+    skos:altLabel "Logon Session" ;
     rdfs:subClassOf :Session ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Login_session> ;
-    :definition "In computing, a login session is the period of activity between a user logging in and logging out of a (multi-user) system. On Unix and Unix-like operating systems, a login session takes one of two main forms: (a) When a textual user interface is used, a login session is represented as a kernel session -- a collection of process groups with the logout action managed by a session leader, and (b) Where an X display manager is employed, a login session is considered to be the lifetime of a designated user process that the display manager invokes." .
+    :definition "In computing, a login session is the period of activity between a user logging in and logging out of a (multi-user) system. This includes local login sessions, where a user has direct physical access to a computer, as well as domain login sessions, where a user logs into a computer that is part of a network domain." ;
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows-server/security/windows-authentication/windows-logon-scenarios> .
 
 :LogisticRegression a owl:Class,
         owl:NamedIndividual ;
@@ -20586,12 +14432,31 @@ Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Log
     :definition "A supervised learning method that builds a logistic regression model using training data." ;
     :kb-article """## References
 Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Logistic_regression)""" ;
-    rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#LogisticRegression" .
+    rdfs:seeAlso :LogisticRegression .
 
 :LogMessageFunction a owl:Class ;
     rdfs:label "Log Message Function" ;
     rdfs:subClassOf :Subroutine ;
     :definition "Produces an entry in a log." .
+
+:LogoffEvent a owl:Class ;
+    rdfs:label "Logoff Event" ;
+    rdfs:subClassOf :AuthenticationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Session ],
+        [ a owl:Restriction ;
+            owl:onProperty :preceded-by ;
+            owl:someValuesFrom :LogonEvent ] ;
+    :definition "An authentication event where an active session is conclusively terminated, resulting in the cessation of access and deallocation of resources associated with the session, ensuring that the connection to the system, application, or resource no longer exists." .
+
+:LogonEvent a owl:Class ;
+    rdfs:label "Logon Event" ;
+    rdfs:subClassOf :AuthenticationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Session ] ;
+    :definition "An authentication event where a new session is initiated, signifying the successful validation of credentials and establishment of an authorized connection to a system, application, or resource. This marks the beginning of the subject’s authenticated interaction with the system." .
 
 :LogonUser a owl:Class ;
     rdfs:label "Logon User" ;
@@ -20782,7 +14647,7 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
         [ a owl:Restriction ;
             owl:onProperty :addresses ;
             owl:someValuesFrom :MemoryWord ] ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Memory_address" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Memory_address> ;
     :definition "In computing, a memory address is a reference to a specific memory location used at various levels by software and hardware." .
 
 :MemoryAddressSpace a owl:Class ;
@@ -20792,6 +14657,11 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
             owl:onProperty :contains ;
             owl:someValuesFrom :MemoryAddress ] ;
     :definition "A memory address space is a space containing memory addresses." .
+
+:MemoryAllocationEvent a owl:Class ;
+    rdfs:label "Memory Allocation Event" ;
+    rdfs:subClassOf :MemoryEvent ;
+    :definition "An event representing the allocation of memory resources to a process, providing it with the capacity to store data or execute instructions." .
 
 :MemoryAllocationFunction a owl:Class ;
     rdfs:label "Memory Allocation Function" ;
@@ -20810,8 +14680,24 @@ Wikipedia. (n.d.). Average absolute deviation. [Link](https://en.wikipedia.org/w
         [ a owl:Restriction ;
             owl:onProperty :may-contain ;
             owl:someValuesFrom :Record ] ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Block_(data_storage)" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Block_(data_storage)> ;
     :definition "In computing (specifically data transmission and data storage), a block, sometimes called a physical record, is a sequence of bytes or bits, usually containing some whole number of records, having a maximum length; a block size. Data thus structured are said to be blocked. The process of putting data into blocks is called blocking, while deblocking is the process of extracting data from blocks. Blocked data is normally stored in a data buffer and read or written a whole block at a time." .
+
+:MemoryBlockStartValidation a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Memory Block Start Validation" ;
+    rdfs:subClassOf :PointerValidation,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :MemoryFreeFunction ] ;
+    :d3fend-id "D3-MBSV" ;
+    :definition "Ensuring that a pointer accurately references the beginning of a designated memory block." ;
+    :kb-article """## How it Works
+Ensure that a pointer is referencing the beginning of the intended block before using.
+
+## Considerations
+Be careful with pointer arithmetic.""" ;
+    :kb-reference :Reference-CManualPointerArithmetic_GNU .
 
 :MemoryBoundaryTracking a :MemoryBoundaryTracking,
         owl:Class,
@@ -20829,6 +14715,31 @@ This technique monitors for indicators of whether a return address is outside me
 ## Considerations
 Kernel malware can manipulate memory contents, for example modifying pointers to hide processes, and thereby impact the accuracy of memory allocation information used to perform the analysis.""" ;
     :kb-reference :Reference-InferentialExploitAttemptDetection_CrowdstrikeInc .
+
+:MemoryDeletionEvent a owl:Class ;
+    rdfs:label "Memory Deletion Event" ;
+    rdfs:subClassOf :MemoryEvent ;
+    :definition "An event marking the release or deallocation of memory resources, reclaiming them for reuse within the system." .
+
+:MemoryDeviceEvent a owl:Class ;
+    rdfs:label "Memory Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :PrimaryStorage ] ;
+    :definition "An event describing activity in primary storage devices, such as DRAM or SRAM memory initialization, reconfiguration, or failures." .
+
+:MemoryEvent a owl:Class ;
+    rdfs:label "Memory Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :MemoryAddress ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :MemoryExtent ] ;
+    :definition "An event capturing operations on the memory resources of a system, encompassing allocation, modification, access, protection, or deallocation." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/memory_activity> .
 
 :MemoryExtent a owl:Class ;
     rdfs:label "Memory Extent" ;
@@ -20857,13 +14768,26 @@ Kernel malware can manipulate memory contents, for example modifying pointers to
         [ a owl:Restriction ;
             owl:onProperty :manages ;
             owl:someValuesFrom :Storage ] ;
-    rdfs:isDefinedBy "https://www.techopedia.com/definition/4768/memory-management-unit-mmu" ;
+    rdfs:isDefinedBy <https://www.techopedia.com/definition/4768/memory-management-unit-mmu> ;
     :definition "A computer’s memory management unit (MMU) is the physical hardware that handles its virtual memory and caching operations. The MMU is usually located within the computer’s central processing unit (CPU), but sometimes operates in a separate integrated chip (IC)." ;
-    rdfs:seeAlso "https://dbpedia.org/page/Memory_management_unit" .
+    rdfs:seeAlso <https://dbpedia.org/page/Memory_management_unit> .
 
 :MemoryManagementUnitComponent a owl:Class ;
     rdfs:label "Memory Management Unit Component" ;
     rdfs:subClassOf :HardwareDevice .
+
+:MemoryMapEvent a owl:Class ;
+    rdfs:label "Memory Map Event" ;
+    rdfs:subClassOf :MemoryEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :VirtualMemorySpace ] ;
+    :definition "An event representing the mapping of memory regions into a process's virtual address space, enabling efficient access to shared or reserved memory." .
+
+:MemoryModificationEvent a owl:Class ;
+    rdfs:label "Memory Modification Event" ;
+    rdfs:subClassOf :MemoryEvent ;
+    :definition "An event where a process modifies allocated memory, potentially altering its content, behavior, or state." .
 
 :MemoryPool a owl:Class ;
     rdfs:label "Memory Pool" ;
@@ -20871,18 +14795,28 @@ Kernel malware can manipulate memory contents, for example modifying pointers to
         [ a owl:Restriction ;
             owl:onProperty :contains ;
             owl:someValuesFrom :MemoryBlock ] ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Memory_pool" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Memory_pool> ;
     :definition "Memory pools, also called fixed-size blocks allocation, is the use of pools for memory management… preallocating a number of memory blocks with the same size called the memory pool. The application can allocate, access, and free blocks represented by handles at run time." .
 
 :MemoryProtectionUnit a owl:Class ;
     rdfs:label "Memory Protection Unit" ;
     rdfs:subClassOf :ProcessorComponent .
 
+:MemoryReadEvent a owl:Class ;
+    rdfs:label "Memory Read Event" ;
+    rdfs:subClassOf :MemoryEvent ;
+    :definition "An event where a process retrieves data from a specific memory address, either from its own allocated space or that of another process." .
+
 :MemoryWord a owl:Class ;
     rdfs:label "Memory Word" ;
     rdfs:subClassOf :MemoryExtent ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Word_(computer_architecture)" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Word_(computer_architecture)> ;
     :definition "A memory word is the natural unit of data used by a particular computer processor design; a fixed-size piece of data handled as a unit by the instruction set or the hardware of the processor." .
+
+:MemoryWriteEvent a owl:Class ;
+    rdfs:label "Memory Write Event" ;
+    rdfs:subClassOf :MemoryEvent ;
+    :definition "An event where a process writes data to a memory address, storing new information or updating existing content." .
 
 :MessageAnalysis a :MessageAnalysis,
         owl:Class,
@@ -20977,7 +14911,7 @@ Symmetric encryption uses the same cryptographic key by both the sender and rece
     rdfs:subClassOf :DigitalInformation ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Metadata> ;
     :definition "Metadata is \"data [information] that provides information about other data\". Three distinct types of metadata exist: structural metadata, descriptive metadata, and administrative metadata. Structural metadata is data about the containers of data. For instance a \"book\" contains data, and data about the book is metadata about that container of data. Descriptive metadata uses individual instances of application data or the data content." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/metadata" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/metadata> .
 
 :Microcode a owl:Class ;
     rdfs:label "Microcode" ;
@@ -20991,7 +14925,7 @@ Symmetric encryption uses the same cryptographic key by both the sender and rece
         [ a owl:Restriction ;
             owl:onProperty :may-contain ;
             owl:someValuesFrom :ExecutableScript ] ;
-    rdfs:isDefinedBy "http://dbpedia.org/resource/HTML_Application" .
+    rdfs:isDefinedBy <http://dbpedia.org/resource/HTML_Application> .
 
 :MobilePhone a owl:Class ;
     rdfs:label "Mobile Phone" ;
@@ -21068,7 +15002,7 @@ Model-free (reinforcement learning). Wikipedia. [Link](https://en.wikipedia.org/
 
 :Modem a owl:Class ;
     rdfs:label "Modem" ;
-    rdfs:subClassOf :NetworkNode ;
+    rdfs:subClassOf :ComputerNetworkNode ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Modem> ;
     :definition "A modem -- a portmanteau of \"modulator-demodulator\" -- is a hardware device that converts data into a format suitable for a transmission medium so that it can be transmitted from one computer to another (historically along telephone wires). A modem modulates one or more carrier wave signals to encode digital information for transmission and demodulates signals to decode the transmitted information. The goal is to produce a signal that can be transmitted easily and decoded reliably to reproduce the original digital data. Modems can be used with almost any means of transmitting analog signals from light-emitting diodes to radio. A common type of modem is one that turns the digital data of a computer into modulated electrical signal for transmission over telephone lines and demodulated by another modem at the receiver side to recover the digital data." .
 
@@ -21081,12 +15015,6 @@ Model-free (reinforcement learning). Wikipedia. [Link](https://en.wikipedia.org/
     :kb-article """## References
 Wikipedia. (n.d.). Moment (mathematics). [Link](https://en.wikipedia.org/wiki/Moment_(mathematics))""" ;
     :todo "Split out the different moments as leaves under moments instead of having them and moments at the same level" .
-
-:Monitoring a owl:Class ;
-    rdfs:label "Monitoring" ;
-    rdfs:subClassOf :D3FENDThing ;
-    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00881724-n> ;
-    :definition "the act of observing something (and sometimes keeping a record of it)" .
 
 :MouseInputDevice a owl:Class ;
     rdfs:label "Mouse Input Device" ;
@@ -21150,7 +15078,7 @@ Multilayer perceptron. Wikipedia. [Link](https://en.wikipedia.org/wiki/Multilaye
     rdfs:label "Multimedia Document File" ;
     rdfs:subClassOf :DocumentFile ;
     :definition "Digital video files which often contain audio." ;
-    rdfs:seeAlso "https://dbpedia.org/page/Multimedia" .
+    rdfs:seeAlso <https://dbpedia.org/page/Multimedia> .
 
 :MultipleRegression a owl:Class,
         owl:NamedIndividual ;
@@ -21170,7 +15098,7 @@ Yale University Department of Statistics. (1997-98). Linear regression and multi
     :definition "A supervised learning method that builds a multiple regression model using training data." ;
     :kb-article """## References
 Yale University Department of Statistics. (1997-98). Linear regression and multivariate analysis. [Link](http://www.stat.yale.edu/Courses/1997-98/101/linmult.htm)""" ;
-    rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#MultipleRegression" .
+    rdfs:seeAlso :MultipleRegression .
 
 :MultivariateAnalysis a owl:Class,
         owl:NamedIndividual ;
@@ -21191,6 +15119,14 @@ Wikipedia. (n.d.). Multivariate statistics. [Link](https://en.wikipedia.org/wiki
     :kb-article """## References
 Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_a&mhq=naive%20bayes).""" .
 
+:NamedPipe a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Named Pipe" ;
+    rdfs:subClassOf :Pipe ;
+    rdfs:isDefinedBy <https://dbpedia.org/resource/Named_pipe> ;
+    :definition "In computing, a named pipe (also known as a FIFO for its behavior) is an extension to the traditional pipe concept on Unix and Unix-like systems, and is one of the methods of inter-process communication (IPC). The concept is also found in OS/2 and Microsoft Windows, although the semantics differ substantially. A traditional pipe is 'unnamed' and lasts only as long as the process. A named pipe, however, can last as long as the system is up, beyond the life of the process. It can be deleted if no longer used. Usually a named pipe appears as a file, and generally processes attach to it for IPC." ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Named_pipe> .
+
 :Network a owl:Class ;
     rdfs:label "Network" ;
     skos:altLabel "Computer Network" ;
@@ -21205,6 +15141,50 @@ Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_
     :definition "Firmware that is installed on a network card (network interface controller)." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Network_interface_controller> .
 
+:NetworkConnectionCloseEvent a owl:Class ;
+    rdfs:label "Network Connection Close Event" ;
+    rdfs:subClassOf :NetworkConnectionEvent ;
+    :definition "An event where a network connection is closed." .
+
+:NetworkConnectionEvent a owl:Class ;
+    rdfs:label "Network Connection Event" ;
+    rdfs:subClassOf :NetworkEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :NetworkSession ] ;
+    :definition "An event related to the establishment, maintenance, or termination of a network connection." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/network_activity> .
+
+:NetworkConnectionFailEvent a owl:Class ;
+    rdfs:label "Network Connection Fail Event" ;
+    rdfs:subClassOf :NetworkConnectionEvent ;
+    :definition "An event where a network connection attempt fails." .
+
+:NetworkConnectionListenEvent a owl:Class ;
+    rdfs:label "Network Connection Listen Event" ;
+    rdfs:subClassOf :NetworkConnectionEvent ;
+    :definition "An event where a network endpoint begins listening for new network connections." .
+
+:NetworkConnectionOpenEvent a owl:Class ;
+    rdfs:label "Network Connection Open Event" ;
+    rdfs:subClassOf :NetworkConnectionEvent ;
+    :definition "An event where a network connection is successfully opened." .
+
+:NetworkConnectionRefuseEvent a owl:Class ;
+    rdfs:label "Network Connection Refuse Event" ;
+    rdfs:subClassOf :NetworkConnectionEvent ;
+    :definition "An event where a network connection is refused." .
+
+:NetworkConnectionResetEvent a owl:Class ;
+    rdfs:label "Network Connection Reset Event" ;
+    rdfs:subClassOf :NetworkConnectionEvent ;
+    :definition "An event where an attempt is made to establish a network connection." .
+
+:NetworkDeviceEvent a owl:Class ;
+    rdfs:label "Network Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent ;
+    :definition "An event capturing the activity or state of network devices, such as Ethernet adapters, Wi-Fi modules, or virtual interfaces. These events highlight connectivity, configuration, or performance changes." .
+
 :NetworkDirectoryResource a owl:Class ;
     rdfs:label "Network Directory Resource" ;
     rdfs:subClassOf :NetworkFileShareResource,
@@ -21212,6 +15192,15 @@ Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_
             owl:onProperty :contains ;
             owl:someValuesFrom :Directory ] ;
     :definition "A directory resource made available from one host to other hosts on a computer network." .
+
+:NetworkEvent a owl:Class ;
+    rdfs:label "Network Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :NetworkTraffic ] ;
+    :definition "An event involving network communications within or between digital systems." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/categories/network> .
 
 :NetworkFileResource a owl:Class ;
     rdfs:label "Network File Resource" ;
@@ -21264,8 +15253,8 @@ Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_
     rdfs:label "Network Link" ;
     rdfs:subClassOf :LogicalLink ;
     :definition "A network link is a link within the network layer, which is responsible for packet forwarding including routing through intermediate routers." ;
-    rdfs:seeAlso "https://dbpedia.org/resource/Network_layer",
-        "https://www.techtarget.com/searchnetworking/definition/Network-layer" ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Network_layer>,
+        <https://www.techtarget.com/searchnetworking/definition/Network-layer> ;
     :synonym "Layer-3 Link",
         "Network Layer Link" .
 
@@ -21279,14 +15268,12 @@ Naive Bayes. IBM. [Link](https://www.ibm.com/topics/naive-bayes?mhsrc=ibmsearch_
             owl:someValuesFrom :Model ] ;
     :d3fend-id "D3-NM" ;
     :definition "Network mapping encompasses the techniques to identify and model the physical layer, network layer, and data exchange layers of the organization's network and their physical location, and determine allowed pathways through that network." ;
-    :display-order 3 .
+    :display-order 3 ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Network_topology> .
 
 :NetworkNode a owl:Class ;
     rdfs:label "Network Node" ;
-    rdfs:subClassOf :DigitalInformationBearer,
-        [ a owl:Restriction ;
-            owl:onProperty :runs ;
-            owl:someValuesFrom :OperatingSystem ] ;
+    rdfs:subClassOf :DigitalInformationBearer ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Node_(networking)> ;
     :definition "In telecommunications networks, a node (Latin nodus, 'knot') is either a redistribution point or a communication endpoint. The definition of a node depends on the network and protocol layer referred to. A physical network node is an electronic device that is attached to a network, and is capable of creating, receiving, or transmitting information over a communications channel. A passive distribution point such as a distribution frame or patch panel is consequently not a node." .
 
@@ -21327,7 +15314,7 @@ Administrators collect information on network nodes in their architecture using 
 
 :NetworkPackets a owl:Class ;
     rdfs:label "Network Packet" ;
-    rdfs:subClassOf :NetworkTraffic ;
+    rdfs:subClassOf :DigitalInformationBearer ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Network_packet> ;
     :definition "A network packet is a formatted unit of data carried by a packet-switched network. Computer communications links that do not support packets, such as traditional point-to-point telecommunications links, simply transmit data as a bit stream. When data is formatted into packets, packet switching is possible and the bandwidth of the communication medium can be better shared among users than with circuit switching." .
 
@@ -21364,6 +15351,17 @@ Administrators collect information on network nodes in their architecture using 
             owl:someValuesFrom :Resource ] ;
     :definition "Ephemeral digital artifact comprising a request of a network resource and any response from that network resource." .
 
+:NetworkScanner a owl:Class ;
+    rdfs:label "Network Scanner" ;
+    skos:altLabel "Network Enumerator" ;
+    rdfs:subClassOf :CyberSensor,
+        [ a owl:Restriction ;
+            owl:onProperty :monitors ;
+            owl:someValuesFrom :Network ] ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Network_enumeration> ;
+    :definition "A network scanner is a computer program used to retrieve usernames and info on groups, shares, and services of networked computers. This type of program scans networks for vulnerabilities in the security of that network. If there is a vulnerability with the security of the network, it will send a report back to a hacker who may use this info to exploit that network glitch to gain entry to the network or for other malicious activities. Ethical hackers often also use the information to remove the glitches and strengthen their network." ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Network_enumeration#Software> .
+
 :NetworkSensor a owl:Class ;
     rdfs:label "Network Sensor" ;
     rdfs:subClassOf :CyberSensor .
@@ -21376,14 +15374,14 @@ Administrators collect information on network nodes in their architecture using 
 
 :NetworkSession a owl:Class ;
     rdfs:label "Network Session" ;
-    rdfs:subClassOf :NetworkTraffic,
+    rdfs:subClassOf :Session,
         [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :NetworkPackets ] ;
+            owl:onProperty :produces ;
+            owl:someValuesFrom :NetworkTraffic ] ;
     :definition "A network session is a temporary and interactive information interchange between two or more devices communicating over a network. A session is established at a certain point in time, and then 'torn down' - brought to an end - at some later point. An established communication session may involve more than one message in each direction. A session is typically stateful, meaning that at least one of the communicating parties needs to hold current state information and save information about the session history in order to be able to communicate, as opposed to stateless communication, where the communication consists of independent requests with responses. Network sessions may be established and implemented as part of protocols and services at the application, session, or transport layers of the OSI model." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/network_connection_info",
-        <http://dbpedia.org/resource/OSI_model>,
-        <http://dbpedia.org/resource/Session_(computer_science)> .
+    rdfs:seeAlso <http://dbpedia.org/resource/OSI_model>,
+        <http://dbpedia.org/resource/Session_(computer_science)>,
+        <https://schema.ocsf.io/objects/network_connection_info> .
 
 :NetworkTimeServer a owl:Class ;
     rdfs:label "Network Time Server" ;
@@ -21391,10 +15389,14 @@ Administrators collect information on network nodes in their architecture using 
     :definition "A network time server is a server computer that reads the actual time from a reference clock and distributes this information to its clients using a computer network. The time server may be a local network time server or an internet time server. The time server may also be a stand-alone hardware device. It can use NTP (RFC5905) or other protocols." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Time_server> .
 
-:NetworkTraffic a owl:Class ;
+:NetworkTraffic a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Network Traffic" ;
     skos:altLabel "Data Traffic" ;
     rdfs:subClassOf :DigitalInformationBearer,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :NetworkPackets ],
         [ a owl:Restriction ;
             owl:onProperty :may-contain ;
             owl:someValuesFrom :DomainName ],
@@ -21402,8 +15404,8 @@ Administrators collect information on network nodes in their architecture using 
             owl:onProperty :originates-from ;
             owl:someValuesFrom :PhysicalLocation ] ;
     :definition "Network traffic or data traffic is the data, or alternatively the amount of data, moving across a network at a given point of time.  Network data in computer networks is mostly encapsulated in network packets, which provide the load in the network." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/network_traffic",
-        <http://dbpedia.org/resource/Network_traffic> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Network_traffic>,
+        <https://schema.ocsf.io/objects/network_traffic> .
 
 :NetworkTrafficAnalysis a :NetworkTrafficAnalysis,
         owl:Class,
@@ -21557,7 +15559,7 @@ Network signature analysis is susceptible to generating false positives. These o
             owl:onProperty :has-member ;
             owl:someValuesFrom :NISTControl ] ;
     :definition "A NIST SP 800-53 control catalog provides the entire set of security and privacy controls for a version of NIST SP 800-53." ;
-    rdfs:seeAlso "https://doi.org/10.6028/NIST.SP.800-53r5" .
+    rdfs:seeAlso <https://doi.org/10.6028/NIST.SP.800-53r5> .
 
 :Non-monotonicLogic a owl:Class,
         owl:NamedIndividual ;
@@ -21580,9 +15582,10 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
 :Non-PersonEntity a owl:Class ;
     rdfs:label "Non-Person Entity" ;
     rdfs:subClassOf :Agent ;
-    rdfs:isDefinedBy "CNSSI 4009 aka \"Committee on National Security Systems (CNSS) Glossary\" (March 2, 2002)" ;
+    rdfs:comment "CNSSI 4009 aka \"Committee on National Security Systems (CNSS) Glossary\" (March 2, 2002)" ;
     :definition "An entity related to information technology with a digital identity that acts in cyberspace, but is not a human actor. This can include organizations, hardware objects (physical entities/devices), software objects (virtual/logical entities), and information artifacts." ;
-    rdfs:seeAlso "NIST 800-63" ;
+    rdfs:seeAlso <https://csrc.nist.gov/glossary/term/non_person_entity>,
+        :NIST_SP_800-53_R5 ;
     :synonym "NPE" .
 
 :NonlinearRegression a owl:Class,
@@ -21602,7 +15605,7 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
     :definition "A supervised learning method that builds a non-linear regression model using training data." ;
     :kb-article """## References
 Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/Nonlinear_regression)""" ;
-    rdfs:seeAlso "http://d3fend.mitre.org/ontologies/d3fend.owl#NonlinearRegression" .
+    rdfs:seeAlso :NonlinearRegression .
 
 :NTFSHardLink a owl:Class ;
     rdfs:label "NTFS Hard Link" ;
@@ -21634,12 +15637,89 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
     rdfs:isDefinedBy <http://dbpedia.org/resource/NTFS_links> ;
     :definition "An NTFS symbolic link records the path of another file that the links contents should show. Can accept relative paths. SMB networking (UNC path) and directory support added in NTFS 3.1." .
 
+:NTPBroadcastEvent a owl:Class ;
+    rdfs:label "NTP Broadcast Event" ;
+    rdfs:subClassOf :NTPEvent ;
+    :definition "An event where an NTP server broadcasts time synchronization messages to multiple clients simultaneously, enabling synchronization without individual request-response cycles." .
+
+:NTPClientSyncEvent a owl:Class ;
+    rdfs:label "NTP Client Synchronization Event" ;
+    rdfs:subClassOf :NTPEvent ;
+    :definition "An event where an NTP client requests and adjusts its clock based on time synchronization data provided by an NTP server, ensuring alignment with a standard time source." .
+
+:NTPControlMessageEvent a owl:Class ;
+    rdfs:label "NTP Control Message Event" ;
+    rdfs:subClassOf :NTPEvent ;
+    :definition "An event where an NTP client or server exchanges control messages used for diagnostic, monitoring, or administrative management of the NTP protocol, rather than time synchronization." .
+
+:NTPEvent a owl:Class ;
+    rdfs:label "NTP Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        :UDPEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :NetworkTimeServer ] ;
+    :definition "An event involving the Network Time Protocol (NTP), a protocol designed to synchronize the clocks of computer systems over packet-switched, variable-latency data networks, UDP as its transport protocol." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/ntp_activity> .
+
+:NTPServerResponseEvent a owl:Class ;
+    rdfs:label "NTP Server Response Event" ;
+    rdfs:subClassOf :NTPEvent ;
+    :definition "An event where an NTP server sends time synchronization data to a client, enabling the client to align its local clock with the server's reference time." .
+
+:NTPSymmetricActiveExchangeEvent a owl:Class ;
+    rdfs:label "NTP Symmetric Active Exchange Event" ;
+    rdfs:subClassOf :NTPEvent ;
+    :definition "An event where an NTP peer operating in symmetric active mode initiates clock synchronization messages to a peer in symmetric passive mode, enabling time synchronization between equal-status systems." .
+
+:NTPSymmetricPassiveExchangeEvent a owl:Class ;
+    rdfs:label "NTP Symmetric Passive Exchange Event" ;
+    rdfs:subClassOf :NTPEvent ;
+    :definition "An event where an NTP peer operating in symmetric passive mode responds to clock synchronization messages initiated by a symmetric active peer, facilitating mutual timekeeping." .
+
+:NullPointerChecking a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Null Pointer Checking" ;
+    rdfs:subClassOf :PointerValidation,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :MemoryFreeFunction ],
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :PointerDereferencingFunction ] ;
+    :d3fend-id "D3-NPC" ;
+    :definition "Checking if a pointer is NULL." ;
+    :kb-article """
+## How it Works
+Programmatically checking if a pointer is NULL before use.
+
+## Considerations
+* Pointers should be checked prior to use after they have, or may have been modified.
+* Note that it may vary by circumstance whether the caller, or callee is responsible for checking if a pointer is NULL.
+* Note: This resource should not be considered a definitive or exhaustive coding guideline.""" ;
+    :kb-reference :Reference-NullPointerChecking_SEI,
+        :Reference-NullPointerDereference_CWE,
+        :Reference-PointerValidationFunction_SEI ;
+    :synonym "Nil Pointer Checking" .
+
 :NumericPatternMatching a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Numeric Pattern Matching" ;
     rdfs:subClassOf :PatternMatching ;
     :d3fend-id "D3A-NPM" ;
     :definition "Numeric pattern matching uses a pattern specification and sees if the numeric value matches that pattern--simple forms include exact matching and range matching." .
+
+:ObjectEviction a :ObjectEviction,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Object Eviction" ;
+    rdfs:subClassOf :DefensiveTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :enables ;
+            owl:someValuesFrom :Evict ] ;
+    :d3fend-id "D3-OE" ;
+    :definition "Terminate or remove an object from a host machine. This is the broadest class for object eviction." ;
+    :enables :Evict .
 
 :ObjectFile a owl:Class ;
     rdfs:label "Object File" ;
@@ -21648,6 +15728,10 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
     :definition "An object file is a file that contains relocatable machine code." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Object_file> ;
     :todo "Fix IRI to fix 'i' in \"File\" substring of IRI" .
+
+:OffensiveAction a owl:Class ;
+    rdfs:label "Offensive Action" ;
+    rdfs:subClassOf :CyberAction .
 
 :OffensiveTactic a owl:Class ;
     rdfs:label "Offensive Tactic" ;
@@ -21661,8 +15745,7 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
 
 :OffensiveTechnique a owl:Class ;
     rdfs:label "Offensive Technique" ;
-    rdfs:subClassOf :Action,
-        :Technique,
+    rdfs:subClassOf :CyberTechnique,
         [ a owl:Restriction ;
             owl:onProperty :enables ;
             owl:someValuesFrom :OffensiveTactic ],
@@ -21681,7 +15764,7 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
     rdfs:label "Office Application File" ;
     rdfs:subClassOf :DocumentFile ;
     :definition "A document file in a format associated with an d3f:OfficeApplication." ;
-    rdfs:seeAlso "d3f:OfficeApplication" .
+    rdfs:seeAlso :OfficeApplication .
 
 :One-timePassword a :One-timePassword,
         owl:Class,
@@ -21750,8 +15833,8 @@ Additionally, after the code file is printed, it could be recovered from the sys
             owl:onProperty :may-contain ;
             owl:someValuesFrom :OperatingSystemConfigurationComponent ] ;
     :definition "An operating system (OS) is system software that manages computer hardware and software resources and provides common services for computer programs. All computer programs, excluding firmware, require an operating system to function. Time-sharing operating systems schedule tasks for efficient use of the system and may also include accounting software for cost allocation of processor time, mass storage, printing, and other resources." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/os",
-        <http://dbpedia.org/resource/Operating_system> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Operating_system>,
+        <https://schema.ocsf.io/objects/os> .
 
 :OperatingSystemConfiguration a owl:Class ;
     rdfs:label "Operating System Configuration" ;
@@ -21774,9 +15857,9 @@ Additionally, after the code file is printed, it could be recovered from the sys
         :OperatingSystemFile ;
     :comment "System configuration files configure system-wide software and services, as well as the operating system which supports scheduling and executing this software, as well as the configuration of peripherals." ;
     :definition "An operating system configuration file is a file used to configure the operating system." ;
-    rdfs:seeAlso "Configuration File",
-        "Operating System",
-        <http://dbpedia.org/resource/Configuration_file> .
+    rdfs:seeAlso :ConfigurationFile,
+        <http://dbpedia.org/resource/Configuration_file>,
+        :OperatingSystem .
 
 :OperatingSystemExecutableFile a owl:Class ;
     rdfs:label "Operating System Executable File" ;
@@ -21795,8 +15878,7 @@ Additionally, after the code file is printed, it could be recovered from the sys
     rdfs:subClassOf :LogFile,
         :OperatingSystemFile ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Log_file> ;
-    :definition "An operating system log file records events that occur in an operating system" ;
-    rdfs:seeAlso "Log File" .
+    :definition "An operating system log file records events that occur in an operating system" .
 
 :OperatingSystemMonitoring a :OperatingSystemMonitoring,
         owl:Class,
@@ -21897,6 +15979,13 @@ Operating System Monitoring Techniques have varied implementations including bui
     :definition "Mainframe computers or mainframes (colloquially referred to as \"big iron\") are computers used primarily by large organizations for critical applications; bulk data processing, such as census, industry and consumer statistics, and enterprise resource planning; and transaction processing. They are larger and have more processing power than some other classes of computers: minicomputers, servers, workstations, and personal computers." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Time-sharing> .
 
+:OpticalDiscImage a owl:Class ;
+    rdfs:label "Optical Disc Image" ;
+    rdfs:subClassOf :DiskImage ;
+    rdfs:isDefinedBy <https://en.wikipedia.org/wiki/Optical_disc_image> ;
+    :definition "An optical disc image (or ISO image, from the ISO 9660 file system used with CD-ROM media) is a disk image that contains everything that would be written to an optical disc, disk sector by disc sector, including the optical disc file system." ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Optical_disc_image> .
+
 :OpticalModem a owl:Class ;
     rdfs:label "Optical Modem" ;
     rdfs:subClassOf :Modem ;
@@ -21925,14 +16014,23 @@ Operating System Monitoring Techniques have varied implementations including bui
 
 :Organization a owl:Class ;
     rdfs:label "Organization" ;
-    rdfs:subClassOf :Non-PersonEntity,
+    rdfs:subClassOf :AgentGroup,
+        :Non-PersonEntity,
         [ a owl:Restriction ;
             owl:onProperty :has-member ;
             owl:someValuesFrom :Person ] .
 
 :OrganizationalActivity a owl:Class ;
     rdfs:label "Organizational Activity" ;
-    rdfs:subClassOf :Activity .
+    rdfs:subClassOf :Plan ;
+    :definition "An activity is a specific behavior representing a set of actions that may be accomplished by an agent." ;
+    rdfs:seeAlso "Mission Critical Function",
+        <http://wordnet-rdf.princeton.edu/id/00408356-n>,
+        <https://en.wikipedia.org/wiki/Business_Process_Model_and_Notation>,
+        <https://en.wikipedia.org/wiki/IDEF0>,
+        <https://enterpriseintegrationlab.github.io/icity/Activity/doc/index-en.html> ;
+    :synonym "Business Process",
+        "Mission Function" .
 
 :OrganizationMapping a :OrganizationMapping,
         owl:Class,
@@ -22038,8 +16136,8 @@ Operating System Monitoring Techniques have varied implementations including bui
 :OSAPIFunction a owl:Class ;
     rdfs:label "OS API Function" ;
     rdfs:subClassOf :Software ;
-    rdfs:seeAlso "http://dbpedia.org/page/Linux_kernel_interfaces",
-        "http://dbpedia.org/resource/Windows_API" .
+    rdfs:seeAlso <http://dbpedia.org/page/Linux_kernel_interfaces>,
+        <http://dbpedia.org/resource/Windows_API> .
 
 :OSAPIGetSystemTime a owl:Class ;
     rdfs:label "OS API Get System Time" ;
@@ -22187,6 +16285,69 @@ Operating System Monitoring Techniques have varied implementations including bui
             owl:onProperty :invokes ;
             owl:someValuesFrom :WriteMemory ] .
 
+:OTActuator a owl:Class ;
+    rdfs:label "OT Actuator" ;
+    rdfs:subClassOf :OutputDevice ;
+    rdfs:isDefinedBy <https://csrc.nist.gov/glossary/term/actuator> ;
+    :definition "An OT actuator is a device for moving or controlling a mechanism or system. It is operated by a source of energy, typically electric current, hydraulic fluid pressure, or pneumatic pressure, and converts that energy into motion. An actuator is the mechanism by which a control system acts upon an environment. The control system can be simple (a fixed mechanical or electronic system), software-based (e.g., a printer driver, robot control system), or a human or other agent." .
+
+:OTController a owl:Class ;
+    rdfs:label "OT Controller" ;
+    rdfs:subClassOf :OTEmbeddedComputer,
+        [ a owl:Restriction ;
+            owl:onProperty :communicates-with ;
+            owl:someValuesFrom :OTInputOutputModule ],
+        [ a owl:Restriction ;
+            owl:onProperty :controls ;
+            owl:someValuesFrom :OTActuator ],
+        [ a owl:Restriction ;
+            owl:onProperty :monitors ;
+            owl:someValuesFrom :OTSensor ],
+        [ a owl:Restriction ;
+            owl:onProperty :powered-by ;
+            owl:someValuesFrom :OTPowerSupply ] ;
+    rdfs:isDefinedBy <https://csrc.nist.gov/glossary/term/controller> ;
+    :definition "A device or program that operates automatically to regulate a controlled variable." .
+
+:OTEmbeddedComputer a owl:Class ;
+    rdfs:label "OT Embedded Computer" ;
+    rdfs:subClassOf :EmbeddedComputer .
+
+:OTInputOutputModule a owl:Class ;
+    rdfs:label "OT Input Output Module" ;
+    rdfs:subClassOf :HardwareDevice,
+        [ a owl:Restriction ;
+            owl:onProperty :communicates-with ;
+            owl:someValuesFrom :OTActuator ],
+        [ a owl:Restriction ;
+            owl:onProperty :communicates-with ;
+            owl:someValuesFrom :OTSensor ] ;
+    rdfs:comment "Rockwell Compact 5000 IO Module",
+        "There are many types of I/O modules, including: analog input, analog output, HART input, HART output, digital input, digital output, mV input, pulse input, universal I/O, vibration input, and many other types of input or output modules.The functionality of the I/O Module can be embedded in the controller or as a separate module connected via chassis or I/O link." ;
+    rdfs:isDefinedBy <https://consteel-electronics.com/articles/what-is-IO-module> ;
+    :definition "An I/O module is a hardware component designed to connect to external devices and sensors, converting analog or digital signals into a format that can be processed by a control system and vice versa." ;
+    rdfs:seeAlso <https://www.rockwellautomation.com/en-us/support/documentation/technical/i-o/compact-5000-i-o-modules.html> ;
+    :synonym "IO Module" .
+
+:OTPowerSupply a owl:Class ;
+    rdfs:label "OT Power Supply" ;
+    rdfs:subClassOf :PhysicalArtifact ;
+    rdfs:comment "OT examples include: Phoenix Contact QUINT, Eaton PSG, and many controller-branded power supplies.",
+        "See following for definition source - IEEE 100: The Authoritative Dictionary of IEEE Standards Terms IEEE STANDARDS DICTIONARY OF ELECTRICAL AND ELECTRONICS TERMS" ;
+    :definition "An electronic module that converts power from some power source to a form which is needed by the equipment to which power is being supplied." .
+
+:OTSensor a owl:Class ;
+    rdfs:label "OT Sensor" ;
+    rdfs:subClassOf :Sensor ;
+    rdfs:comment "Components of the sensor include a sensing element and may include a power source, display, housing, communication interface or signal processor.",
+        "Types of sensors include: level, pressure, temperature, and flow measurement devices." ;
+    rdfs:isDefinedBy <https://csrc.nist.rip/glossary/term/sensor> ;
+    :definition "An OT sensor is a device that measures a physical quantity and converts it into a signal which can be read by an observer or by an instrument. A sensor is a device, which responds to an input quantity by generating a functionally related output usually in the form of an electrical or optical signal." ;
+    rdfs:seeAlso <https://emerson.com/en-us/catalog/rosemount-sku-3051-coplanar-pressure-transmitter>,
+        <https://www.emerson.com/en-us/catalog/rosemount-sku-708-wireless-acoustic-transmitter>,
+        <https://www.omega.com/en-us/pressure-measurement/pressure-gauges/c/analog-pressure-gauges>,
+        <https://www.vega.com/en-us/products/product-catalog/level/radar> .
+
 :OutboundInternetDNSLookupTraffic a owl:Class ;
     rdfs:label "Outbound Internet DNS Lookup Traffic" ;
     rdfs:subClassOf :DNSNetworkTraffic,
@@ -22312,6 +16473,14 @@ There are various strategies for developing filtering rulesets:
     rdfs:isDefinedBy <http://dbpedia.org/resource/Output_device> ;
     :definition "An output device is any piece of computer hardware equipment which converts information into human-readable form. It can be text, graphics, tactile, audio, and video. Some of the output devices are Visual Display Units (VDU) i.e. a Monitor, Printer, Graphic Output devices, Plotters, Speakers etc. A new type of Output device is been developed these days, known as Speech synthesizer, a mechanism attached to the computer which produces verbal output sounding almost like human speeches." .
 
+:OutputDeviceEvent a owl:Class ;
+    rdfs:label "Output Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :OutputDevice ] ;
+    :definition "An event describing the activity or state of output devices, including sound cards, display adapters, or media controllers. These events relate to audio, video, or graphics functionality." .
+
 :OWL a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "OWL" ;
@@ -22339,7 +16508,7 @@ The OWL languages are characterized by formal semantics. They are built upon the
 :Page a owl:Class ;
     rdfs:label "Page" ;
     rdfs:subClassOf :MemoryBlock ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Page_(computer_memory)" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Page_(computer_memory)> ;
     :definition "A page, memory page, logical page, or virtual page is a fixed-length contiguous block of virtual memory, described by a single entry in the page table. It is the smallest unit of data for memory management in a virtual memory operating system." .
 
 :PageFrame a owl:Class ;
@@ -22348,7 +16517,7 @@ The OWL languages are characterized by formal semantics. They are built upon the
         [ a owl:Restriction ;
             owl:onProperty :contained-by ;
             owl:someValuesFrom :PrimaryStorage ] ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Page_(computer_memory)" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Page_(computer_memory)> ;
     :definition "A page frame is the smallest fixed-length contiguous block of physical memory into which memory pages are mapped by the operating system." .
 
 :PageTable a owl:Class ;
@@ -22360,7 +16529,7 @@ The OWL languages are characterized by formal semantics. They are built upon the
         [ a owl:Restriction ;
             owl:onProperty :contains ;
             owl:someValuesFrom :VirtualAddress ] ;
-    rdfs:isDefinedBy "Page table - Wikipedia" ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Page_table> ;
     :definition "A page table  is the data structure used by the MMU in a virtual memory computer system  to store the mapping between virtual addresses (virtual pages) and physical addresses (page frames)." .
 
 :Parameter-basedTransferLearning a owl:Class,
@@ -22413,7 +16582,10 @@ Newcastle University. (n.d.). Parametric Hypothesis Tests. [Link](https://www.nc
     rdfs:subClassOf :DigitalInformationBearer,
         [ a owl:Restriction ;
             owl:onProperty :addresses ;
-            owl:someValuesFrom :Partition ] ;
+            owl:someValuesFrom :Partition ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :BootRecord ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Partition_table> ;
     :definition "A partition is a fixed-size subset of a storage device which is treated as a unit by the operating system. A partition table is a table maintained on the storage device by the operating system describing the partitions on that device. The terms partition table and partition map are most commonly associated with the MBR partition table of a Master Boot Record (MBR) in IBM PC compatibles, but it may be used generically to refer to other \"formats\" that divide a disk drive into partitions, such as: GUID Partition Table (GPT), Apple partition map (APM), or BSD disklabel." .
 
@@ -22466,15 +16638,6 @@ Log integrity is verified by log auditors. Auditors make use of log proofs are u
     :kb-reference :Reference-TenablePassiveNetworkMonitoring ;
     :synonym "Passive Logical Layer Mapping" .
 
-:PassivePhysicalLinkMapping a owl:Class,
-        owl:NamedIndividual,
-        :PassivePhysicalLinkMapping ;
-    rdfs:label "Passive Physical Link Mapping" ;
-    rdfs:subClassOf :PhysicalLinkMapping ;
-    :d3fend-id "D3-PPLM" ;
-    :definition "Passive physical link mapping only listens to network traffic as a means to map the physical layer." ;
-    :synonym "Passive Physical Layer Mapping" .
-
 :Password a owl:Class ;
     rdfs:label "Password" ;
     skos:altLabel "Passcode" ;
@@ -22505,9 +16668,7 @@ Log integrity is verified by log auditors. Auditors make use of log proofs are u
     :definition "A user repository of account passwords, often accessed via a password manager." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Password_manager> .
 
-:Patent a owl:Class,
-        owl:NamedIndividual,
-        :ReferenceType ;
+:Patent a owl:Class ;
     rdfs:label "Patent" ;
     rdfs:subClassOf :Document .
 
@@ -22551,6 +16712,14 @@ Aggregate pull vs. push ratios from metadata are used to develop a baseline for 
 Collection and analysis of large network packet captures requires large storage and intensive computing power. The time windows used to calculate the ratio may vary in implementations, this consideration should take into account a threat model and likely effects (impacts) delivered by an adversary.""" ;
     :kb-reference :Reference-SystemForDetectingThreatsUsingScenario-basedTrackingOfInternalAndExternalNetworkTraffic_VECTRANETWORKSInc .
 
+:PeripheralDeviceEvent a owl:Class ;
+    rdfs:label "Peripheral Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :RemovableMediaDevice ] ;
+    :definition "An event involving external or auxiliary devices, such as USB drives, Thunderbolt peripherals, or Bluetooth devices. Peripheral events provide visibility into resource availability and potential unauthorized access." .
+
 :PeripheralFirmware a owl:Class ;
     rdfs:label "Peripheral Firmware" ;
     rdfs:subClassOf :Firmware ;
@@ -22585,6 +16754,16 @@ Changes in firmware hash values may indicate that the firmware has been tampered
     rdfs:subClassOf :PeripheralFirmware ;
     :definition "Firmware that is installed on peripheral hub device such as a USB or Firewire hub." ;
     rdfs:seeAlso <http://dbpedia.org/resource/USB_hub> .
+
+:PermissionGrantingEvent a owl:Class ;
+    rdfs:label "Permission Granting Event" ;
+    rdfs:subClassOf :AccessControlAdministrationEvent ;
+    :definition "An administrative event where authorization is given, allowing a subject to perform specific operations on a protected resource, effectuating a policy decision to allow access rights." .
+
+:PermissionRevokingEvent a owl:Class ;
+    rdfs:label "Permission Revoking Event" ;
+    rdfs:subClassOf :AccessControlAdministrationEvent ;
+    :definition "An administrative event entailing the withdrawal of previously granted access rights, reconfiguring permissions to prevent a subject from performing specific actions on a resource, in accordance with updated access policies." .
 
 :PersistenceTechnique a owl:Class ;
     rdfs:label "Persistence Technique" ;
@@ -22632,13 +16811,16 @@ Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Le
 :PhysicalAddress a owl:Class ;
     rdfs:label "Physical Address" ;
     rdfs:subClassOf :MemoryAddress ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Physical_address" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Physical_address> ;
     :definition "In a computer supporting virtual memory, the term physical address is used mostly to differentiate from a virtual address. In particular, in computers utilizing a memory management unit(MMU) to translate memory addresses, the virtual and physical addresses refer to an address before and after translation performed by the MMU, respectively." .
 
 :PhysicalArtifact a owl:Class ;
     rdfs:label "Physical Artifact" ;
+    skos:altLabel "Physical Object" ;
     rdfs:subClassOf :Artifact,
-        :PhysicalObject .
+        [ a owl:Restriction ;
+            owl:onProperty :has-location ;
+            owl:someValuesFrom :PhysicalLocation ] .
 
 :PhysicalLink a owl:Class ;
     rdfs:label "Physical Link" ;
@@ -22646,7 +16828,7 @@ Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Le
     :definition """A physical link is a dedicated connection for communication that uses some physical media (electrical, electromagnetic, optical, to include clear spaces or vacuums.)  A physical link represents only a single hop (link) in any larger communcations path, circuit, or network.
 
 NOTE: not synonymous with data link as a data link can be over a telecommunications circuit, which may be a virtual circuit composed of multiple phyical links.""" ;
-    rdfs:seeAlso "https://dbpedia.org/resource/Physical_layer" ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Physical_layer> ;
     :synonym "Layer-1 Link" .
 
 :PhysicalLinkMapping a owl:Class,
@@ -22663,26 +16845,20 @@ NOTE: not synonymous with data link as a data link can be over a telecommunicati
     :d3fend-id "D3-PLM" ;
     :definition "Physical link mapping identifies and models the link connectivity of the network devices within a physical network." ;
     :kb-reference :Reference-LibreNMSDocsNetworkMapExtension ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Network_topology#Links> ;
     :synonym "Layer 1 Mapping" .
 
 :PhysicalLocation a owl:Class ;
     rdfs:label "Physical Location" ;
-    rdfs:subClassOf :DigitalInformation ;
+    rdfs:subClassOf :D3FENDCore ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Location_(geography)> ;
     :definition "The terms location  [here, a physical location] and place in geography are used to identify a point or an area on the Earth's surface or elsewhere. The term location generally implies a higher degree of certainty than place, which often indicates an entity with an ambiguous boundary, relying more on human or social attributes of place identity and sense of place than on geometry. The distinction between space and place is considered a central concern of geography, and has been addressed by scholars such as Yi-Fu Tuan and John Agnew." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/location" .
-
-:PhysicalObject a owl:Class ;
-    rdfs:label "Physical Object" ;
-    rdfs:subClassOf :D3FENDThing,
-        [ a owl:Restriction ;
-            owl:onProperty :has-location ;
-            owl:someValuesFrom :PhysicalLocation ] .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/location> .
 
 :Pipe a owl:Class ;
     rdfs:label "Pipe" ;
     skos:altLabel "Pipeline" ;
-    rdfs:subClassOf :InterprocessCommunication ;
+    rdfs:subClassOf :DigitalInformationBearer ;
     rdfs:isDefinedBy <http://www.linfo.org/pipe.html> ;
     :definition "In Unix-like computer operating systems, a pipeline is a mechanism for inter-process communication using message passing.  In the strictest sense, a pipe is a single segment of a pipeline, allowing one process to pass information forward to another.  Network pipes allow processes on different hosts to interact." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Pipeline_(Unix)> .
@@ -22696,26 +16872,13 @@ NOTE: not synonymous with data link as a data link can be over a telecommunicati
     :kb-article """## References
 Esri. (n.d.). How Pix2Pix Works. [Link](https://developers.arcgis.com/python/guide/how-pix2pix-works/)""" .
 
+:Plan a owl:Class ;
+    rdfs:label "Plan" ;
+    rdfs:subClassOf :D3FENDCore .
+
 :Planning a owl:Class ;
     rdfs:label "Planning" ;
     rdfs:subClassOf :AnalyticalPurpose .
-
-:Platform a owl:Class ;
-    rdfs:label "Platform" ;
-    skos:altLabel "Computer Platform" ;
-    rdfs:subClassOf :DigitalInformationBearer,
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :Firmware ],
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :HardwareDevice ],
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :OperatingSystem ] ;
-    :definition "Platform includes the hardware and OS. The term computing platform can refer to different abstraction levels, including a certain hardware architecture, an operating system (OS), and runtime libraries. In total it can be said to be the stage on which computer programs can run." ;
-    rdfs:seeAlso <http://dbpedia.org/resource/Computing_platform> ;
-    :todo "Future work might identify an application platform like Chrome, however Chrome OS would be considered a platform with respect to cybersecurity architects." .
 
 :PlatformHardening a owl:Class,
         owl:NamedIndividual,
@@ -22812,6 +16975,14 @@ A known potential limitation of PACs concerns signing gadgets. Under certain cir
     rdfs:comment "Note, this is not the actual code which performs the dereferencing operation internal to an application runtime." ;
     :definition "A function which has an operation which dereferences a pointer." .
 
+:PointerValidation a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Pointer Validation" ;
+    rdfs:subClassOf :SourceCodeHardening ;
+    :d3fend-id "D3-PV" ;
+    :definition "Ensuring that a pointer variable has the required properties for use. " ;
+    :kb-reference :Reference-PointerValidationFunction_SEI .
+
 :PointEstimation a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Point Estimation" ;
@@ -22859,6 +17030,22 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     :definition "A PowerShell profile script is a script that runs when PowerShell starts and can be used as a logon script to customize user environments." ;
     rdfs:seeAlso <https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.1> .
 
+:PowerThermalDeviceEvent a owl:Class ;
+    rdfs:label "Power and Thermal Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Sensor ] ;
+    :definition "An event involving power supplies, batteries, or thermal management devices. These events represent changes in power states, temperature thresholds, or cooling system activity." .
+
+:PreAuthenticationEvent a owl:Class ;
+    rdfs:label "Pre-Authentication Event" ;
+    rdfs:subClassOf :AuthenticationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :precedes ;
+            owl:someValuesFrom :Authentication ] ;
+    :definition "An event representing preparatory steps or processes conducted prior to the primary authentication operation. Pre-authentication often involves initial protocol exchanges, cryptographic challenges, or the validation of supplemental factors (e.g., pre-shared keys) to ensure the readiness and security of the authentication workflow." .
+
 :PredicateLogic a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Predicate Logic" ;
@@ -22880,9 +17067,9 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
         [ a owl:Restriction ;
             owl:onProperty :contains ;
             owl:someValuesFrom :ProcessSegment ] ;
-    rdfs:isDefinedBy "https://www.memorymanagement.org/glossary/m.html#term-main-memory" ;
+    rdfs:isDefinedBy <https://www.memorymanagement.org/glossary/m.html#term-main-memory> ;
     :definition "Primary memory of a computer is memory that is wired directly to the processor, consisting of RAM and possibly ROM.  These terms are used in contrast to mass storage devices and cache memory (although we may note that when a program accesses main memory, it is often actually interacting with a cache)." ;
-    rdfs:seeAlso "https://en.wikipedia.org/wiki/Computer_data_storage#Primary_storage" .
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Computer_data_storage#Primary_storage> .
 
 :PrincipalComponentAnalysis a owl:Class,
         owl:NamedIndividual ;
@@ -22940,15 +17127,17 @@ Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org
 1. Probabilistic logic. (2023, June 5). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Probabilistic_logic)""" .
 
 :Procedure a owl:Class ;
-    rdfs:subClassOf :D3FENDThing,
+    rdfs:label "Procedure" ;
+    rdfs:subClassOf :Plan,
         [ a owl:Restriction ;
             owl:onProperty :implements ;
             owl:someValuesFrom :Technique ],
         [ a owl:Restriction ;
             owl:onProperty :start ;
-            owl:someValuesFrom :Step ] .
+            owl:allValuesFrom :Step ] .
 
-:Process a owl:Class ;
+:Process a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Process" ;
     rdfs:subClassOf :DigitalInformationBearer,
         [ a owl:Restriction ;
@@ -22983,7 +17172,12 @@ Wikipedia. (n.d.). Principal component analysis. [Link](https://en.wikipedia.org
             owl:someValuesFrom :Resource ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Process_(computing)> ;
     :definition "A process is an instance of a computer program that is being executed. It contains the program code and its current activity. Depending on the operating system (OS), a process may be made up of multiple threads of execution that execute instructions concurrently. A computer program is a passive collection of instructions, while a process is the actual execution of those instructions. Several processes may be associated with the same program; for example, opening up several instances of the same program often means more than one process is being executed." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/process" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/process> .
+
+:ProcessAccessEvent a owl:Class ;
+    rdfs:label "Process Access Event" ;
+    rdfs:subClassOf :ProcessEvent ;
+    :definition "An event where one process interacts with another, such as reading memory, inspecting state, or altering behavior." .
 
 :ProcessAnalysis a owl:Class,
         owl:NamedIndividual,
@@ -23065,12 +17259,17 @@ False negatives can occur via alteration of the verification logic or source of 
         :Reference-TamperProofMutatingSoftware_ARXANTECHNOLOGIESInc,
         :Reference-ThreatDetectionThroughTheAccumulatedDetectionOfThreatCharacteristics_SophosLtd .
 
+:ProcessCreationEvent a owl:Class ;
+    rdfs:label "Process Creation Event" ;
+    rdfs:subClassOf :ProcessEvent ;
+    :definition "An event where a new process is spawned, initializing its execution context and resource allocation." .
+
 :ProcessDataSegment a owl:Class ;
     rdfs:label "Process Data Segment" ;
     rdfs:subClassOf :ProcessSegment ;
     :definition "A process data segment, is a portion of the program's virtual address space that contains executable instructions and corresponds to the loaded image data segment." ;
-    rdfs:seeAlso "Image Data Segment",
-        <http://dbpedia.org/resource/Data_segment> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Data_segment>,
+        :ImageDataSegment .
 
 :ProcessEnvironmentVariable a owl:Class ;
     rdfs:label "Process Environment Variable" ;
@@ -23079,6 +17278,15 @@ False negatives can occur via alteration of the verification logic or source of 
     rdfs:isDefinedBy <http://dbpedia.org/resource/Environment_variable> ;
     :definition "An environment variable is a dynamic-named value that can affect the way running processes will behave on a computer. They are part of the environment in which a process runs." ;
     :todo "Did \"Environment Variable\" have an conflict with prior version of ATT&CK technique names or were there other env var classes that are no longer in d3fend?" .
+
+:ProcessEvent a owl:Class ;
+    rdfs:label "Process Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Process ] ;
+    :definition "An event capturing lifecycle transitions, interactions, or activities of computer processes, including their creation, termination, and inter-process communication." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/process_activity> .
 
 :ProcessEviction a owl:Class,
         owl:NamedIndividual,
@@ -23090,11 +17298,11 @@ False negatives can occur via alteration of the verification logic or source of 
             owl:someValuesFrom :Evict ] ;
     :d3fend-id "D3-PE" ;
     :definition "Process eviction techniques terminate or remove running process." ;
-    :enables :Evict .
+    :kb-reference :Reference-MalwareDetectionUsingLocalComputationalModels_CrowdstrikeInc .
 
 :ProcessImage a owl:Class ;
     rdfs:label "Process Image" ;
-    rdfs:subClassOf :DigitalInformationBearer,
+    rdfs:subClassOf :ComputingImage,
         [ a owl:Restriction ;
             owl:onProperty :contains ;
             owl:someValuesFrom :ProcessSegment ] ;
@@ -23158,9 +17366,9 @@ For example, Microsoft Word may block execution of any subprocess that is not in
         [ a owl:Restriction ;
             owl:onProperty :contained-by ;
             owl:someValuesFrom :CentralProcessingUnit ] ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Processor_register" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Processor_register> ;
     :definition "A processor register is a quickly accessible location available to a computer's processor. Registers usually consist of a small amount of fast storage, although some registers have specific hardware functions, and may be read-only or write-only." ;
-    rdfs:seeAlso "https://www.techtarget.com/whatis/definition/register" .
+    rdfs:seeAlso <https://www.techtarget.com/whatis/definition/register> .
 
 :ProcessSegment a owl:Class ;
     rdfs:label "Process Segment" ;
@@ -23224,6 +17432,11 @@ A security agent installed on the host machine intercepts API calls between a pr
 ## Considerations
 Comparing loaded code segments of processes with what is expected to have been loaded from a file can result in false positives, due to legitimate uses of self-modification for decrypting or uncompressing code segments.""" ;
     :kb-reference :Reference-SystemAndMethodForProcessHollowingDetection_CarbonBlackInc .
+
+:ProcessSetUserIDEvent a owl:Class ;
+    rdfs:label "Process Set User ID Event" ;
+    rdfs:subClassOf :ProcessEvent ;
+    :definition "An event where a process changes or adopts a specific user identity, modifying its access privileges or operational context." .
 
 :ProcessSpawnAnalysis a owl:Class,
         owl:NamedIndividual,
@@ -23429,6 +17642,11 @@ Processes that are started in a subsystem might not be fully terminated if they 
         :Reference-MalwareDetectionUsingLocalComputationalModels_CrowdstrikeInc ;
     :todo "Research on the proprietary methods.  This might include directly overwriting process memory, altering system data structures which relate to processes, changing the operating system task scheduler, or other low-level nonstandard operations that cause a process to cease its own intended operation." .
 
+:ProcessTerminationEvent a owl:Class ;
+    rdfs:label "Process Termination Event" ;
+    rdfs:subClassOf :ProcessEvent ;
+    :definition "An event marking the cessation of a process, including resource deallocation and cleanup, either due to normal completion or abnormal termination." .
+
 :ProcessTree a owl:Class ;
     rdfs:label "Process Tree" ;
     rdfs:subClassOf :DigitalInformationBearer,
@@ -23436,9 +17654,9 @@ Processes that are started in a subsystem might not be fully terminated if they 
             owl:onProperty :contains ;
             owl:someValuesFrom :Process ] ;
     :definition "A process tree is a tree structure representation of parent-child relationships established via process spawn operations." ;
-    rdfs:seeAlso "Process Spawn",
-        <http://dbpedia.org/resource/Child_process>,
-        <http://dbpedia.org/resource/Parent_process> .
+    rdfs:seeAlso <http://dbpedia.org/resource/Child_process>,
+        <http://dbpedia.org/resource/Parent_process>,
+        :ProcessSpawnAnalysis .
 
 :Product a owl:Class ;
     rdfs:label "Product" ;
@@ -23552,11 +17770,11 @@ Metadata collection on enterprises can yield large data sets. Storage, indexing,
 
 :ProxyServer a owl:Class ;
     rdfs:label "Proxy Server" ;
-    rdfs:subClassOf :NetworkNode,
+    rdfs:subClassOf :ComputerNetworkNode,
         :Server ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Proxy_server> ;
     :definition "In computer networking, a proxy server is a server application or appliance that acts as an intermediary for requests from clients seeking resources from servers that provide those resources. A proxy server thus functions on behalf of the client when requesting service, potentially masking the true origin of the request to the resource server." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/network_proxy" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/network_proxy> .
 
 :PublicKey a owl:Class ;
     rdfs:label "Public Key" ;
@@ -23601,7 +17819,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
 :RAM a owl:Class ;
     rdfs:label "RAM" ;
     rdfs:subClassOf :PrimaryStorage ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Random-access_memory" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Random-access_memory> ;
     :definition "Random-access memory (RAM) is a form of computer memory that can be read and changed in any order, typically used to store working data and machine code." ;
     :synonym "Random-access Memory" .
 
@@ -23655,6 +17873,39 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
             owl:someValuesFrom :MemoryBlock ] ;
     :definition "A function which accesses raw memory, usually using memory addresses." .
 
+:RDPConnectRequestEvent a owl:Class ;
+    rdfs:label "RDP Connect Request Event" ;
+    rdfs:subClassOf :RDPEvent ;
+    :definition "An event where an RDP client sends a connection request specifying session parameters, such as display settings, compression preferences, and security requirements, to prepare for an interactive session." .
+
+:RDPConnectResponseEvent a owl:Class ;
+    rdfs:label "RDP Connect Response Event" ;
+    rdfs:subClassOf :RDPEvent ;
+    :definition "An event where an RDP server acknowledges a connection request, finalizing session parameters and confirming the transition to an interactive remote session." .
+
+:RDPEvent a owl:Class ;
+    rdfs:label "RDP Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        [ a owl:Class ;
+            owl:unionOf (
+                    :TCPEvent
+                    :UDPEvent ) ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :RDPSession ] ;
+    :definition "An event involving the Remote Desktop Protocol (RDP), a communication protocol developed by Microsoft that facilitates secure remote access to graphical interfaces on desktops or applications hosted on remote servers. RDP supports multi-channel communication for transferring input, output, and management commands." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/rdp_activity> .
+
+:RDPInitialRequestEvent a owl:Class ;
+    rdfs:label "RDP Initial Request Event" ;
+    rdfs:subClassOf :RDPEvent ;
+    :definition "An event where an RDP client initiates communication with a server by sending a request to establish a session and negotiate protocol capabilities for remote interaction." .
+
+:RDPInitialResponseEvent a owl:Class ;
+    rdfs:label "RDP Initial Response Event" ;
+    rdfs:subClassOf :RDPEvent ;
+    :definition "An event where an RDP server responds to an initial request from a client, presenting its supported capabilities and agreeing to proceed with session negotiation." .
+
 :RDPSession a owl:Class ;
     rdfs:label "RDP Session" ;
     skos:altLabel "Remote Desktop Session",
@@ -23663,6 +17914,12 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
     :definition "A Remote Desktop Protocol (RDP) session is a session established using the RDP protocol to access Remove Desktop Services (RDS)." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Remote_Desktop_Protocol>,
         <http://dbpedia.org/resource/Remote_Desktop_Services> .
+
+:RDPTLSHandshakeEvent a owl:Class ;
+    rdfs:label "RDP TLS Handshake Event" ;
+    rdfs:subClassOf :RDPEvent,
+        :TCPEvent ;
+    :definition "An event representing the cryptographic exchange of keys and certificates between an RDP client and server to establish a secure communication channel. The handshake ensures encryption, integrity, and authentication for the session." .
 
 :ReadFile a owl:Class ;
     rdfs:label "Read File" ;
@@ -23704,13 +17961,23 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
 Wikipedia. (2021, September 7). Recurrent Neural Network. [Link](https://en.wikipedia.org/wiki/Recurrent_neural_network)""" ;
     :todo "Review: Which Definition" .
 
-:Reference a owl:Class ;
-    rdfs:label "Reference" ;
-    rdfs:subClassOf :D3FENDThing .
+:ReferenceNullification a owl:Class ;
+    rdfs:label "Reference Nullification" ;
+    rdfs:subClassOf :SourceCodeHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :MemoryFreeFunction ] ;
+    :d3fend-id "D3-RN" ;
+    :definition """Invalidating all pointers that reference a specific memory block, ensuring that the block cannot be accessed or modified after deallocation.
+""" ;
+    :kb-article """## How it Works
+Nullifying references to memory blocks makes those blocks no longer accessible. This is critical to prevent use-after-free errors.
 
-:ReferenceType a owl:Class ;
-    rdfs:label "Reference Type" ;
-    rdfs:subClassOf :D3FENDThing .
+## Considerations
+* If a memory block is freed, all other references to that block should be nullified.
+* This is particularly relevant when manually managing memory.
+* Note: This resource should not be considered a definitive or exhaustive coding guideline.""" ;
+    :kb-reference :Reference-ReferenceNullification_SecureSoftwareInc .
 
 :RegexMatching a owl:Class,
         owl:NamedIndividual ;
@@ -23733,6 +18000,18 @@ A regular expression (shortened as regex or regexp) is a sequence of characters 
 2. String-searching algorithm. (2023, April 8). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/String-searching_algorithm).""" ;
     :synonym "Regex",
         "Regexp" .
+
+:RegistryKeyDeletion a owl:Class,
+        owl:NamedIndividual,
+        :RegistryKeyDeletion ;
+    rdfs:label "Registry Key Deletion" ;
+    rdfs:subClassOf :ObjectEviction,
+        [ a owl:Restriction ;
+            owl:onProperty :deletes ;
+            owl:someValuesFrom :WindowsRegistryKey ] ;
+    :d3fend-id "D3-RKD" ;
+    :definition "Delete a registry key." ;
+    :kb-reference :Reference-CybersecurityIncidentandVulnerabilityResponsePlaybooks .
 
 :RegressionAnalysis a owl:Class,
         owl:NamedIndividual ;
@@ -23765,7 +18044,7 @@ Reinforcement learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Reinfor
         owl:NamedIndividual,
         :ReissueCredential ;
     rdfs:label "Reissue Credential" ;
-    rdfs:subClassOf :RestoreObject,
+    rdfs:subClassOf :RestoreAccess,
         [ a owl:Restriction ;
             owl:onProperty :restores ;
             owl:someValuesFrom :Credential ] ;
@@ -23814,8 +18093,7 @@ Complex intranet VPNs or routing encapsulation may affect the detection analytic
 
 :RemoteCommand a owl:Class ;
     rdfs:label "Remote Command" ;
-    rdfs:subClassOf :Command,
-        :NetworkSession ;
+    rdfs:subClassOf :Command ;
     :definition "A remote command is a command sent from one computer to another to be executed on the remote computer.  One example of this, is through a command-line interface (CLI) like using Invoke-Command from PowerShell or a command sent through an ssh session. This class generalizes to all means of sending a command through an established protocol to control capabilities on a remote computer." .
 
 :RemoteDatabaseQuery a owl:Class ;
@@ -23824,12 +18102,17 @@ Complex intranet VPNs or routing encapsulation may affect the detection analytic
         :RemoteCommand ;
     :definition "A remote query session enabling a user to make an SQL, SPARQL, or similar query over the network from one host to another." .
 
+:RemoteLoginSession a owl:Class ;
+    rdfs:label "Remote Login Session" ;
+    rdfs:subClassOf :NetworkSession ;
+    :definition "A remote login session is a login session where a client has logged in from their local host machine to a server via a network." .
+
 :RemoteProcedureCall a owl:Class ;
     rdfs:label "Remote Procedure Call" ;
     rdfs:subClassOf :RemoteCommand ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Remote_procedure_call> ;
     :definition "In distributed computing a remote procedure call (RPC) is when a computer program causes a procedure (subroutine) to execute in another address space (commonly on another computer on a shared network), which is coded as if it were a normal (local) procedure call, without the programmer explicitly coding the details for the remote interaction. That is, the programmer writes essentially the same code whether the subroutine is local to the executing program, or remote. This is a form of client-server interaction (caller is client, executor is server), typically implemented via a request-response message-passing system. The object-oriented programming analog is remote method invocation (RMI). The RPC model implies a level of location transparency." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/dce_rpc" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/dce_rpc> .
 
 :RemoteResource a owl:Class ;
     rdfs:label "Remote Resource" ;
@@ -23839,7 +18122,7 @@ Complex intranet VPNs or routing encapsulation may affect the detection analytic
 
 :RemoteSession a owl:Class ;
     rdfs:label "Remote Session" ;
-    rdfs:subClassOf :LoginSession ;
+    rdfs:subClassOf :NetworkSession ;
     :definition "A remote login session is a login session where a client has logged in from their local host machine to a server via a network." .
 
 :RemoteTerminalSession a owl:Class ;
@@ -23887,6 +18170,17 @@ Analysis algorithms look for patterns in the network traffic captured from the s
     :definition "A removable media device is a hardware device used for computer storage and that is designed to be inserted and removed from the system.  It is distinct from other removable media in that all the hardware required to read the data are built into the device.  So USB flash drives and external hard drives are removable media devices, whereas tapes and disks are not, as they require additional hardware to perform read/write operations." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Removable_media> .
 
+:RemoveUserFromGroupEvent a owl:Class ;
+    rdfs:label "Remove User from Group Event" ;
+    rdfs:subClassOf :GroupManagementEvent ;
+    :definition "An event where a user is removed from a group, revoking the permissions and privileges associated with the group from the user." .
+
+:Repository a owl:Class ;
+    rdfs:label "Repository" ;
+    rdfs:subClassOf :DigitalInformationBearer ;
+    rdfs:isDefinedBy <https://phoenixnap.com/glossary/what-is-a-repository> ;
+    :definition "A centralized digital storage location where code, files, and related resources are systematically organized, managed, and maintained." .
+
 :ResamplingEnsemble a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Resampling Ensemble" ;
@@ -23915,8 +18209,7 @@ Wikipedia contributors. (2021, August 23). Residual neural network. In Wikipedia
 
 :ResourceAccess a owl:Class ;
     rdfs:label "Resource Access" ;
-    rdfs:subClassOf :DigitalEvent,
-        :UserAction ;
+    rdfs:subClassOf :UserAction ;
     :definition "Ephemeral digital artifact comprising a request of a resource and any response from that resource." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Computer_access_control> .
 
@@ -23960,7 +18253,16 @@ This technique analyzes a user's resource accesses by comparing the user's recen
     rdfs:isDefinedBy <http://dbpedia.org/resource/Resource_fork> ;
     :definition "The resource fork is a fork or section of a file on Apple's classic Mac OS operating system, which was also carried over to the modern macOS for compatibility, used to store structured data along with the unstructured data stored within the data fork." .
 
-:Restore a owl:Class ;
+:RestorationEvent a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Restoration Event" ;
+    rdfs:subClassOf :SecurityEvent ;
+    :definition "An event representing actions to return a compromised system or resource to a trusted operational state, such as through backup restoration, system reinstallation, or repair." ;
+    :related :Restore .
+
+:Restore a :DefensiveTactic,
+        owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Restore" ;
     rdfs:subClassOf :DefensiveTactic ;
     :definition "The restore tactic is used to return the system to a better state." ;
@@ -24096,42 +18398,13 @@ This technique analyzes a user's resource accesses by comparing the user's recen
         [ a owl:Restriction ;
             owl:onProperty :resumes ;
             owl:someValuesFrom :Thread ] ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-resumethread" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-resumethread> .
 
 :ReverseProxyServer a owl:Class ;
     rdfs:label "Reverse Proxy Server" ;
     rdfs:subClassOf :ProxyServer ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Reverse_proxy> ;
     :definition "In computer networks, a reverse proxy is a type of proxy server that retrieves resources on behalf of a client from one or more servers. These resources are then returned to the client, appearing as if they originated from the proxy server itself. Unlike a forward proxy, which is an intermediary for its associated clients to contact any server, a reverse proxy is an intermediary for its associated servers to be contacted by any client. In other words, a proxy acts on behalf of the client(s), while a reverse proxy acts on behalf of the server(s); a reverse proxy is usually an internal-facing proxy used as a 'front-end' to control and protect access to a server on a private network." .
-
-:ReverseResolutionDomainDenylisting a owl:Class,
-        owl:NamedIndividual,
-        :ReverseResolutionDomainDenylisting ;
-    rdfs:label "Reverse Resolution Domain Denylisting" ;
-    rdfs:subClassOf :DNSDenylisting,
-        [ a owl:Restriction ;
-            owl:onProperty :blocks ;
-            owl:someValuesFrom :InboundInternetDNSResponseTraffic ] ;
-    :d3fend-id "D3-RRDD" ;
-    :definition "Blocking a reverse DNS lookup's answer's domain name value." ;
-    :kb-article """## How it works
-
-In reverse resolution requests, the client sends to a nameserver (such as a DNS server) a query of an IP address, to get a response of the associated domain name(s). This technique drops reverse lookup responses where a domain name matches an entry in the blacklist, either verbatim or as a wildcard subdomain of a higher-level domain on the list. Such domain names might be unwanted because Forward Domain Name Resolution requests to such a blacklisted domain might return an unwanted IP address.
-
-This technique is useful because relying solely on Forward Resolution Domain Blacklisting will miss instances where the domain in question is forward-resolved in a manner that is not inspected via a subsequent technique (as is likely the case if that resolution is performed with DoH (DNS over HTTPS) or DoT (DNS over TLS)). Additionally, note that responses to forward lookups of that domain are *not* necessarily equal to the original IP in the reverse lookup request, and that future lookups of a string based on this domain may even employ a less-common name resolution protocol, such as NBNS.
-
-The DNS response can either be blocked by dropping the network traffic with an inline device, or by modifying the value of the response sent by the DNS server.  To prevent client applications from hanging on a request, it is common practice to replace malicious values, either with names like "localhost." or the address of a honeypot maintained by the network administrators.
-
-## Considerations
-
-* This technique does not prevent the client from contacting the blacklisted domain or any IP addresses that it might resolve to, only from learning about this domain name via a nameserver lookup.
-* DNS response traffic can be transmitted over many different protocols, which presents a challenge to implementing methods to extract all DNS answer domain name value(s).
-  * DNS has historically used UDP port 53, with TCP port 53 instead used for responses over 512 bytes or after a lack of response over UDP.
-  * Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS responses. These protocols have often been enabled in browser settings transparently after a browser update, with DNS requests proxied over one of these cryptographic protocols through a specified host.
-* This technique must be deployed between the application that receives the response and the server which sent the response.
-  * DNS responses sent in an encrypted manner, such as using DoH or DoT, will require interception of the TLS connections in order to determine the domain name(s) in the response.
-* Replacing the response is not effective in the case that the nameserver uses a technique to provide integrity of its responses, such as DNSSEC for DNS responses.""" ;
-    :synonym "Reverse Resolution Domain Blacklisting" .
 
 :ReverseResolutionIPDenylisting a owl:Class,
         owl:NamedIndividual,
@@ -24155,6 +18428,11 @@ Queries for reverse resolution requests (that is, requests where IP(s) are sent 
   - Usage of new protocols to provide confidentiality for DNS traffic, such as DoH (DNS over HTTPS) and DoT (DNS over TLS), complicates collection of the IP address(es) in DNS queries. These protocols have often been enabled in browser settings transparently after a browser update, with DNS queries proxied over one of these cryptographic protocols through a specified host.""" ;
     :kb-reference :Reference-UseDNSPolicyForApplyingFiltersOnDNSQueries ;
     :synonym "Reverse Resolution IP Blacklisting" .
+
+:RevokePrivilegesFromGroupEvent a owl:Class ;
+    rdfs:label "Revoke Privileges from Group Event" ;
+    rdfs:subClassOf :GroupManagementEvent ;
+    :definition "An event where specific privileges or rights are removed from a group, restricting its members from performing actions or accessing resources previously allowed by those privileges." .
 
 :RFNode a owl:Class ;
     rdfs:label "RF Node" ;
@@ -24185,13 +18463,13 @@ Queries for reverse resolution requests (that is, requests where IP(s) are sent 
 :ROM a owl:Class ;
     rdfs:label "ROM" ;
     rdfs:subClassOf :PrimaryStorage ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Read-only_memory" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Read-only_memory> ;
     :definition "Read-only memory (ROM) is a type of non-volatile memory used in computers and other electronic devices. Data stored in ROM cannot be electronically modified after the manufacture of the memory device. Read-only memory is useful for storing software that is rarely changed during the life of the system, also known as firmware." ;
     :synonym "Read-only Memory" .
 
 :Router a owl:Class ;
     rdfs:label "Router" ;
-    rdfs:subClassOf :NetworkNode ;
+    rdfs:subClassOf :ComputerNetworkNode ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Router_(computing)> ;
     :definition "A router is a networking device that forwards data packets between computer networks. Routers perform the traffic directing functions on the Internet. Data sent through the internet, such as a web page or email, is in the form of data packets. A packet is typically forwarded from one router to another router through the networks that constitute an internetwork (e.g. the Internet) until it reaches its destination node." .
 
@@ -24247,7 +18525,7 @@ Example RPC Protocols:
         owl:NamedIndividual ;
     rdfs:label "SARSA" ;
     rdfs:subClassOf :Model-freeReinforcementLearning ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/State%E2%80%93action%E2%80%93reward%E2%80%93state%E2%80%93action" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/State%E2%80%93action%E2%80%93reward%E2%80%93state%E2%80%93action> ;
     :d3fend-id "D3A-SAR" ;
     :definition "State-action-reward-state-action (SARSA) is an algorithm for learning a Markov decision process policy, used in the reinforcement learning area of machine learning." ;
     :kb-article """## References
@@ -24267,7 +18545,8 @@ State-action-reward-state-action. Wikipedia.  [Link](https://en.wikipedia.org/wi
             owl:onProperty :copies ;
             owl:someValuesFrom :ProcessorRegister ] .
 
-:ScheduledJob a owl:Class ;
+:ScheduledJob a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Scheduled Job" ;
     rdfs:subClassOf :OperatingSystemProcess,
         [ a owl:Restriction ;
@@ -24280,10 +18559,10 @@ State-action-reward-state-action. Wikipedia.  [Link](https://en.wikipedia.org/wi
             owl:onProperty :modified-by ;
             owl:someValuesFrom :JobSchedulerSoftware ] ;
     :definition "A task scheduler process is an operating system process that executes scheduled tasks (time-scheduling in the sense of wall clock time; not operating system scheduling of processes for multitasking)." ;
-    rdfs:seeAlso "https://linux.die.net/man/1/at",
-        "https://schema.ocsf.io/objects/job",
-        <http://dbpedia.org/resource/Cron>,
-        <http://dbpedia.org/resource/Windows_Task_Scheduler> ;
+    rdfs:seeAlso <http://dbpedia.org/resource/Cron>,
+        <http://dbpedia.org/resource/Windows_Task_Scheduler>,
+        <https://linux.die.net/man/1/at>,
+        <https://schema.ocsf.io/objects/job> ;
     :synonym "Scheduled Task",
         "Task Scheduler Process" .
 
@@ -24308,6 +18587,45 @@ Jobs can be scheduled in many different and sometimes creative ways through oper
         :Reference-ExecutionWithSchtasks_MITRE,
         :Reference-PreventingExecutionOfTaskScheduledMalware_McAfeeLLC ;
     :synonym "Scheduled Job Execution" .
+
+:ScheduledJobCreationEvent a owl:Class ;
+    rdfs:label "Scheduled Job Creation Event" ;
+    rdfs:subClassOf :ScheduledJobEvent ;
+    :definition "An event representing the addition of a new task to the system's scheduler, defining its execution criteria and associated actions." .
+
+:ScheduledJobDeletionEvent a owl:Class ;
+    rdfs:label "Scheduled Job Deletion Event" ;
+    rdfs:subClassOf :ScheduledJobEvent ;
+    :definition "An event marking the removal of a scheduled task from the system, terminating its execution schedule." .
+
+:ScheduledJobDisableEvent a owl:Class ;
+    rdfs:label "Scheduled Job Disable Event" ;
+    rdfs:subClassOf :ScheduledJobEvent ;
+    :definition "An event where a scheduled task is deactivated, preventing further execution until re-enabled." .
+
+:ScheduledJobEnableEvent a owl:Class ;
+    rdfs:label "Scheduled Job Enable Event" ;
+    rdfs:subClassOf :ScheduledJobEvent ;
+    :definition "An event where a scheduled task is activated, allowing it to execute according to its defined parameters." .
+
+:ScheduledJobEvent a owl:Class ;
+    rdfs:label "Scheduled Job Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :ScheduledJob ] ;
+    :definition "An event capturing the lifecycle or management of scheduled tasks within a system, including creation, modification, execution, or removal." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/scheduled_job_activity> .
+
+:ScheduledJobStartEvent a owl:Class ;
+    rdfs:label "Scheduled Job Start Event" ;
+    rdfs:subClassOf :ScheduledJobEvent ;
+    :definition "An event indicating the execution of a scheduled task, triggered either automatically by the scheduler or manually by a user." .
+
+:ScheduledJobUpdateEvent a owl:Class ;
+    rdfs:label "Scheduled Job Update Event" ;
+    rdfs:subClassOf :ScheduledJobEvent ;
+    :definition "An event where an existing scheduled task is updated, altering parameters such as timing, conditions, or actions." .
 
 :Scheduling a owl:Class ;
     rdfs:label "Scheduling" ;
@@ -24349,9 +18667,17 @@ List of known unauthorized script files or regular expression patterns must be k
     rdfs:label "Secondary Storage" ;
     rdfs:subClassOf :HardwareDevice,
         :Storage ;
-    rdfs:isDefinedBy "https://whatis.techtarget.com/definition/memory" ;
+    rdfs:isDefinedBy <https://whatis.techtarget.com/definition/memory> ;
     :definition "Secondary memory (storage, hard disk) is the computer component holding information that does not need to be accessed quickly and that needs to be retained long-term." ;
-    rdfs:seeAlso "https://en.wikipedia.org/wiki/Computer_data_storage#Secondary_storage" .
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Computer_data_storage#Secondary_storage> .
+
+:SecurityEvent a owl:Class ;
+    rdfs:label "Security Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :caused-by ;
+            owl:someValuesFrom :DefensiveAction ] ;
+    :definition "An event describing occurrences related to cybersecurity, including detection, remediation, or enforcement actions. Security events provide critical insights into the state, behavior, and resilience of digital systems." .
 
 :SecurityToken a owl:Class ;
     rdfs:label "Security Token" ;
@@ -24468,7 +18794,7 @@ Zhou, D., & Li, M. (2005). Semi-supervised learning by higher order regularizati
     :definition "Semi-supervised learning is a branch of machine learning that combines a small amount of labeled data with a large amount of unlabeled data during training." ;
     :kb-article """## References
 Semi-Supervised Learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Semi-Supervised_Learning).""" ;
-    rdfs:seeAlso "https://link.springer.com/article/10.1007/s10994-019-05855-6" .
+    rdfs:seeAlso <https://link.springer.com/article/10.1007/s10994-019-05855-6> .
 
 :Semi-supervisedManifoldLearning a owl:Class,
         owl:NamedIndividual ;
@@ -24581,8 +18907,8 @@ Legitimate emails from a sender may receive a lower trust rating over time if th
     rdfs:label "Sensor" ;
     rdfs:subClassOf :D3FENDCore,
         :DigitalInformationBearer ;
-    :definition "In the broadest definition, a sensor is a device, module, machine, or subsystem that detects events or changes in its environment and sends the information to other electronics, frequently a computer processor." ;
-    rdfs:seeAlso "https://en.wikipedia.org/wiki/Sensor" .
+    :definition "In the broadest definition, a sensor is a device, module, machine, or subsystem that detects events or changes in its environment and sends the information to other electronics, frequently a computer." ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Sensor> .
 
 :SeqGAN a owl:Class,
         owl:NamedIndividual ;
@@ -24615,6 +18941,12 @@ Yu, L., Zhang, W., Wang, J., & Yu, Y. (2017). SeqGAN: Sequence Generative Advers
     rdfs:label "Service" ;
     rdfs:subClassOf :CapabilityImplementation .
 
+:ServiceAccount a owl:Class ;
+    rdfs:label "Service Account" ;
+    rdfs:subClassOf :UserAccount ;
+    :definition "A service account is a type of account used by an application or service to interact with the operating system." ;
+    :synonym "System Account" .
+
 :ServiceApplication a owl:Class ;
     rdfs:label "Service Application" ;
     rdfs:subClassOf :Application ;
@@ -24622,7 +18954,8 @@ Yu, L., Zhang, W., Wang, J., & Yu, Y. (2017). SeqGAN: Sequence Generative Advers
     rdfs:seeAlso <http://dbpedia.org/resource/Server_(computing)>,
         <http://dbpedia.org/resource/Service_(systems_architecture)> .
 
-:ServiceApplicationProcess a owl:Class ;
+:ServiceApplicationProcess a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "Service Application Process" ;
     rdfs:subClassOf :ApplicationProcess .
 
@@ -24643,6 +18976,12 @@ System service applications may originate from the operating system installation
 * These files change for legitimate reasons when the system or software updates.
 * The source of truth must not be corrupted in order for this method to work.""" ;
     :kb-reference :Reference-ServiceBinaryModifications_MITRE .
+
+:ServiceDeletionEvent a owl:Class ;
+    rdfs:label "Service Deletion Event" ;
+    rdfs:subClassOf :ApplicationDeletionEvent,
+        :ServiceEvent ;
+    :definition "An event capturing the uninstallation or deregistration of a service application, ensuring it is no longer operational or available to clients." .
 
 :ServiceDependency a owl:Class ;
     rdfs:label "Service Dependency" ;
@@ -24671,6 +19010,32 @@ The organization collects and models architectural information about the service
         :Reference-UnifiedArchitectureFrameworkUAF ;
     :synonym "Distributed Tracing" .
 
+:ServiceDisableEvent a owl:Class ;
+    rdfs:label "Service Disable Event" ;
+    rdfs:subClassOf :ApplicationDisableEvent,
+        :ServiceEvent ;
+    :definition "An event capturing the deactivation of a service application, preventing it from being started or accessed until re-enabled." .
+
+:ServiceEnableEvent a owl:Class ;
+    rdfs:label "Service Enable Event" ;
+    rdfs:subClassOf :ApplicationEnableEvent,
+        :ServiceEvent ;
+    :definition "An event representing the activation of a service application, allowing it to start and provide its background or networked functionality." .
+
+:ServiceEvent a owl:Class ;
+    rdfs:label "Service Event" ;
+    rdfs:subClassOf :ApplicationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :ServiceApplication ] ;
+    :definition "An event capturing the operation, configuration, or lifecycle of a service application. Services are specialized applications designed to provide reusable functionality to clients, systems, or other applications, often operating in the background or across networks." .
+
+:ServiceInstallationEvent a owl:Class ;
+    rdfs:label "Service Installation Event" ;
+    rdfs:subClassOf :ApplicationInstallationEvent,
+        :ServiceEvent ;
+    :definition "An event representing the installation or registration of a service application within the system, enabling it to provide background or reusable functionality." .
+
 :ServiceProvider a owl:Class ;
     rdfs:label "Service Provider" ;
     rdfs:subClassOf :Provider,
@@ -24678,12 +19043,36 @@ The organization collects and models architectural information about the service
             owl:onProperty :provides ;
             owl:someValuesFrom :Service ] .
 
+:ServiceRestartEvent a owl:Class ;
+    rdfs:label "Service Restart Event" ;
+    rdfs:subClassOf :ApplicationRestartEvent,
+        :ServiceEvent ;
+    :definition "An event describing the sequential stopping and starting of a service application to refresh its state, apply updates, or resolve operational issues." .
+
+:ServiceStartEvent a owl:Class ;
+    rdfs:label "Service Start Event" ;
+    rdfs:subClassOf :ApplicationStartEvent,
+        :ServiceEvent ;
+    :definition "An event representing the initiation of a service application, transitioning it from an inactive state to an active state, enabling its background or networked operations." .
+
+:ServiceStopEvent a owl:Class ;
+    rdfs:label "Service Stop Event" ;
+    rdfs:subClassOf :ApplicationStopEvent,
+        :ServiceEvent ;
+    :definition "An event capturing the cessation of a service application’s operations, transitioning it to an inactive state while ceasing its functionality to clients or dependent systems." .
+
+:ServiceUpdateEvent a owl:Class ;
+    rdfs:label "Service Update Event" ;
+    rdfs:subClassOf :ApplicationUpdateEvent,
+        :ServiceEvent ;
+    :definition "An event describing changes made to a service application, such as updates, reconfigurations, or patch installations, ensuring its continued availability and functionality." .
+
 :Session a owl:Class ;
     rdfs:label "Session" ;
     rdfs:subClassOf :DigitalInformationBearer ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Session_(computer_science)> ;
     :definition "In computer science, in particular networking, a session is a semi-permanent interactive information interchange, also known as a dialogue, a conversation or a meeting, between two or more communicating devices, or between a computer and user (see Login session). A session is set up or established at a certain point in time, and then torn down at some later point. An established communication session may involve more than one message in each direction. A session is typically, but not always, stateful, meaning that at least one of the communicating parts needs to save information about the session history in order to be able to communicate, as opposed to stateless communication, where the communication consists of independent requests with responses." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/session" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/session> .
 
 :SessionCookie a owl:Class ;
     rdfs:label "Session Cookie" ;
@@ -24694,8 +19083,8 @@ The organization collects and models architectural information about the service
     rdfs:subClassOf :Credential ;
     rdfs:isDefinedBy <https://schema.ocsf.io/objects/http_cookie> ;
     :definition "A session cookie, also known as an in-memory cookie, transient cookie or non-persistent cookie, exists only in temporary memory while the user navigates the website. Web browsers normally delete session cookies when the user closes the browser. Unlike other cookies, session cookies do not have an expiration date assigned to them, which is how the browser knows to treat them as session cookies." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/http_cookie",
-        <http://dbpedia.org/resource/HTTP_cookie> .
+    rdfs:seeAlso <http://dbpedia.org/resource/HTTP_cookie>,
+        <https://schema.ocsf.io/objects/http_cookie> .
 
 :SessionDurationAnalysis a owl:Class,
         owl:NamedIndividual,
@@ -24719,6 +19108,19 @@ Detecting unauthorized user sessions by comparing the duration of a user logon s
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC .
 
+:SessionTermination a owl:Class,
+        owl:NamedIndividual,
+        :SessionTermination ;
+    rdfs:label "Session Termination" ;
+    rdfs:subClassOf :ProcessEviction,
+        [ a owl:Restriction ;
+            owl:onProperty :deletes ;
+            owl:someValuesFrom :Session ] ;
+    :d3fend-id "D3-ST" ;
+    :definition "Forcefully end all active sessions associated with compromised accounts or devices." ;
+    :kb-article "Defined in NIST 800-53 as AC-12." ;
+    :kb-reference :Reference-NIST-Special-Publication-800-53A-Revision-5 .
+
 :SetRegisters a owl:Class ;
     rdfs:label "Set Registers" ;
     rdfs:subClassOf :SystemCall,
@@ -24732,7 +19134,7 @@ Detecting unauthorized user sessions by comparing the duration of a user logon s
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
             owl:someValuesFrom :SystemConfigurationDatabaseRecord ] ;
-    rdfs:seeAlso "https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regsetvalueexa" .
+    rdfs:seeAlso <https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regsetvalueexa> .
 
 :SetThreadContext a owl:Class ;
     rdfs:label "Set Thread Context" ;
@@ -24740,7 +19142,7 @@ Detecting unauthorized user sessions by comparing the duration of a user logon s
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
             owl:someValuesFrom :Thread ] ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadcontext" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadcontext> .
 
 :ShadowStack a owl:Class ;
     rdfs:label "Shadow Stack" ;
@@ -24748,7 +19150,7 @@ Detecting unauthorized user sessions by comparing the duration of a user logon s
         [ a owl:Restriction ;
             owl:onProperty :copy-of ;
             owl:someValuesFrom :CallStack ] ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Shadow_stack" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Shadow_stack> ;
     :definition "A shadow stack is a mechanism for protecting a procedure's stored return address, such as from a stack buffer overflow. The shadow stack itself is a second, separate stack that \"shadows\" the program call stack. In the function prologue, a function stores its return address to both the call stack and the shadow stack. In the function epilogue, a function loads the return address from both the call stack and the shadow stack, and then compares them. If the two records of the return address differ, then an attack is detected." ;
     :todo "Model more completely: what manages the shadowstack, where does it reside specifically in memory." .
 
@@ -24853,6 +19255,46 @@ Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
     :definition "A slow symbolic link is any symbolic link on a Unix filesystem that is not a fast symbolic link; slow symlink is thus retroactively termed from fast symlink.  Slow symbolic links stored the symbolic link information as data in regular files." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Symbolic_link#Storage_of_symbolic_links> .
 
+:SMBEvent a owl:Class ;
+    rdfs:label "SMB Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        :TCPEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :FileTransferNetworkTraffic ] ;
+    :definition "An event involving the Server Message Block (SMB) protocol, a network file sharing protocol that allows client-server communication for accessing files, printers, and other shared network resources. SMB supports both transactional file operations and communication over reliable transport layers." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/smb_activity> .
+
+:SMBFileCreateEvent a owl:Class ;
+    rdfs:label "SMB File Create Event" ;
+    rdfs:subClassOf :SMBEvent ;
+    :definition "An event where a file is created if it does not already exist, failing if the file is already present. This operation strictly enforces new file creation." .
+
+:SMBFileOpenEvent a owl:Class ;
+    rdfs:label "SMB File Open Event" ;
+    rdfs:subClassOf :SMBEvent ;
+    :definition "An event where a file is opened if it exists, failing otherwise. This operation is used to access or query the existing file." .
+
+:SMBFileOpenIfEvent a owl:Class ;
+    rdfs:label "SMB File Open If Event" ;
+    rdfs:subClassOf :SMBEvent ;
+    :definition "An event where a file is opened if it exists, or created if it does not. This operation merges file creation and access behavior." .
+
+:SMBFileOverwriteEvent a owl:Class ;
+    rdfs:label "SMB File Overwrite Event" ;
+    rdfs:subClassOf :SMBEvent ;
+    :definition "An event where a file is opened and truncated if it exists, failing if the file does not already exist. This operation is destructive and focuses on replacing the file's contents." .
+
+:SMBFileOverwriteIfEvent a owl:Class ;
+    rdfs:label "SMB File Overwrite If Event" ;
+    rdfs:subClassOf :SMBEvent ;
+    :definition "An event where a file is opened and truncated if it exists, or created otherwise. This operation combines destructive overwrite and creation behaviors." .
+
+:SMBFileSupersedeEvent a owl:Class ;
+    rdfs:label "SMB File Supersede Event" ;
+    rdfs:subClassOf :SMBEvent ;
+    :definition "An event where a file is overwritten if it exists or created if it does not. This operation combines file creation and modification semantics." .
+
 :Software a owl:Class ;
     rdfs:label "Software" ;
     rdfs:subClassOf :DigitalInformation,
@@ -24938,7 +19380,7 @@ Application-layer discovery:
 :SoftwarePackage a owl:Class ;
     rdfs:label "Software Package" ;
     rdfs:subClassOf :DigitalInformationBearer ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/package" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/package> .
 
 :SoftwarePackagingTool a owl:Class ;
     rdfs:label "Software Packaging Tool" ;
@@ -24958,6 +19400,16 @@ Application-layer discovery:
     rdfs:label "Software Product" ;
     skos:altLabel "SaaP" ;
     rdfs:subClassOf :Product .
+
+:SoftwareRepository a owl:Class ;
+    rdfs:label "Software Repository" ;
+    skos:altLabel "Package Repository" ;
+    rdfs:subClassOf :Repository,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :SoftwarePackage ] ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Software_repository> ;
+    :definition "A software repository, or repo for short, is a storage location for software packages. Often a table of contents is also stored, along with metadata. A software repository is typically managed by source or version control, or repository managers. Package managers allow automatically installing and updating repositories, sometimes called 'packages'." .
 
 :SoftwareService a owl:Class ;
     rdfs:label "Software Service" ;
@@ -24994,9 +19446,7 @@ The goal is for homophones to be encoded to the same representation so that they
 ## References
 1. Soundex. (2023, April 19). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Soundex)""" .
 
-:SourceCode a owl:Class,
-        owl:NamedIndividual,
-        :ReferenceType ;
+:SourceCode a owl:Class ;
     rdfs:label "Source Code" ;
     rdfs:subClassOf :InformationContentEntity .
 
@@ -25005,6 +19455,17 @@ The goal is for homophones to be encoded to the same representation so that they
     rdfs:subClassOf :StaticAnalysisTool ;
     :definition "A source code analyzer tool is a static analysis tool that operates specifically on source code, but not object code." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Static_program_analysis> .
+
+:SourceCodeHardening a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Source Code Hardening" ;
+    rdfs:subClassOf :DefensiveTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :enables ;
+            owl:someValuesFrom :Harden ] ;
+    :d3fend-id "D3-SCH" ;
+    :definition "Hardening source code with the intention of making it more difficult to exploit and less error prone." ;
+    :enables :Harden .
 
 :SourceCodeReference a owl:Class ;
     rdfs:label "Source Code Reference" ;
@@ -25039,6 +19500,52 @@ The goal is for homophones to be encoded to the same representation so that they
     :definition "Spectral clustering is a technique that identifies communities of nodes in a graph based on the edges connecting them." ;
     :kb-article """## References
 Towards Data Science. (n.d.). Spectral Clustering. [Link](https://towardsdatascience.com/spectral-clustering-aba2640c0d5b)""" .
+
+:SSHConnectionCloseEvent a owl:Class ;
+    rdfs:label "SSH Connection Close Event" ;
+    rdfs:subClassOf :NetworkConnectionCloseEvent,
+        :SSHEvent ;
+    :definition "An event indicating the termination of an SSH connection, signaling the end of a secure session." .
+
+:SSHConnectionFailEvent a owl:Class ;
+    rdfs:label "SSH Connection Fail Event" ;
+    rdfs:subClassOf :NetworkConnectionFailEvent,
+        :SSHEvent ;
+    :definition "An event indicating a failure to establish an SSH connection, often due to issues such as authentication errors, network timeouts, or server unavailability." .
+
+:SSHConnectionOpenEvent a owl:Class ;
+    rdfs:label "SSH Connection Open Event" ;
+    rdfs:subClassOf :NetworkConnectionOpenEvent,
+        :SSHEvent ;
+    :definition "An event indicating the successful establishment of an SSH connection between a client and a server, marking the initiation of a secure session." .
+
+:SSHConnectionRefuseEvent a owl:Class ;
+    rdfs:label "SSH Connection Refuse Event" ;
+    rdfs:subClassOf :NetworkConnectionRefuseEvent,
+        :SSHEvent ;
+    :definition "An event indicating that an SSH connection attempt was refused, typically due to server-side restrictions or closed ports." .
+
+:SSHConnectionResetEvent a owl:Class ;
+    rdfs:label "SSH Connection Reset Event" ;
+    rdfs:subClassOf :NetworkConnectionResetEvent,
+        :SSHEvent ;
+    :definition "An event indicating the abrupt termination of an SSH connection due to protocol errors, network disruptions, or administrative actions." .
+
+:SSHEvent a owl:Class ;
+    rdfs:label "SSH Event" ;
+    rdfs:subClassOf :ApplicationLayerEvent,
+        :TCPEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :SSHSession ] ;
+    :definition "An event involving the Secure Shell (SSH) protocol, a cryptographic network protocol designed to provide secure remote login, command execution, and data transfer. SSH facilitates encrypted communication between clients and servers, ensuring confidentiality, integrity, and authenticity." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/ssh_activity> .
+
+:SSHListenEvent a owl:Class ;
+    rdfs:label "SSH Listen Event" ;
+    rdfs:subClassOf :NetworkConnectionListenEvent,
+        :SSHEvent ;
+    :definition "An event indicating that an SSH server has started listening for incoming connection requests, enabling potential clients to initiate secure sessions." .
 
 :SSHSession a owl:Class ;
     rdfs:label "SSH Session" ;
@@ -25193,7 +19700,8 @@ Wikipedia. (n.d.). Standard deviation. [Link](https://en.wikipedia.org/wiki/Stan
 Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Statistics.html)""" .
 
 :Step a owl:Class ;
-    rdfs:subClassOf :D3FENDThing,
+    rdfs:label "Step" ;
+    rdfs:subClassOf :Plan,
         [ a owl:Restriction ;
             owl:onProperty :end ;
             owl:someValuesFrom :Step ],
@@ -25217,6 +19725,25 @@ Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Stat
     :definition "Computer data storage, often called storage or memory, is a technology consisting of computer components and recording media used to retain digital data. It is a core function and fundamental component of computers. In the Von Neumann architecture, the CPU consists of two main parts: The control unit and the arithmetic / logic unit (ALU). The former controls the flow of data between the CPU and memory, while the latter performs arithmetic and logical operations on data." ;
     :synonym "Computer data storage",
         "Storage" .
+
+:StorageDeviceEvent a owl:Class ;
+    rdfs:label "Storage Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :SecondaryStorage ] ;
+    :definition "An event describing the activity, configuration, or errors of storage devices, including physical disks, SSDs, or logical partitions. These events often pertain to data availability, integrity, and storage health." .
+
+:StorageImage a owl:Class ;
+    rdfs:label "Storage Image" ;
+    rdfs:subClassOf :ComputingImage,
+        :File ;
+    :definition "A storage image is a complete, encapsulated representation of a storage medium or system environment. It contains all the data, files, and configurations necessary to replicate or deploy a specific system state or software setup." .
+
+:StorageSnapshot a owl:Class ;
+    rdfs:label "Storage Snapshot" ;
+    rdfs:subClassOf :ComputingSnapshot ;
+    :definition "A storage snapshot is a copy of a storage medium or system environment at a point in time." .
 
 :StoredProcedure a owl:Class ;
     rdfs:label "Stored Procedure" ;
@@ -25348,7 +19875,7 @@ About Support Vector Machine (SVM). IBM SPSS Modeler SaaS Documentation. [Link](
             owl:onProperty :suspends ;
             owl:someValuesFrom :Thread ] ;
     :definition "Suspending a thread causes the thread to stop executing user-mode code." ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-suspendthread" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-suspendthread> .
 
 :Switch a owl:Class ;
     rdfs:label "Switch" ;
@@ -25356,7 +19883,7 @@ About Support Vector Machine (SVM). IBM SPSS Modeler SaaS Documentation. [Link](
         "MAC Bridge",
         "Network Switch",
         "Switching Hub" ;
-    rdfs:subClassOf :NetworkNode ;
+    rdfs:subClassOf :ComputerNetworkNode ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Network_switch> ;
     :definition "A network switch (also called switching hub, bridging hub, and by the IEEE MAC bridge) is networking hardware that connects devices on a computer network by using packet switching to receive and forward data to the destination device. A network switch is a multiport network bridge that uses MAC addresses to forward data at the data link layer (layer 2) of the OSI model. Some switches can also forward data at the network layer (layer 3) by additionally incorporating routing functionality. Such switches are commonly known as layer-3 switches or multilayer switches." .
 
@@ -25417,13 +19944,12 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
 :System a owl:Class ;
     rdfs:label "System" ;
     rdfs:subClassOf :Artifact ;
-    rdfs:isDefinedBy "http://wordnet-rdf.princeton.edu/id/04384144-n" ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/04384144-n> ;
     :definition "An artifact (instrumentality) that combines interrelated interacting artifacts designed to work as a coherent entity.  [Note that not all digital artifacts are systems nor are all systems digital artifacts.]" .
 
 :SystemCall a owl:Class ;
     rdfs:label "System Call" ;
-    rdfs:subClassOf :DigitalEvent,
-        :DigitalInformationBearer,
+    rdfs:subClassOf :DigitalInformationBearer,
         [ a owl:Restriction ;
             owl:onProperty :executes ;
             owl:someValuesFrom :Subroutine ] ;
@@ -25481,6 +20007,14 @@ System calls are analyzed with a variety of methods. Some analytics look for spe
         :Reference-Hardware-assistedSystemAndMethodForDetectingAndAnalyzingSystemCallsMadeToAnOpertingSystemKernel_EndgameInc,
         :Reference-MalwareDetectionInEventLoops_CrowdstrikeInc,
         :Reference-PostSandboxMethodsAndSystemsForDetectingAndBlockingZero-dayExploitsViaApiCallValidation_K2CyberSecurityInc .
+
+:SystemCallEvent a owl:Class ;
+    rdfs:label "System Call Event" ;
+    rdfs:subClassOf :KernelEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :SystemCall ] ;
+    :definition "An event where a user-space process requests a service or resource from the operating system kernel through a system call interface, enabling controlled interactions with hardware or kernel-level operations." .
 
 :SystemCallFiltering a owl:Class,
         owl:NamedIndividual,
@@ -25557,9 +20091,9 @@ Attackers may manipulate system settings or services to disable system logging o
     rdfs:label "System Dependency" ;
     rdfs:subClassOf :Dependency ;
     :definition "A system dependency indicates a system has an activity, agent, or another system which relies on it in order to be functional." ;
-    rdfs:seeAlso "https://dl.acm.org/doi/10.1145/960116.53994",
-        "https://r-docs.synapse.org/articles/systemDependencies.html",
-        "https://www.ibm.com/docs/en/taddm/7.3.0?topic=model-dependencies-between-resources" .
+    rdfs:seeAlso <https://dl.acm.org/doi/10.1145/960116.53994>,
+        <https://r-docs.synapse.org/articles/systemDependencies.html>,
+        <https://www.ibm.com/docs/en/taddm/7.3.0?topic=model-dependencies-between-resources> .
 
 :SystemDependencyMapping a owl:Class,
         owl:NamedIndividual,
@@ -25724,6 +20258,14 @@ When system firmware verification fails a set of predefined responses is typical
         :SystemInitConfiguration ;
     :definition "A system startup directory is a directory containing executable files or links to executable files which are run when the system starts." .
 
+:SystemStateImage a owl:Class ;
+    rdfs:label "System State Image" ;
+    skos:altLabel "System Image" ;
+    rdfs:subClassOf :StorageImage ;
+    rdfs:isDefinedBy <https://en.wikipedia.org/wiki/System_image> ;
+    :definition "In computing, a system image is a serialized copy of the entire state of a computer system stored in some non-volatile form, such as a binary executable file." ;
+    rdfs:seeAlso <https://dbpedia.org/resource/System_Image> .
+
 :SystemTimeApplication a owl:Class ;
     rdfs:label "System Time Application" ;
     rdfs:subClassOf :UtilitySoftware ;
@@ -25771,7 +20313,7 @@ When system firmware verification fails a set of predefined responses is typical
     :definition "Adversaries may use steganographic techniques to hide command and control traffic to make detection efforts more difficult. Steganographic techniques can be used to hide data in digital messages that are transferred between systems. This hidden information can be used for command and control of compromised systems. In some cases, the passing of files embedded using steganography, such as image or document files, can be used for command and control. " .
 
 :T1001.003 a owl:Class ;
-    rdfs:label "Protocol Impersonation" ;
+    rdfs:label "Protocol or Service Impersonation" ;
     rdfs:subClassOf :T1001 ;
     :attack-id "T1001.003" ;
     :definition "Adversaries may impersonate legitimate protocols or web service traffic to disguise command and control activity and thwart analysis efforts. By impersonating legitimate protocols or web services, adversaries can make their command and control traffic blend in with legitimate network traffic.  " .
@@ -26318,6 +20860,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1027.013" ;
     :definition "Adversaries may encrypt or encode files to obfuscate strings, bytes, and other specific patterns to impede detection. Encrypting and/or encoding file content aims to conceal malicious artifacts within a file used in an intrusion. Many other techniques, such as [Software Packing](https://attack.mitre.org/techniques/T1027/002), [Steganography](https://attack.mitre.org/techniques/T1027/003), and [Embedded Payloads](https://attack.mitre.org/techniques/T1027/009), share this same broad objective. Encrypting and/or encoding files could lead to a lapse in detection of static signatures, only for this malicious content to be revealed (i.e., [Deobfuscate/Decode Files or Information](https://attack.mitre.org/techniques/T1140)) at the time of execution/use." .
 
+:T1027.014 a owl:Class ;
+    rdfs:label "Polymorphic Code" ;
+    rdfs:subClassOf :T1027 ;
+    :attack-id "T1027.014" ;
+    :definition "Adversaries may utilize polymorphic code (also known as metamorphic or mutating code) to evade detection. Polymorphic code is a type of software capable of changing its runtime footprint during code execution.(Citation: polymorphic-blackberry) With each execution of the software, the code is mutated into a different version of itself that achieves the same purpose or objective as the original. This functionality enables the malware to evade traditional signature-based defenses, such as antivirus and antimalware tools.(Citation: polymorphic-sentinelone)" .
+
 :T1028 a owl:Class ;
     owl:deprecated true ;
     rdfs:label "Windows Remote Management" ;
@@ -26492,6 +21040,12 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :T1036 ;
     :attack-id "T1036.009" ;
     :definition "An adversary may attempt to evade process tree-based analysis by modifying executed malware's parent process ID (PPID). If endpoint protection software leverages the “parent-child\" relationship for detection, breaking this relationship could result in the adversary’s behavior not being associated with previous process tree activity. On Unix-based systems breaking this process tree is common practice for administrators to execute software using scripts and programs.(Citation: 3OHA double-fork 2022) " .
+
+:T1036.010 a owl:Class ;
+    rdfs:label "Masquerade Account Name" ;
+    rdfs:subClassOf :T1036 ;
+    :attack-id "T1036.010" ;
+    :definition "Adversaries may match or approximate the names of legitimate accounts to make newly created ones appear benign. This will typically occur during [Create Account](https://attack.mitre.org/techniques/T1136), although accounts may also be renamed at a later date. This may also coincide with [Account Access Removal](https://attack.mitre.org/techniques/T1531) if the actor first deletes an account before re-creating one with the same name.(Citation: Huntress MOVEit 2023)" .
 
 :T1037 a owl:Class ;
     rdfs:label "Boot or Logon Initialization Scripts" ;
@@ -27062,6 +21616,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1059.010" ;
     :definition "Adversaries may execute commands and perform malicious tasks using AutoIT and AutoHotKey automation scripts. AutoIT and AutoHotkey (AHK) are scripting languages that enable users to automate Windows tasks. These automation scripts can be used to perform a wide variety of actions, such as clicking on buttons, entering text, and opening and closing programs.(Citation: AutoIT)(Citation: AutoHotKey)" .
 
+:T1059.011 a owl:Class ;
+    rdfs:label "Lua" ;
+    rdfs:subClassOf :T1059 ;
+    :attack-id "T1059.011" ;
+    :definition "Adversaries may abuse Lua commands and scripts for execution. Lua is a cross-platform scripting and programming language primarily designed for embedded use in applications. Lua can be executed on the command-line (through the stand-alone lua interpreter), via scripts (<code>.lua</code>), or from Lua-embedded programs (through the <code>struct lua_State</code>).(Citation: Lua main page)(Citation: Lua state)" .
+
 :T1060 a owl:Class ;
     owl:deprecated true ;
     rdfs:label "Registry Run Keys / Startup Folder" ;
@@ -27252,6 +21812,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1070.009" ;
     :definition "Adversaries may clear artifacts associated with previously established persistence on a host system to remove evidence of their activity. This may involve various actions, such as removing services, deleting executables, [Modify Registry](https://attack.mitre.org/techniques/T1112), [Plist File Modification](https://attack.mitre.org/techniques/T1647), or other methods of cleanup to prevent defenders from collecting evidence of their persistent presence.(Citation: Cylance Dust Storm) Adversaries may also delete accounts previously created to maintain persistence (i.e. [Create Account](https://attack.mitre.org/techniques/T1136)).(Citation: Talos - Cisco Attack 2022)" .
 
+:T1070.010 a owl:Class ;
+    rdfs:label "Relocate Malware" ;
+    rdfs:subClassOf :T1070 ;
+    :attack-id "T1070.010" ;
+    :definition "Once a payload is delivered, adversaries may reproduce copies of the same malware on the victim system to remove evidence of their presence and/or avoid defenses. Copying malware payloads to new locations may also be combined with [File Deletion](https://attack.mitre.org/techniques/T1070/004) to cleanup older artifacts." .
+
 :T1071 a owl:Class ;
     rdfs:label "Application Layer Protocol" ;
     rdfs:subClassOf :CommandAndControlTechnique,
@@ -27303,6 +21869,12 @@ When system firmware verification fails a set of predefined responses is typical
             owl:someValuesFrom :OutboundInternetDNSLookupTraffic ] ;
     :attack-id "T1071.004" ;
     :definition "Adversaries may communicate using the Domain Name System (DNS) application layer protocol to avoid detection/network filtering by blending in with existing traffic. Commands to the remote system, and often the results of those commands, will be embedded within the protocol traffic between the client and server. " .
+
+:T1071.005 a owl:Class ;
+    rdfs:label "Publish/Subscribe Protocols" ;
+    rdfs:subClassOf :T1071 ;
+    :attack-id "T1071.005" ;
+    :definition "Adversaries may communicate using publish/subscribe (pub/sub) application layer protocols to avoid detection/network filtering by blending in with existing traffic. Commands to the remote system, and often the results of those commands, will be embedded within the protocol traffic between the client and server." .
 
 :T1072 a owl:Class ;
     rdfs:label "Software Deployment Tools" ;
@@ -27523,13 +22095,14 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:label "Account Discovery" ;
     rdfs:subClassOf :DiscoveryTechnique ;
     :attack-id "T1087" ;
-    :definition "Adversaries may attempt to get a listing of valid accounts, usernames, or email addresses on a system or within a compromised environment. This information can help adversaries determine which accounts exist, which can aid in follow-on behavior such as brute-forcing, spear-phishing attacks, or account takeovers (e.g., [Valid Accounts](https://attack.mitre.org/techniques/T1078))." .
+    :definition "Adversaries may attempt to get a listing of valid accounts, usernames, or email addresses on a system or within a compromised environment. This information can help adversaries determine which accounts exist, which can aid in follow-on behavior such as brute-forcing, spear-phishing attacks, or account takeovers (e.g., [Valid Accounts](https://attack.mitre.org/techniques/T1078))." ;
+    rdfs:seeAlso :T1136 .
 
 :T1087.001 a owl:Class ;
     rdfs:label "Local Account" ;
-    rdfs:subClassOf :T1136,
+    rdfs:subClassOf :T1087,
         [ a owl:Restriction ;
-            owl:onProperty :creates ;
+            owl:onProperty :enumerates ;
             owl:someValuesFrom :LocalUserAccount ] ;
     :attack-id "T1087.001" ;
     :definition "Adversaries may attempt to get a listing of local system accounts. This information can help adversaries determine which local accounts exist on a system to aid in follow-on behavior." ;
@@ -27537,9 +22110,9 @@ When system firmware verification fails a set of predefined responses is typical
 
 :T1087.002 a owl:Class ;
     rdfs:label "Domain Account" ;
-    rdfs:subClassOf :T1136,
+    rdfs:subClassOf :T1087,
         [ a owl:Restriction ;
-            owl:onProperty :creates ;
+            owl:onProperty :enumerates ;
             owl:someValuesFrom :DomainUserAccount ] ;
     :attack-id "T1087.002" ;
     :definition "Adversaries may attempt to get a listing of domain accounts. This information can help adversaries determine which domain accounts exist to aid in follow-on behavior such as targeting specific accounts which possess particular privileges." .
@@ -27552,9 +22125,9 @@ When system firmware verification fails a set of predefined responses is typical
 
 :T1087.004 a owl:Class ;
     rdfs:label "Cloud Account" ;
-    rdfs:subClassOf :T1136,
+    rdfs:subClassOf :T1087,
         [ a owl:Restriction ;
-            owl:onProperty :creates ;
+            owl:onProperty :enumerates ;
             owl:someValuesFrom :CloudUserAccount ] ;
     :attack-id "T1087.004" ;
     :definition "Adversaries may attempt to get a listing of cloud accounts. Cloud accounts are those created and configured by an organization for use by users, remote support, services, or for administration of resources within a cloud service provider or SaaS application." .
@@ -27740,6 +22313,12 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :T1098 ;
     :attack-id "T1098.006" ;
     :definition "An adversary may add additional roles or permissions to an adversary-controlled user or service account to maintain persistent access to a container orchestration system. For example, an adversary with sufficient permissions may create a RoleBinding or a ClusterRoleBinding to bind a Role or ClusterRole to a Kubernetes account.(Citation: Kubernetes RBAC)(Citation: Aquasec Kubernetes Attack 2023) Where attribute-based access control (ABAC) is in use, an adversary with sufficient permissions may modify a Kubernetes ABAC policy to give the target account additional permissions.(Citation: Kuberentes ABAC)" .
+
+:T1098.007 a owl:Class ;
+    rdfs:label "Additional Local or Domain Groups" ;
+    rdfs:subClassOf :T1098 ;
+    :attack-id "T1098.007" ;
+    :definition "An adversary may add additional local or domain groups to an adversary-controlled account to maintain persistent access to a system or domain." .
 
 :T1099 a owl:Class ;
     owl:deprecated true ;
@@ -28121,6 +22700,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1127.001" ;
     :definition "Adversaries may use MSBuild to proxy execution of code through a trusted Windows utility. MSBuild.exe (Microsoft Build Engine) is a software build platform used by Visual Studio. It handles XML formatted project files that define requirements for loading and building various platforms and configurations.(Citation: MSDN MSBuild)" .
 
+:T1127.002 a owl:Class ;
+    rdfs:label "ClickOnce" ;
+    rdfs:subClassOf :T1127 ;
+    :attack-id "T1127.002" ;
+    :definition "Adversaries may use ClickOnce applications (.appref-ms and .application files) to proxy execution of code through a trusted Windows utility.(Citation: Burke/CISA ClickOnce BlackHat) ClickOnce is a deployment that enables a user to create self-updating Windows-based .NET applications (i.e, .XBAP, .EXE, or .DLL) that install and run from a file share or web page with minimal user interaction. The application launches as a child process of DFSVC.EXE, which is responsible for installing, launching, and updating the application.(Citation: SpectorOps Medium ClickOnce)" .
+
 :T1128 a owl:Class ;
     owl:deprecated true ;
     rdfs:label "Netsh Helper DLL" ;
@@ -28199,8 +22784,7 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1134" ;
     :definition "Adversaries may modify access tokens to operate under a different user or system security context to perform actions and bypass access controls. Windows uses access tokens to determine the ownership of a running process. A user can manipulate access tokens to make a running process appear as though it is the child of a different process or belongs to someone other than the user that started the process. When this occurs, the process also takes on the security context associated with the new token." .
 
-:T1134.001 a :AccessToken,
-        owl:Class,
+:T1134.001 a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Token Impersonation/Theft" ;
     rdfs:subClassOf :T1134,
@@ -28264,7 +22848,6 @@ When system firmware verification fails a set of predefined responses is typical
 :T1136 a owl:Class ;
     rdfs:label "Create Account" ;
     rdfs:subClassOf :PersistenceTechnique,
-        :PrivilegeEscalationTechnique,
         [ a owl:Restriction ;
             owl:onProperty :creates ;
             owl:someValuesFrom :UserAccount ] ;
@@ -28273,19 +22856,28 @@ When system firmware verification fails a set of predefined responses is typical
 
 :T1136.001 a owl:Class ;
     rdfs:label "Local Account" ;
-    rdfs:subClassOf :T1136 ;
+    rdfs:subClassOf :T1136,
+        [ a owl:Restriction ;
+            owl:onProperty :creates ;
+            owl:someValuesFrom :LocalUserAccount ] ;
     :attack-id "T1136.001" ;
     :definition "Adversaries may create a local account to maintain access to victim systems. Local accounts are those configured by an organization for use by users, remote support, services, or for administration on a single system or service. " .
 
 :T1136.002 a owl:Class ;
     rdfs:label "Domain Account" ;
-    rdfs:subClassOf :T1136 ;
+    rdfs:subClassOf :T1136,
+        [ a owl:Restriction ;
+            owl:onProperty :creates ;
+            owl:someValuesFrom :DomainUserAccount ] ;
     :attack-id "T1136.002" ;
     :definition "Adversaries may create a domain account to maintain access to victim systems. Domain accounts are those managed by Active Directory Domain Services where access and permissions are configured across systems and services that are part of that domain. Domain accounts can cover user, administrator, and service accounts. With a sufficient level of access, the <code>net user /add /domain</code> command can be used to create a domain account.(Citation: Savill 1999)" .
 
 :T1136.003 a owl:Class ;
     rdfs:label "Cloud Account" ;
-    rdfs:subClassOf :T1136 ;
+    rdfs:subClassOf :T1136,
+        [ a owl:Restriction ;
+            owl:onProperty :creates ;
+            owl:someValuesFrom :CloudUserAccount ] ;
     :attack-id "T1136.003" ;
     :definition "Adversaries may create a cloud account to maintain access to victim systems. With a sufficient level of access, such accounts may be used to establish secondary credentialed access that does not require persistent remote access tools to be deployed on the system.(Citation: Microsoft O365 Admin Roles)(Citation: Microsoft Support O365 Add Another Admin, October 2019)(Citation: AWS Create IAM User)(Citation: GCP Create Cloud Identity Users)(Citation: Microsoft Azure AD Users)" .
 
@@ -29081,7 +23673,7 @@ When system firmware verification fails a set of predefined responses is typical
             owl:onProperty :produces ;
             owl:someValuesFrom :NetworkTraffic ] ;
     :attack-id "T1205" ;
-    :definition "used all over so its not just internet traffic" .
+    :definition "Adversaries use traffic signaling techniques, such as sending specific network sequences or magic packets, to covertly trigger actions like opening ports, activating backdoors, or installing filters, facilitating command and control, persistence, and defense evasion." .
 
 :T1205.001 a owl:Class ;
     rdfs:label "Port Knocking" ;
@@ -29221,6 +23813,18 @@ When system firmware verification fails a set of predefined responses is typical
             owl:someValuesFrom :CodeRepository ] ;
     :attack-id "T1213.003" ;
     :definition "Adversaries may leverage code repositories to collect valuable information. Code repositories are tools/services that store source code and automate software builds. They may be hosted internally or privately on third party sites such as Github, GitLab, SourceForge, and BitBucket. Users typically interact with code repositories through a web application or command-line utilities such as git." .
+
+:T1213.004 a owl:Class ;
+    rdfs:label "Customer Relationship Management Software" ;
+    rdfs:subClassOf :T1213 ;
+    :attack-id "T1213.004" ;
+    :definition "Adversaries may leverage Customer Relationship Management (CRM) software to mine valuable information. CRM software is used to assist organizations in tracking and managing customer interactions, as well as storing customer data." .
+
+:T1213.005 a owl:Class ;
+    rdfs:label "Messaging Applications" ;
+    rdfs:subClassOf :T1213 ;
+    :attack-id "T1213.005" ;
+    :definition "Adversaries may leverage chat and messaging applications, such as Microsoft Teams, Google Chat, and Slack, to mine valuable information." .
 
 :T1214 a owl:Class ;
     owl:deprecated true ;
@@ -29477,6 +24081,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1480.001" ;
     :definition "Adversaries may environmentally key payloads or other features of malware to evade defenses and constraint execution to a specific target environment. Environmental keying uses cryptography to constrain execution or actions based on adversary supplied environment specific conditions that are expected to be present on the target. Environmental keying is an implementation of [Execution Guardrails](https://attack.mitre.org/techniques/T1480) that utilizes cryptographic techniques for deriving encryption/decryption keys from specific types of values in a given computing environment.(Citation: EK Clueless Agents)" .
 
+:T1480.002 a owl:Class ;
+    rdfs:label "Mutual Exclusion" ;
+    rdfs:subClassOf :T1480 ;
+    :attack-id "T1480.002" ;
+    :definition "Adversaries may constrain execution or actions based on the presence of a mutex associated with malware. A mutex is a locking mechanism used to synchronize access to a resource. Only one thread or process can acquire a mutex at a given time.(Citation: Microsoft Mutexes)" .
+
 :T1482 a owl:Class ;
     rdfs:label "Domain Trust Discovery" ;
     rdfs:subClassOf :DiscoveryTechnique ;
@@ -29519,6 +24129,12 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :ImpactTechnique ;
     :attack-id "T1485" ;
     :definition "Adversaries may destroy data and files on specific systems or in large numbers on a network to interrupt availability to systems, services, and network resources. Data destruction is likely to render stored data irrecoverable by forensic techniques through overwriting files or data on local and remote drives.(Citation: Symantec Shamoon 2012)(Citation: FireEye Shamoon Nov 2016)(Citation: Palo Alto Shamoon Nov 2016)(Citation: Kaspersky StoneDrill 2017)(Citation: Unit 42 Shamoon3 2018)(Citation: Talos Olympic Destroyer 2018) Common operating system file deletion commands such as <code>del</code> and <code>rm</code> often only remove pointers to files without wiping the contents of the files themselves, making the files recoverable by proper forensic methodology. This behavior is distinct from [Disk Content Wipe](https://attack.mitre.org/techniques/T1561/001) and [Disk Structure Wipe](https://attack.mitre.org/techniques/T1561/002) because individual files are destroyed rather than sections of a storage disk or the disk's logical structure." .
+
+:T1485.001 a owl:Class ;
+    rdfs:label "Lifecycle-Triggered Deletion" ;
+    rdfs:subClassOf :T1485 ;
+    :attack-id "T1485.001" ;
+    :definition "Adversaries may modify the lifecycle policies of a cloud storage bucket to destroy all objects stored within." .
 
 :T1486 a owl:Class ;
     rdfs:label "Data Encrypted for Impact" ;
@@ -29618,6 +24234,30 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :ImpactTechnique ;
     :attack-id "T1496" ;
     :definition "Adversaries may leverage the resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. " .
+
+:T1496.001 a owl:Class ;
+    rdfs:label "Compute Hijacking" ;
+    rdfs:subClassOf :T1496 ;
+    :attack-id "T1496.001" ;
+    :definition "Adversaries may leverage the compute resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability." .
+
+:T1496.002 a owl:Class ;
+    rdfs:label "Bandwidth Hijacking" ;
+    rdfs:subClassOf :T1496 ;
+    :attack-id "T1496.002" ;
+    :definition "Adversaries may leverage the network bandwidth resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability." .
+
+:T1496.003 a owl:Class ;
+    rdfs:label "SMS Pumping" ;
+    rdfs:subClassOf :T1496 ;
+    :attack-id "T1496.003" ;
+    :definition "Adversaries may leverage messaging services for SMS pumping, which may impact system and/or hosted service availability.(Citation: Twilio SMS Pumping) SMS pumping is a type of telecommunications fraud whereby a threat actor first obtains a set of phone numbers from a telecommunications provider, then leverages a victim’s messaging infrastructure to send large amounts of SMS messages to numbers in that set. By generating SMS traffic to their phone number set, a threat actor may earn payments from the telecommunications provider.(Citation: Twilio SMS Pumping Fraud)" .
+
+:T1496.004 a owl:Class ;
+    rdfs:label "Cloud Service Hijacking" ;
+    rdfs:subClassOf :T1496 ;
+    :attack-id "T1496.004" ;
+    :definition "Adversaries may leverage compromised software-as-a-service (SaaS) applications to complete resource-intensive tasks, which may impact hosted service availability." .
 
 :T1497 a owl:Class ;
     rdfs:label "Virtualization/Sandbox Evasion" ;
@@ -30292,6 +24932,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1546.016" ;
     :definition "Adversaries may establish persistence and elevate privileges by using an installer to trigger the execution of malicious content. Installer packages are OS specific and contain the resources an operating system needs to install applications on a system. Installer packages can include scripts that run prior to installation as well as after installation is complete. Installer scripts may inherit elevated permissions when executed. Developers often use these scripts to prepare the environment for installation, check requirements, download dependencies, and remove files after installation.(Citation: Installer Package Scripting Rich Trouton)" .
 
+:T1546.017 a owl:Class ;
+    rdfs:label "Udev Rules" ;
+    rdfs:subClassOf :T1546 ;
+    :attack-id "T1546.017" ;
+    :definition "Adversaries may maintain persistence through executing malicious content triggered using udev rules. Udev is the Linux kernel device manager that dynamically manages device nodes, handles access to pseudo-device files in the `/dev` directory, and responds to hardware events, such as when external devices like hard drives or keyboards are plugged in or removed. Udev uses rule files with `match keys` to specify the conditions a hardware event must meet and `action keys` to define the actions that should follow. Root permissions are required to create, modify, or delete rule files located in `/etc/udev/rules.d/`, `/run/udev/rules.d/`, `/usr/lib/udev/rules.d/`, `/usr/local/lib/udev/rules.d/`, and `/lib/udev/rules.d/`. Rule priority is determined by both directory and by the digit prefix in the rule filename.(Citation: Ignacio Udev research 2024)(Citation: Elastic Linux Persistence 2024)" .
+
 :T1547 a owl:Class ;
     rdfs:label "Boot or Logon Autostart Execution" ;
     rdfs:subClassOf :PersistenceTechnique,
@@ -30868,6 +25514,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1557.003" ;
     :definition "Adversaries may redirect network traffic to adversary-owned systems by spoofing Dynamic Host Configuration Protocol (DHCP) traffic and acting as a malicious DHCP server on the victim network. By achieving the adversary-in-the-middle (AiTM) position, adversaries may collect network communications, including passed credentials, especially those sent over insecure, unencrypted protocols. This may also enable follow-on behaviors such as [Network Sniffing](https://attack.mitre.org/techniques/T1040) or [Transmitted Data Manipulation](https://attack.mitre.org/techniques/T1565/002)." .
 
+:T1557.004 a owl:Class ;
+    rdfs:label "Evil Twin" ;
+    rdfs:subClassOf :T1557 ;
+    :attack-id "T1557.004" ;
+    :definition "Adversaries may host seemingly genuine Wi-Fi access points to deceive users into connecting to malicious networks as a way of supporting follow-on behaviors such as [Network Sniffing](https://attack.mitre.org/techniques/T1040), [Transmitted Data Manipulation](https://attack.mitre.org/techniques/T1565/002), or [Input Capture](https://attack.mitre.org/techniques/T1056).(Citation: Australia ‘Evil Twin’)" .
+
 :T1558 a owl:Class ;
     rdfs:label "Steal or Forge Kerberos Tickets" ;
     rdfs:subClassOf :CredentialAccessTechnique,
@@ -30910,6 +25562,12 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:subClassOf :T1558 ;
     :attack-id "T1558.004" ;
     :definition "Adversaries may reveal credentials of accounts that have disabled Kerberos preauthentication by [Password Cracking](https://attack.mitre.org/techniques/T1110/002) Kerberos messages.(Citation: Harmj0y Roasting AS-REPs Jan 2017) " .
+
+:T1558.005 a owl:Class ;
+    rdfs:label "Ccache Files" ;
+    rdfs:subClassOf :T1558 ;
+    :attack-id "T1558.005" ;
+    :definition "Adversaries may attempt to steal Kerberos tickets stored in credential cache files (or ccache). These files are used for short term storage of a user's active session credentials. The ccache file is created upon user authentication and allows for access to multiple services without the user having to re-enter credentials." .
 
 :T1559 a owl:Class ;
     rdfs:label "Inter-Process Communication" ;
@@ -32468,6 +27126,12 @@ When system firmware verification fails a set of predefined responses is typical
     :attack-id "T1665" ;
     :definition "Adversaries may manipulate network traffic in order to hide and evade detection of their C2 infrastructure. This can be accomplished in various ways including by identifying and filtering traffic from defensive tools,(Citation: TA571) masking malicious domains to obfuscate the true destination from both automated scanning tools and security researchers,(Citation: Schema-abuse)(Citation: Facad1ng)(Citation: Browser-updates) and otherwise hiding malicious artifacts to delay discovery and prolong the effectiveness of adversary infrastructure that could otherwise be identified, blocked, or taken down entirely." .
 
+:T1666 a owl:Class ;
+    rdfs:label "Modify Cloud Resource Hierarchy" ;
+    rdfs:subClassOf :DefenseEvasionTechnique ;
+    :attack-id "T1666" ;
+    :definition "Adversaries may attempt to modify hierarchical structures in infrastructure-as-a-service (IaaS) environments in order to evade defenses." .
+
 :t-SNEClustering a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "t-SNE Clustering" ;
@@ -32594,18 +27258,20 @@ Wikipedia. (n.d.). T-distributed stochastic neighbor embedding. [Link](https://e
 
 :TargetAudience a owl:Class ;
     rdfs:label "Target Audience" ;
-    rdfs:subClassOf :D3FENDUseCaseThing .
+    rdfs:subClassOf :AgentGroup .
+
+:TCPEvent a owl:Class ;
+    rdfs:label "TCP Event" ;
+    rdfs:subClassOf :TransportLayerEvent ;
+    :definition "An event involving the Transmission Control Protocol (TCP), providing reliable, ordered, and error-checked delivery of data between applications." .
 
 :Technique a owl:Class ;
     rdfs:label "Technique" ;
-    rdfs:subClassOf :D3FENDThing,
-        [ a owl:Restriction ;
-            owl:onProperty :implemented-by ;
-            owl:someValuesFrom :Procedure ] .
+    rdfs:subClassOf :Plan .
 
 :TechniqueReference a owl:Class ;
     rdfs:label "Technique Reference" ;
-    rdfs:subClassOf :D3FENDThing,
+    rdfs:subClassOf :D3FENDKBThing,
         [ a owl:Restriction ;
             owl:onProperty :has-link ;
             owl:someValuesFrom xsd:anyURI ],
@@ -32651,7 +27317,7 @@ Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/T
     rdfs:subClassOf :HardwareDevice,
         :MemoryBlock,
         :SecondaryStorage ;
-    rdfs:isDefinedBy "https://en.wikipedia.org/wiki/Computer_data_storage#Tertiary_storage" ;
+    rdfs:isDefinedBy <https://en.wikipedia.org/wiki/Computer_data_storage#Tertiary_storage> ;
     :definition "Tertiary storage or tertiary memory is memory primarily used for archiving rarely accessed information. It is primarily useful for extraordinarily large data stores. Typical examples include tape libraries and optical jukeboxes." .
 
 :TestExecutionTool a owl:Class ;
@@ -32795,9 +27461,9 @@ DMARC is an email policy and authentication protocol that seeks to ensure that t
     :definition "Transfer learning (TL) is a research problem in machine learning (ML) that focuses on storing knowledge gained while solving one problem and applying it to a different but related problem." ;
     :kb-article """## References
 Transfer learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Transfer_learning).""" ;
-    rdfs:seeAlso "https://arxiv.org/abs/1808.01974",
-        "https://arxiv.org/abs/1911.02685",
-        "https://journalofbigdata.springeropen.com/articles/10.1186/s40537-016-0043-6" .
+    rdfs:seeAlso <https://arxiv.org/abs/1808.01974>,
+        <https://arxiv.org/abs/1911.02685>,
+        <https://journalofbigdata.springeropen.com/articles/10.1186/s40537-016-0043-6> .
 
 :Transformer-basedLearning a owl:Class,
         owl:NamedIndividual ;
@@ -32820,8 +27486,13 @@ Transformer-XL. (n.d.). Papers with Code. [Link](https://paperswithcode.com/meth
 :TranslationLookasideBuffer a owl:Class ;
     rdfs:label "Translation Lookaside Buffer" ;
     rdfs:subClassOf :MemoryManagementUnitComponent ;
-    rdfs:isDefinedBy "https://dbpedia.org/page/Translation_lookaside_buffer" ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Translation_lookaside_buffer> ;
     :definition "A translation lookaside buffer (TLB) is a memory cache that is used to reduce the time taken to access a user memory location. It is a part of the chip's memory-management unit (MMU)." .
+
+:TransportLayerEvent a owl:Class ;
+    rdfs:label "Transport Layer Event" ;
+    rdfs:subClassOf :NetworkEvent ;
+    :definition "An event occurring at the transport layer, responsible for end-to-end communication and data transfer management." .
 
 :TransportLink a owl:Class ;
     rdfs:label "Transport Link" ;
@@ -32837,6 +27508,26 @@ Transformer-XL. (n.d.). Papers with Code. [Link](https://paperswithcode.com/meth
 Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Central_tendency)""" ;
     :synonym "Truncated mean" .
 
+:TrustedLibrary a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Trusted Library" ;
+    rdfs:subClassOf :SourceCodeHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :Subroutine ] ;
+    :d3fend-id "D3-TL" ;
+    :definition """A trusted library is a collection of pre-verified and secure code modules or components that are used within software applications to perform specific functions. These libraries are considered reliable and have been vetted for security vulnerabilities, ensuring they do not introduce risks into the application.
+""" ;
+    :kb-article """## How it Works
+Using a trusted library can reduce the chances of introducing errors compared to writing code from scratch.
+
+
+
+## Considerations
+
+Note: This resource should not be considered a definitive or exhaustive coding guideline.""" ;
+    :kb-reference :Reference-LeverageSecurityFrameworksLibraries_OWASP .
+
 :TrustStore a owl:Class ;
     rdfs:label "Trust Store" ;
     rdfs:subClassOf :DigitalInformationBearer ;
@@ -32844,6 +27535,31 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:seeAlso <http://dbpedia.org/resource/Public_key_certificate>,
         <https://www.educative.io/edpresso/keystore-vs-truststore> ;
     :todo "Not sure in practice we need this abstraction... what is the trust store that is not a certificate trust store?  Or was it to distinguish between standard CA PKI truststores and other non-SSL schemes?" .
+
+:TunnelCloseEvent a owl:Class ;
+    rdfs:label "Tunnel Close Event" ;
+    rdfs:subClassOf :TunnelEvent ;
+    :definition "An event where a network tunnel is terminated, ending encapsulated communication and releasing the associated resources." .
+
+:TunnelEvent a owl:Class ;
+    rdfs:label "Tunnel Event" ;
+    rdfs:subClassOf :NetworkEvent ;
+    :definition "An event involving the establishment, usage, or termination of a network tunnel. Tunnels provide encapsulated communication pathways across various layers, enabling secure, isolated, or virtualized transport of data." .
+
+:TunnelOpenEvent a owl:Class ;
+    rdfs:label "Tunnel Open Event" ;
+    rdfs:subClassOf :TunnelEvent ;
+    :definition "An event where a network tunnel is established, enabling encapsulated communication between endpoints. This marks the initiation of secure or isolated data transport through the tunnel." .
+
+:TunnelRenewEvent a owl:Class ;
+    rdfs:label "Tunnel Renew Event" ;
+    rdfs:subClassOf :TunnelEvent ;
+    :definition "An event where the lifecycle of a network tunnel is extended, ensuring continued encapsulated communication and avoiding session expiration." .
+
+:UDPEvent a owl:Class ;
+    rdfs:label "UDP Event" ;
+    rdfs:subClassOf :TransportLayerEvent ;
+    :definition "An event involving the User Datagram Protocol (UDP), providing a connectionless datagram service with minimal protocol mechanisms." .
 
 :UncertaintySampling a owl:Class,
         owl:NamedIndividual ;
@@ -32872,7 +27588,16 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :FileSystemLink ;
     :definition "A Unix link is a file link in a Unix file system." .
 
+:UnloadLibraryEvent a owl:Class ;
+    rdfs:label "Unload Library Event" ;
+    rdfs:subClassOf :ProcessEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :SharedLibraryFile ] ;
+    :definition "An event where a process unloads a dynamically linked library or module, reducing its memory footprint or functionality." .
+
 :UnloadModule a owl:Class ;
+    rdfs:label "Unload Module" ;
     rdfs:subClassOf :SystemCall,
         [ a owl:Restriction ;
             owl:onProperty :unloads ;
@@ -32921,7 +27646,7 @@ SAS Institute Inc. (n.d.). Decision Trees. In SAS® Visual Data Mining and Machi
             owl:someValuesFrom :Resource ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Uniform_Resource_Locator> ;
     :definition "A Uniform Resource Locator (URL), commonly informally termed a web address (a term which is not defined identically) is a reference to a web resource that specifies its location on a computer network and a mechanism for retrieving it.A URL is a specific type of Uniform Resource Identifier (URI), although many people use the two terms interchangeably. A URL implies the means to access an indicated resource, which is not true of every URI. URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/url" .
+    rdfs:seeAlso <https://schema.ocsf.io/objects/url> .
 
 :URLAnalysis a owl:Class,
         owl:NamedIndividual,
@@ -32975,27 +27700,30 @@ URL analysis may trigger follow-on analytics such as **File Analysis**
     :definition "Analyzing the reputation of a URL." ;
     :kb-reference :Reference-Finding_phishing_sites .
 
+:UseCase a owl:Class ;
+    rdfs:label "Use Case" ;
+    rdfs:subClassOf :D3FENDKBThing .
+
 :UseCaseGoal a owl:Class ;
     rdfs:label "Use Case Goal" ;
-    rdfs:subClassOf :D3FENDUseCaseThing .
+    rdfs:subClassOf :Goal .
 
 :UseCasePrerequisite a owl:Class ;
     rdfs:label "Use Case Prerequisite" ;
-    rdfs:subClassOf :D3FENDUseCaseThing .
+    rdfs:subClassOf :Condition .
 
 :UseCaseProcedure a owl:Class ;
     rdfs:label "Use Case Procedure" ;
-    rdfs:subClassOf :D3FENDUseCaseThing,
-        :Procedure .
+    rdfs:subClassOf :Procedure .
 
 :UseCaseStep a owl:Class ;
     rdfs:label "Use Case Step" ;
-    rdfs:subClassOf :D3FENDUseCaseThing,
-        :Step .
+    rdfs:subClassOf :Step .
 
 :User a owl:Class ;
     rdfs:label "User" ;
-    rdfs:subClassOf :DigitalInformationBearer,
+    rdfs:subClassOf :Agent,
+        :DigitalInformationBearer,
         [ a owl:Restriction ;
             owl:onProperty :has-account ;
             owl:someValuesFrom :UserAccount ],
@@ -33004,16 +27732,81 @@ URL analysis may trigger follow-on analytics such as **File Analysis**
             owl:someValuesFrom :AccessControlList ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/User_(computing)> ;
     :definition "A user is a person [or agent] who uses a computer or network service. Users generally use a system or a software product without the technical expertise required to fully understand it. Power users use advanced features of programs, though they are not necessarily capable of computer programming and system administration. A user often has a user account and is identified to the system by a username (or user name). Other terms for username include login name, screenname (or screen name), nickname (or nick) and handle, which is derived from the identical Citizen's Band radio term. Some software products provide services to other systems and have no direct end users." ;
-    rdfs:seeAlso "UserAccount",
-        <http://wordnet-rdf.princeton.edu/id/10761247-n> .
+    rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/10761247-n>,
+        :UserAccount .
 
-:UserAccount a owl:Class ;
+:UserAccount a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "User Account" ;
     rdfs:subClassOf :DigitalInformationBearer ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/User_(computing)#User_account> ;
     :definition "A user account allows a user to authenticate to a system and potentially to receive authorization to access resources provided by or connected to that system; however, authentication does not imply authorization. To log into an account, a user is typically required to authenticate oneself with a password or other credentials for the purposes of accounting, security, logging, and resource management." ;
-    rdfs:seeAlso "https://schema.ocsf.io/objects/user",
-        <http://dbpedia.org/resource/User_account> .
+    rdfs:seeAlso <http://dbpedia.org/resource/User_account>,
+        <https://schema.ocsf.io/objects/user> .
+
+:UserAccountAttachPolicyEvent a owl:Class ;
+    rdfs:label "User Account Attach Policy Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where an IAM policy is attached to a user account." .
+
+:UserAccountCreationEvent a owl:Class ;
+    rdfs:label "User Account Creation Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event representing the creation of a new user account within a system or domain." .
+
+:UserAccountDeletionEvent a owl:Class ;
+    rdfs:label "User Account Deletion Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event representing the permanent deletion of a user account from a system or domain." .
+
+:UserAccountDetachPolicyEvent a owl:Class ;
+    rdfs:label "User Account Detach Policy Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where an IAM policy is detached from a user account." .
+
+:UserAccountDisableEvent a owl:Class ;
+    rdfs:label "User Account Disable Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where a user account is disabled, preventing its active use within the system." .
+
+:UserAccountEnableEvent a owl:Class ;
+    rdfs:label "User Account Enable Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where a user account is enabled, granting it active use within the system." .
+
+:UserAccountEvent a owl:Class ;
+    rdfs:label "User Account Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :UserAccount ] ;
+    :definition "An event capturing operations or state changes performed on user accounts, including lifecycle management, access control modifications, and policy assignments." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/account_change> .
+
+:UserAccountLockEvent a owl:Class ;
+    rdfs:label "User Account Lock Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where a user account is locked out due to failed authentication attempts or administrative action." .
+
+:UserAccountMFADisableEvent a owl:Class ;
+    rdfs:label "User Account MFA Disable Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where multi-factor authentication (MFA) is disabled for a user account." .
+
+:UserAccountMFAEnableEvent a owl:Class ;
+    rdfs:label "User Account MFA Enable Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where multi-factor authentication (MFA) is enabled for a user account." .
+
+:UserAccountPasswordChangeEvent a owl:Class ;
+    rdfs:label "User Account Password Change Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where a user account's password is modified, typically by the user or an administrator." .
+
+:UserAccountPasswordResetEvent a owl:Class ;
+    rdfs:label "User Account Password Reset Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event where a user account's password is reset, typically due to a forgotten password or administrative action." .
 
 :UserAccountPermissions a owl:Class,
         owl:NamedIndividual,
@@ -33027,10 +27820,17 @@ URL analysis may trigger follow-on analytics such as **File Analysis**
     :definition "Restricting a user account's access to resources." ;
     :kb-reference :Reference-ConfigureUserAccessControlAndPermissions .
 
+:UserAccountUpdateEvent a owl:Class ;
+    rdfs:label "User Account Update Event" ;
+    rdfs:subClassOf :UserAccountEvent ;
+    :definition "An event capturing updates to a user account, including changes to its attributes or configuration." .
+
 :UserAction a owl:Class ;
     rdfs:label "User Action" ;
-    rdfs:subClassOf :DigitalEvent,
-        :DigitalInformationBearer ;
+    rdfs:subClassOf :DigitalInformationBearer,
+        [ a owl:Restriction ;
+            owl:onProperty :records ;
+            owl:someValuesFrom :Action ] ;
     :definition "An action performed by a user. Executing commands, granting permissions, and accessing resources are examples of user actions." .
 
 :UserApplication a owl:Class ;
@@ -33111,7 +27911,8 @@ Geolocation data for each user logon attempt is collected and used to create a b
     :kb-reference <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-System,Method,AndComputerProgramProductForDetectingAndAssessingSecurityRisksInANetwork_ExabeamInc>,
         :Reference-MethodAndApparatusForNetworkFraudDetectionAndRemediationThroughAnalytics_IdaptiveLLC .
 
-:UserGroup a owl:Class ;
+:UserGroup a owl:Class,
+        owl:NamedIndividual ;
     rdfs:label "User Group" ;
     rdfs:subClassOf :AccessControlGroup,
         [ a owl:Restriction ;
@@ -33151,9 +27952,7 @@ Geolocation data for each user logon attempt is collected and used to create a b
     rdfs:subClassOf :LocalResource ;
     :definition "A user logon initialization resource contains information used to configure a user's environment when a user logs into a system." .
 
-:UserManual a owl:Class,
-        owl:NamedIndividual,
-        :ReferenceType ;
+:UserManual a owl:Class ;
     rdfs:label "User Manual" ;
     rdfs:subClassOf :Document .
 
@@ -33166,6 +27965,13 @@ Geolocation data for each user logon attempt is collected and used to create a b
     rdfs:label "User Process" ;
     rdfs:subClassOf :Process ;
     :definition "A user process is a process running to perform functions in the name of on particular user and user account, such as run an application or application service serving any number users.  This is in contrast to a system process, which executes software to fulfill operating system functions." .
+
+:UserProfile a owl:Class ;
+    rdfs:label "User Profile" ;
+    rdfs:subClassOf :DigitalInformationBearer ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/User_profile> ;
+    :definition "A user profile is a collection of settings and information associated with a user. It contains critical information that is used to identify an individual, such as their name, age, portrait photograph and individual characteristics such as knowledge or expertise. " ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/User_profile> .
 
 :UserSessionInitConfigAnalysis a owl:Class,
         owl:NamedIndividual,
@@ -33231,6 +28037,42 @@ Geolocation data for each user logon attempt is collected and used to create a b
 Wikipedia. (n.d.). Statistical dispersion. [Link](https://en.wikipedia.org/wiki/Statistical_dispersion)""" ;
     :todo "Name should maybe be thought about as dispersion may be more descriptive or intuitive. Perhaps dispersion measure" .
 
+:VariableInitialization a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Variable Initialization" ;
+    rdfs:subClassOf :SourceCodeHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :Subroutine ] ;
+    :d3fend-id "D3-VI" ;
+    :definition "Setting variables to a known value before use." ;
+    :kb-article """## How it Works
+Initializing variables upon declaration ensures that the variable has a known quantity before use.
+
+## Considerations
+* Default behavior when declaring variables varies by language.
+* This is particularly important in programming languages that do not initialize variables to a default value upon declaration. In these instances, the value that a variable will contain after declaration is indeterminate which can cause issues. In fact, that value could be different each time the program is ran.
+* Note: This resource should not be considered a definitive or exhaustive coding guideline.""" ;
+    :kb-reference :Reference-CManualIntegerInitialization_GNU,
+        :Reference-VariableInitialization_CWE .
+
+:VariableTypeValidation a owl:Class ;
+    rdfs:label "Variable Type Validation" ;
+    rdfs:subClassOf :SourceCodeHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :PointerDereferencingFunction ] ;
+    :d3fend-id "D3-VTV" ;
+    :definition "Ensuring that a variable has the correct type." ;
+    :kb-article """## How it Works
+A developer should consider how the variable will be used throughout the program and choose the correct variable type.
+A developer should programmatically check if a variable has the correct (expected) type before using that variable.
+
+## Considerations
+* The result of an operation on an unexpected variable type will vary based on the language.
+* Note: This resource should not be considered a definitive or exhaustive coding guideline.""" ;
+    :kb-reference :Reference-TypeSystems_Princeton .
+
 :Variance a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Variance" ;
@@ -33274,10 +28116,10 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
 :VirtualAddress a owl:Class ;
     rdfs:label "Virtual Address" ;
     rdfs:subClassOf :MemoryAddress ;
-    rdfs:isDefinedBy "https://www.techopedia.com/definition/9934/virtual-address-va" ;
+    rdfs:isDefinedBy <https://www.techopedia.com/definition/9934/virtual-address-va> ;
     :definition "A virtual address in memory is a pointer or marker for a memory space that an operating system allows a process to use. The virtual address points to a location in primary storage that a process can use independently of other processes." ;
-    rdfs:seeAlso "https://dbpedia.org/page/Virtual_address_space",
-        "https://en.wikipedia.org/wiki/Memory_address#Logical_addresses" ;
+    rdfs:seeAlso <https://dbpedia.org/page/Virtual_address_space>,
+        <https://en.wikipedia.org/wiki/Memory_address#Logical_addresses> ;
     :synonym "Logical Address" .
 
 :VirtualizationSoftware a owl:Class ;
@@ -33289,9 +28131,21 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
 :VirtualMemorySpace a owl:Class ;
     rdfs:label "Virtual Memory Space" ;
     rdfs:subClassOf :MemoryAddressSpace ;
-    rdfs:isDefinedBy "https://whatis.techtarget.com/definition/memory" ;
+    rdfs:isDefinedBy <https://whatis.techtarget.com/definition/memory> ;
     :definition "Virtual memory is a memory management technique where secondary memory can be used as if it were a part of the main memory. Virtual memory uses hardware and software to enable a computer to compensate for physical memory shortages" ;
-    rdfs:seeAlso "https://dbpedia.org/page/Virtual_memory" .
+    rdfs:seeAlso <https://dbpedia.org/page/Virtual_memory> .
+
+:VMImage a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Virtual Machine Image" ;
+    skos:altLabel "VM Image" ;
+    rdfs:subClassOf :StorageImage,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :SystemStateImage ] ;
+    rdfs:isDefinedBy <https://www.ituonline.com/tech-definitions/what-is-a-virtual-machine-image/> ;
+    :definition "A Virtual Machine Image (VMI) is a file that encapsulates the entire state of a virtual machine at a given point in time. This includes the operating system, applications, data, and configurations. VMIs are used to create and replicate virtual machines, ensuring consistency and reliability across different environments." ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Virtual_machine_image> .
 
 :Volume a owl:Class ;
     rdfs:label "Volume" ;
@@ -33306,6 +28160,14 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :BootRecord ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Volume_boot_record> ;
     :definition "A volume boot record (VBR) (also known as a volume boot sector, a partition boot record or a partition boot sector) is a type of boot sector introduced by the IBM Personal Computer. It may be found on a partitioned data storage device, such as a hard disk, or an unpartitioned device, such as a floppy disk, and contains machine code for bootstrapping programs (usually, but not necessarily, operating systems) stored in other parts of the device. On non-partitioned storage devices, it is the first sector of the device. On partitioned devices, it is the first sector of an individual partition on the device, with the first sector of the entire device being a Master Boot Record (MBR) containing the partition table." .
+
+:VolumeSnapshot a owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Volume Snapshot" ;
+    rdfs:subClassOf :StorageSnapshot ;
+    rdfs:isDefinedBy <https://kubernetes-csi.github.io/docs/snapshot-restore-feature.html> ;
+    :definition "A volume snapshot is a point-in-time copy of a storage volume." ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Shadow_Copy> .
 
 :Voting a owl:Class,
         owl:NamedIndividual ;
@@ -33326,12 +28188,12 @@ It is a combination of VPN hardware and software technologies that provides VPN 
     rdfs:seeAlso <http://dbpedia.org/resource/Virtual_private_network> .
 
 :Vulnerability a owl:Class ;
-    rdfs:subClassOf :D3FENDThing .
+    rdfs:label "Vulnerability" ;
+    rdfs:subClassOf :D3FENDCore .
 
 :Weakness a owl:Class ;
     rdfs:label "Weakness" ;
-    rdfs:subClassOf :D3FENDCore,
-        :D3FENDThing ;
+    rdfs:subClassOf :D3FENDCore ;
     :comment "A type of behavior that has the potential for allowing an attacker to violate the intended security policy, if the behavior is made accessible to the attacker. For example, an unbounded strcpy() call is a weakness, since it might be subject to a buffer overflow if an attacker can provide an input buffer that is larger than the output buffer. (CWE)",
         "Logic present in hardware or software which enables an attacker to violate the intended security policy." ;
     :definition "A weakness is a condition in a software, firmware, hardware, or service component that, under certain circumstances, could contribute to the introduction of vulnerabilities." .
@@ -33380,7 +28242,7 @@ It is a combination of VPN hardware and software technologies that provides VPN 
     rdfs:label "Web Resource" ;
     rdfs:subClassOf :NetworkResource ;
     :definition "A web resource is a resource identified by a Uniform Resource Identifier (URI) and made available from one host to another host via a web protocol and across a network or networks." ;
-    rdfs:seeAlso "http://dbpedia.org/resource/Web_resource" .
+    rdfs:seeAlso <http://dbpedia.org/resource/Web_resource> .
 
 :WebResourceAccess a owl:Class ;
     rdfs:label "Web Resource Access" ;
@@ -33454,7 +28316,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtOpenFile ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-openfile" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-openfile> ;
     :definition "Creates, opens, reopens, or deletes a file." .
 
 :WindowsCreateFileA a owl:Class ;
@@ -33473,7 +28335,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtCreatePagingFile ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea> ;
     :definition "Creates or opens a file or I/O device. The most commonly used I/O devices are as follows: file, file stream, directory, physical disk, volume, console buffer, tape drive, communications resource, mailslot, and pipe. The function returns a handle that can be used to access the file or device for various types of I/O depending on the file or device and the flags and attributes specified." .
 
 :WindowsCreateProcessA a owl:Class ;
@@ -33485,7 +28347,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtCreateProcessEx ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa> ;
     :definition "Creates a new process and its primary thread. The new process runs in the security context of the calling process." .
 
 :WindowsCreateRemoteThread a owl:Class ;
@@ -33494,7 +28356,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtCreateThreadEx ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createremotethread" .
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createremotethread> .
 
 :WindowsCreateThread a owl:Class ;
     rdfs:label "Windows CreateThread" ;
@@ -33505,7 +28367,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtCreateThreadEx ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createthread" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createthread> ;
     :definition "Creates a thread to execute within the virtual address space of the calling process." .
 
 :WindowsDeleteFile a owl:Class ;
@@ -33514,7 +28376,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtDeleteFile ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-deletefile" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-deletefile> ;
     :definition "Deletes an existing file." .
 
 :WindowsDuplicateToken a owl:Class ;
@@ -33523,7 +28385,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtDuplicateToken ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-duplicatetoken" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-duplicatetoken> ;
     :definition "The DuplicateToken function creates a new access token that duplicates one already in existence." .
 
 :WindowsGetThreadContext a owl:Class ;
@@ -33532,13 +28394,13 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNTGetThreadContext ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreadcontext" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreadcontext> ;
     :definition "Retrieves the context of the specified thread." .
 
 :WindowsNtAllocateVirtualMemory a owl:Class ;
     rdfs:label "Windows NtAllocateVirtualMemory" ;
     rdfs:subClassOf :OSAPIAllocateMemory ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtAllocateVirtualMemoryEx a owl:Class ;
     rdfs:label "Windows NtAllocateVirtualMemoryEx" ;
@@ -33547,30 +28409,30 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
 :WindowsNtCreateFile a owl:Class ;
     rdfs:label "Windows NtCreateFile" ;
     rdfs:subClassOf :OSAPICreateFile ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtCreateMailslotFile a owl:Class ;
     rdfs:label "Windows NtCreateMailslotFile" ;
     rdfs:subClassOf :OSAPICreateFile ;
     :definition "Creates a special File Object called Mailslot." ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtCreateNamedPipeFile a owl:Class ;
     rdfs:label "Windows NtCreateNamedPipeFile" ;
     rdfs:subClassOf :OSAPICreateFile ;
     :definition "Creates Named Pipe File Object." ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtCreatePagingFile a owl:Class ;
     rdfs:label "Windows NtCreatePagingFile" ;
     rdfs:subClassOf :OSAPICreateFile ;
     :definition "Typically used by Control Panel's \"System\" applet for creating new paged files." ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtCreateProcess a owl:Class ;
     rdfs:label "Windows NtCreateProcess" ;
     rdfs:subClassOf :OSAPICreateProcess ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtCreateProcessEx a owl:Class ;
     rdfs:label "Windows NtCreateProcessEx" ;
@@ -33579,7 +28441,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
 :WindowsNtCreateThread a owl:Class ;
     rdfs:label "Windows NtCreateThread" ;
     rdfs:subClassOf :OSAPICreateThread ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtCreateThreadEx a owl:Class ;
     rdfs:label "Windows NtCreateThreadEx" ;
@@ -33589,12 +28451,12 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:label "Windows NtDeleteFile" ;
     rdfs:subClassOf :OSAPIDeleteFile ;
     :definition "Deletes the specified file." ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtDuplicateToken a owl:Class ;
     rdfs:label "Windows NtDuplicateToken" ;
     rdfs:subClassOf :OSAPICopyToken ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtFlushInstructionCache a owl:Class ;
     rdfs:label "Windows NtFlushInstructionCache" ;
@@ -33603,7 +28465,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
 :WindowsNtFreeVirtualMemory a owl:Class ;
     rdfs:label "Windows NtFreeVirtualMemory" ;
     rdfs:subClassOf :OSAPIFreeMemory ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNTGetThreadContext a owl:Class ;
     rdfs:label "Windows NtGetThreadContext" ;
@@ -33612,41 +28474,41 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
 :WindowsNtOpenFile a owl:Class ;
     rdfs:label "Windows NtOpenFile" ;
     rdfs:subClassOf :OSAPIOpenFile ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtOpenProcess a owl:Class ;
     rdfs:label "Windows NtOpenProcess" ;
     rdfs:subClassOf :OSAPITraceProcess ;
     :definition "Opens a handle to process obj and sets the access rights to this object." ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/nf-ntddk-ntopenprocess" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/nf-ntddk-ntopenprocess> .
 
 :WindowsNtOpenThread a owl:Class ;
     rdfs:label "Windows NtOpenThread" ;
     rdfs:subClassOf :OSAPITraceThread ;
     :definition "Opens a handle to a thread object with the access specified." ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows/win32/devnotes/ntopenthread" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows/win32/devnotes/ntopenthread> .
 
 :WindowsNtProtectVirtualMemory a owl:Class ;
     rdfs:label "Windows NtProtectVirtualMemory" ;
     rdfs:subClassOf :OSAPIAllocateMemory ;
-    rdfs:seeAlso "https://www.delphibasics.info/home/delphibasicssnippets/nativewriteprocessmemoryapireplacement" .
+    rdfs:seeAlso <https://www.delphibasics.info/home/delphibasicssnippets/nativewriteprocessmemoryapireplacement> .
 
 :WindowsNtQuerySystemTime a owl:Class ;
     rdfs:label "Windows NtQuerySystemTime" ;
     rdfs:subClassOf :OSAPIGetSystemTime ;
     :definition "Returns current time in Coordinated Universal Time (UTC) 8-bytes format." ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtReadFile a owl:Class ;
     rdfs:label "Windows NtReadFile" ;
     rdfs:subClassOf :OSAPIReadFile ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtReadFileScatter a owl:Class ;
     rdfs:label "Windows NtReadFileScatter" ;
     rdfs:subClassOf :OSAPIReadFile ;
     :definition "Reads specified block from file into multiple buffers. Each buffer must have one page length." ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtResumeThread a owl:Class ;
     rdfs:label "Windows NtResumeThread" ;
@@ -33656,7 +28518,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:label "Windows NtSetInformationFile Argument FileDispositionInformation" ;
     rdfs:subClassOf :OSAPIDeleteFile ;
     :definition "Request to delete the file when it is closed or cancel a previously requested deletion." ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntsetinformationfile" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntsetinformationfile> .
 
 :WindowsNtSetThreadContext a owl:Class ;
     rdfs:label "Windows NtSetThreadContext" ;
@@ -33669,23 +28531,23 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
 :WindowsNtSuspendThread a owl:Class ;
     rdfs:label "Windows NtSuspendThread" ;
     rdfs:subClassOf :OSAPISuspendThread ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtTerminateProcess a owl:Class ;
     rdfs:label "Windows NtTerminateProcess" ;
     rdfs:subClassOf :OSAPITerminateProcess ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtWriteFile a owl:Class ;
     rdfs:label "Windows NtWriteFile" ;
     rdfs:subClassOf :OSAPIWriteFile ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtWriteFileGather a owl:Class ;
     rdfs:label "Windows NtWriteFileGather" ;
     rdfs:subClassOf :OSAPIWriteFile ;
     :definition "Writes specified block of file with data from memory pages." ;
-    rdfs:seeAlso "https://j00ru.vexillium.org/syscalls/nt/64/" .
+    rdfs:seeAlso <https://j00ru.vexillium.org/syscalls/nt/64/> .
 
 :WindowsNtWriteVirtualMemory a owl:Class ;
     rdfs:label "Windows NtWriteVirtualMemory" ;
@@ -33697,7 +28559,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtOpenProcess ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess> ;
     :definition "Opens an existing local process object." .
 
 :WindowsOpenThread a owl:Class ;
@@ -33706,7 +28568,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtOpenThread ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openthread" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openthread> ;
     :definition "Opens an existing thread object." .
 
 :WindowsQueryPerformanceCounter a owl:Class ;
@@ -33715,7 +28577,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtQuerySystemTime ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter> ;
     :definition "Retrieves the current value of the performance counter, which is a high resolution (<1us) time stamp that can be used for time-interval measurements." .
 
 :WindowsReadFile a owl:Class ;
@@ -33727,7 +28589,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtReadFileScatter ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile> ;
     :definition "Reads data from the specified file or input/output (I/O) device. Reads occur at the position specified by the file pointer if supported by the device." .
 
 :WindowsRegistry a owl:Class ;
@@ -33736,9 +28598,17 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :contains ;
             owl:someValuesFrom :WindowsRegistryKey ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/windows-registry-advanced-users",
-        <http://dbpedia.org/resource/Windows_Registry> ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Windows_Registry>,
+        <https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/windows-registry-advanced-users> ;
     :definition "The Windows Registry is a hierarchical database that stores low-level settings for the Microsoft Windows operating system and for applications that opt to use the registry. The kernel, device drivers, services, Security Accounts Manager, and user interface can all use the registry. The registry also allows access to counters for profiling system performance." .
+
+:WindowsRegistryEvent a owl:Class ;
+    rdfs:label "Windows Registry Event" ;
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :WindowsRegistry ] ;
+    :definition "Events involving interactions with the Windows Registry, including keys, values, and associated security configurations." .
 
 :WindowsRegistryKey a owl:Class ;
     rdfs:label "Windows Registry Key" ;
@@ -33752,11 +28622,65 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :windows-registry-key ;
             owl:someValuesFrom xsd:string ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry",
-        <http://dbpedia.org/resource/Windows_Registry#Keys_and_values> ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Windows_Registry#Keys_and_values>,
+        <https://learn.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry> ;
     :definition "Windows Registry Keys are container objects similar to folders that contain subkeys and/or data entries called values. A key can be a 'Registry Hive' when it is root key of a logical group of keys, subkeys, and values that has a set of supporting files loaded into memory when the operating system is started or a user logs in." ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-hives",
-        "https://schema.ocsf.io/objects/registry_key" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-hives>,
+        <https://schema.ocsf.io/objects/registry_key> .
+
+:WindowsRegistryKeyCreationEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Creation Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event where a new registry key is added to the Windows Registry, establishing a new hierarchical node for configuration." .
+
+:WindowsRegistryKeyDeletionEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Deletion Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event representing the removal of a registry key from the Windows Registry, including its hierarchical structure and associated metadata." .
+
+:WindowsRegistryKeyEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Event" ;
+    rdfs:subClassOf :WindowsRegistryEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :WindowsRegistryKey ] ;
+    :definition "Events representing actions performed on Windows Registry keys, such as creation, modification, or deletion, which define hierarchical nodes for storing configuration data." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/win/registry_key_activity> .
+
+:WindowsRegistryKeyExportEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Export Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event representing the export of registry key data from the Windows Registry to an external file or format." .
+
+:WindowsRegistryKeyImportEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Import Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event where registry key data is imported into the Windows Registry from an external source." .
+
+:WindowsRegistryKeyReadEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Read Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event where a registry key is accessed to query its structure, properties, or associated metadata without modifying its state." .
+
+:WindowsRegistryKeyRenamingEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Renaming Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event where the name of a registry key is changed, altering its identifier within the registry hierarchy." .
+
+:WindowsRegistryKeyRestoreEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Restore Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event where a registry key is restored to a previous state using a backup or recovery mechanism." .
+
+:WindowsRegistryKeySetSecurityEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Set Security Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event representing the application or modification of access controls or security settings to a registry key." .
+
+:WindowsRegistryKeyUpdateEvent a owl:Class ;
+    rdfs:label "Windows Registry Key Update Event" ;
+    rdfs:subClassOf :WindowsRegistryKeyEvent ;
+    :definition "An event where an existing registry key is updated or reconfigured, reflecting changes to its metadata or properties." .
 
 :WindowsRegistryValue a owl:Class ;
     rdfs:label "Windows Registry Value" ;
@@ -33767,10 +28691,39 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :windows-registry-value ;
             owl:someValuesFrom xsd:string ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/winreg/ns-winreg-valentw" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/winreg/ns-winreg-valentw> ;
     :definition "A Windows Registry Value is a data structure consisting of a name, type, data (as a pointer), and the length. Windows Registry Values are always associated with a Windows Registry Key. They store the actual configuration data for the operating system and the programs that run on the system." ;
-    rdfs:seeAlso "https://learn.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry",
-        "https://schema.ocsf.io/objects/registry_value" .
+    rdfs:seeAlso <https://learn.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry>,
+        <https://schema.ocsf.io/objects/registry_value> .
+
+:WindowsRegistryValueDeletionEvent a owl:Class ;
+    rdfs:label "Windows Registry Value Deletion Event" ;
+    rdfs:subClassOf :WindowsRegistryValueEvent ;
+    :definition "An event where a registry value is deleted from the Windows Registry, permanently removing its associated data." .
+
+:WindowsRegistryValueEvent a owl:Class ;
+    rdfs:label "Windows Registry Value Event" ;
+    rdfs:subClassOf :WindowsRegistryEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :WindowsRegistryValue ] ;
+    :definition "Events representing actions performed on Windows Registry values, which store configuration data within registry keys." ;
+    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/win/registry_value_activity> .
+
+:WindowsRegistryValueGetEvent a owl:Class ;
+    rdfs:label "Windows Registry Value Get Event" ;
+    rdfs:subClassOf :WindowsRegistryValueEvent ;
+    :definition "An event where the data of a registry value is retrieved, typically to read its configuration or state." .
+
+:WindowsRegistryValueSetEvent a owl:Class ;
+    rdfs:label "Windows Registry Value Set Event" ;
+    rdfs:subClassOf :WindowsRegistryValueEvent ;
+    :definition "An event where data is assigned to a registry value, either creating it or updating its existing content." .
+
+:WindowsRegistryValueUpdateEvent a owl:Class ;
+    rdfs:label "Windows Registry Value Update Event" ;
+    rdfs:subClassOf :WindowsRegistryValueEvent ;
+    :definition "An event indicating changes to the data or configuration of an existing registry value within the Windows Registry." .
 
 :WindowsResumeThread a owl:Class ;
     rdfs:label "Windows ResumeThread" ;
@@ -33778,7 +28731,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtResumeThread ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-resumethread" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-resumethread> ;
     :definition "Decrements a thread's suspend count. When the suspend count is decremented to zero, the execution of the thread is resumed." .
 
 :WindowsSetThreadContext a owl:Class ;
@@ -33787,7 +28740,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtSetThreadContext ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadcontext" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadcontext> ;
     :definition "Sets the context for the specified thread." .
 
 :WindowsShortcutFile a owl:Class ;
@@ -33804,7 +28757,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtSuspendThread ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-suspendthread" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-suspendthread> ;
     :definition "Suspends the specified thread." .
 
 :WindowsTerminateProcess a owl:Class ;
@@ -33813,7 +28766,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtTerminateProcess ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminateprocess" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminateprocess> ;
     :definition "Terminates the specified process and all of its threads." .
 
 :WindowsVirtualAllocEx a owl:Class ;
@@ -33825,7 +28778,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtProtectVirtualMemory ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualallocex" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualallocex> ;
     :definition "Reserves, commits, or changes the state of a region of memory within the virtual address space of a specified process. The function initializes the memory it allocates to zero." .
 
 :WindowsVirtualFree a owl:Class ;
@@ -33834,7 +28787,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtFreeVirtualMemory ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree> ;
     :definition "Releases, decommits, or releases and decommits a region of pages within the virtual address space of the calling process." .
 
 :WindowsVirtualProtectEx a owl:Class ;
@@ -33846,7 +28799,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtProtectVirtualMemory ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualprotectex" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualprotectex> ;
     :definition "Changes the protection on a region of committed pages in the virtual address space of a specified process." .
 
 :WindowsWriteFile a owl:Class ;
@@ -33858,7 +28811,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtWriteFileGather ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile> ;
     :definition "Writes data to the specified file or input/output (I/O) device." .
 
 :WindowsWriteProcessMemory a owl:Class ;
@@ -33873,14 +28826,16 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :WindowsNtWriteVirtualMemory ] ;
-    rdfs:isDefinedBy "https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-writeprocessmemory" ;
+    rdfs:isDefinedBy <https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-writeprocessmemory> ;
     :definition "Writes data to an area of memory in a specified process. The entire area to be written to must be accessible or the operation fails." .
 
 :WirelessAccessPoint a owl:Class ;
     rdfs:label "Wireless Access Point" ;
     skos:altLabel "WAP" ;
-    rdfs:subClassOf :NetworkNode,
-        :RFTransceiver ;
+    rdfs:subClassOf :ComputerNetworkNode,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :RFTransmitter ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Wireless_access_point> ;
     :definition "In computer networking, a wireless access point (WAP), or more generally just access point (AP), is a networking hardware device that allows other Wi-Fi devices to connect to a wired network. The AP usually connects to a router (via a wired network) as a standalone device, but it can also be an integral component of the router itself. An AP is differentiated from a hotspot which is a physical location where Wi-Fi access is available." .
 
@@ -33889,8 +28844,7 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     rdfs:subClassOf :Router,
         :WirelessAccessPoint ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Wireless_router> ;
-    :definition "A wireless router is a device that performs the functions of a router and also includes the functions of a wireless access point. It is used to provide access to the Internet or a private computer network. Depending on the manufacturer and model, it can function in a wired local area network, in a wireless-only LAN, or in a mixed wired and wireless network." ;
-    rdfs:seeAlso "Wireless Access Point" .
+    :definition "A wireless router is a device that performs the functions of a router and also includes the functions of a wireless access point. It is used to provide access to the Internet or a private computer network. Depending on the manufacturer and model, it can function in a wired local area network, in a wireless-only LAN, or in a mixed wired and wireless network." .
 
 :WriteFile a owl:Class ;
     rdfs:label "Write File" ;
@@ -33939,10 +28893,6 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         owl:NamedIndividual ;
     rdfs:label "Bash Script File" .
 
-:Book a owl:NamedIndividual,
-        :ReferenceType ;
-    rdfs:label "Book" .
-
 :BSDProcess a owl:NamedIndividual,
         :Process ;
     rdfs:label "BSD Process" .
@@ -33951,16 +28901,273 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
         owl:NamedIndividual ;
     rdfs:label "CCI Catalog v2022-04-05" ;
     :archived-at "https://public.cyber.mil/stigs/cci/"^^xsd:anyURI ;
-    rdfs:seeAlso "https://public.cyber.mil/stigs/cci/" ;
+    rdfs:seeAlso <https://public.cyber.mil/stigs/cci/> ;
     :version "2022-04-05" .
-
-:Connection-basedClustering a owl:NamedIndividual ;
-    :d3fend-id "D3A-CBC" .
 
 :DISA_FSO a :Organization,
         owl:NamedIndividual ;
     rdfs:label "DISA FSO" ;
     :definition "Defense Information Systems Agency (DISA) Field Security Office (FSO)" .
+
+:DS0001 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Firmware (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to firmware and therefore has no direct mappings to digital artifacts." ;
+    :definition "Computer software that provides low-level control for the hardware and device(s) of a host, such as BIOS or UEFI/EFI" .
+
+:DS0002 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "User Account (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the User Account Metadata component" ;
+    :definition "A profile representing a user, device, service, or application used to authenticate and access resources" ;
+    :exactly :UserAccount .
+
+:DS0003 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Scheduled Job (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Scheduled Job Metadata component" ;
+    :definition "Automated tasks that can be executed at a specific time or on a recurring schedule running in the background (ex: Cron daemon, task scheduler, BITS)" ;
+    :exactly :ScheduledJob .
+
+:DS0004 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Malware Repository (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Scheduled Job Metadata component" ;
+    :definition "Information obtained (via shared or submitted samples) regarding malicious software (droppers, backdoors, etc.) used by adversaries" ;
+    :narrower :FileHash,
+        :ImageCodeSegment .
+
+:DS0005 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "WMI (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to WMI objects and therefore has no direct mappings to digital artifacts." ;
+    :definition "The infrastructure for management data and operations that enables local and remote management of Windows personal computers and servers" .
+
+:DS0006 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Web Credential (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to web credentials and therefore has no direct mappings to digital artifacts." ;
+    :definition "Credential material, such as session cookies or tokens, used to authenticate to web applications and services" .
+
+:DS0007 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Image (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Image Metadata component" ;
+    :definition "A single file used to deploy a virtual machine/bootable disk into an on-premise or third-party cloud environment" ;
+    :exactly :VMImage .
+
+:DS0008 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Kernel (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to kernel modules and therefore has no direct mappings to digital artifacts." ;
+    :definition "A computer program, at the core of a computer OS, that resides in memory and facilitates interactions between hardware and software components" .
+
+:DS0009 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Process (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Process Metadata component" ;
+    :definition "Instances of computer programs that are being executed by at least one thread. Processes have memory space for process executables, loaded modules (DLLs or shared libraries), and allocated memory regions containing everything from user input to application-specific data structures" ;
+    :exactly :Process .
+
+:DS0010 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Cloud Storage (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Cloud Storage Metadata component" ;
+    :definition "Data object storage infrastructure hosted on-premise or by third-party providers, made available to users through network connections and/or APIs" ;
+    :exactly :CloudStorage .
+
+:DS0011 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Module (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to software libraries and therefore has no direct mappings to digital artifacts." ;
+    :definition "Executable files consisting of one or more shared classes and interfaces, such as portable executable (PE) format binaries/dynamic link libraries (DLL), executable and linkable format (ELF) binaries/shared libraries, and Mach-O format binaries/shared libraries" .
+
+:DS0012 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Script (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to scripts and therefore has no direct mappings to digital artifacts." ;
+    :definition "A file or stream containing a list of commands, allowing them to be launched in sequence" .
+
+:DS0013 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Sensor Health (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "Information from host telemetry providing insights about system status, errors, or other notable functional activity" .
+
+:DS0014 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Pod (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to pods and therefore has no direct mappings to digital artifacts." ;
+    :definition "A single unit of shared resources within a cluster, comprised of one or more containers" .
+
+:DS0015 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Application Log (ATT&CK DS)" ;
+    :broader :Log ;
+    :definition "Events collected by third-party services such as mail servers, web applications, or other appliances (not by the native OS or platform)" .
+
+:DS0016 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Drive (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to drives and therefore has no direct mappings to digital artifacts." ;
+    :definition "A non-volatile data storage device (hard drive, floppy disk, USB flash drive) with at least one formatted partition, typically mounted to the file system and/or assigned a drive letter" .
+
+:DS0017 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Command (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to commands and therefore has no direct mappings to digital artifacts." ;
+    :definition "A directive given to a computer program, acting as an interpreter of some kind, in order to perform a specific task" .
+
+:DS0018 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Firewall (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Firewall Metadata component" ;
+    :definition "A network security system, running locally on an endpoint or remotely as a service (ex: cloud environment), that monitors and controls incoming/outgoing network traffic based on predefined rules" ;
+    :exactly :Firewall .
+
+:DS0019 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Service (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Service Metadata component" ;
+    :definition "A computer process that is configured to execute continuously in the background and perform system tasks, in some cases before any user has logged in" ;
+    :exactly :ServiceApplicationProcess .
+
+:DS0020 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Snapshot (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Volume Metadata component" ;
+    :definition "A point-in-time copy of cloud volumes (files, settings, etc.) that can be created and/or deployed in cloud environments" ;
+    :exactly :VolumeSnapshot .
+
+:DS0021 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Persona (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "A malicious online profile representing a user commonly used by adversaries to social engineer or otherwise target victims" .
+
+:DS0022 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "File (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the File Metadata component" ;
+    :definition "A computer resource object, managed by the I/O system, for storing data (such as images, text, videos, computer programs, or any wide variety of other media)" ;
+    :narrower :FileSystemMetadata .
+
+:DS0023 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Named Pipe (ATT&CK DS)" ;
+    :definition "Mechanisms that allow inter-process communication locally or over the network. A named pipe is usually found as a file and processes attach to it" ;
+    :exactly :NamedPipe .
+
+:DS0024 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Windows Registry (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to Windows registry keys and values and therefore has no direct mappings to digital artifacts." ;
+    :definition "A Windows OS hierarchical database that stores much of the information and settings for software programs, hardware devices, user preferences, and operating-system configurations" .
+
+:DS0025 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Cloud Service (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "Infrastructure, platforms, or software that are hosted on-premise or by third-party providers, made available to users through network connections and/or APIs" .
+
+:DS0026 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Active Directory (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to Active Directory objects and therefore has no direct mappings to digital artifacts." ;
+    :definition "A database and set of services that allows administrators to manage permissions, access to network resources, and stored data objects (user, group, application, or devices)" .
+
+:DS0027 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Driver (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to hardware drivers and therefore has no direct mappings to digital artifacts." ;
+    :definition "A computer program that operates or controls a particular type of device that is attached to a computer. Provides a software interface to hardware devices, enabling operating systems and other computer programs to access hardware functions without needing to know precise details about the hardware being used" .
+
+:DS0028 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Logon Session (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Login Session Metadata component" ;
+    :broader :LoginSession ;
+    :definition "Logon occurring on a system or resource (local, domain, or cloud) to which a user/device is gaining access after successful authentication and authorization" .
+
+:DS0029 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Network Traffic (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Network Traffic Content component" ;
+    :definition "Data transmitted across a network (ex: Web, DNS, Mail, File, etc.), that is either summarized (ex: Netflow) and/or captured as raw data in an analyzable format (ex: PCAP)" ;
+    :exactly :NetworkTraffic .
+
+:DS0030 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Instance (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "A virtual server environment which runs workloads, hosted on-premise or by third-party cloud providers" .
+
+:DS0032 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Container (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to containers and therefore has no direct mappings to digital artifacts." ;
+    :definition "A standard unit of virtualized software that packages up code and all its dependencies so the application runs quickly and reliably from one computing environment to another" .
+
+:DS0033 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Network Share (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to shared network resources and therefore has no direct mappings to digital artifacts." ;
+    :definition "A storage resource (typically a folder or drive) made available from one host to others using network protocols, such as Server Message Block (SMB) or Network File System (NFS)" .
+
+:DS0034 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Volume (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "Block object storage hosted on-premise or by third-party providers, typically made available to resources as virtualized hard drives" .
+
+:DS0035 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Internet Scan (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "Information obtained (commonly via active network traffic probes or web crawling) regarding various types of resources and servers connected to the public Internet" .
+
+:DS0036 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Group (ATT&CK DS)" ;
+    rdfs:comment "The digital artifact mapping for this data source is only applicable to the Group Metadata component" ;
+    :definition "A collection of multiple user accounts that share the same access rights to the computer and/or network resources and have common security rights" ;
+    :exactly :UserGroup .
+
+:DS0037 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Certificate (ATT&CK DS)" ;
+    rdfs:comment "This data source captures events relating to certificates and therefore has no direct mappings to digital artifacts." ;
+    :definition "A digital document, which highlights information such as the owner's identity, used to instill trust in public keys used while encrypting network communications" .
+
+:DS0038 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Domain Name (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "Information obtained (commonly through registration or activity logs) regarding one or more IP addresses registered with human readable names (ex: mitre.org)" .
+
+:DS0039 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Asset (ATT&CK DS)" ;
+    :definition "Data sources with information about the set of devices found within the network, along with their current software and configurations" ;
+    :exactly :AssetInventoryAgent .
+
+:DS0040 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Operational Database (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts." ;
+    :definition "Operational databases contain information about the status of the operational process and associated devices, including any measurements, events, history, or alarms that have occurred" .
+
+:DS0041 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "Application Vetting (ATT&CK DS)" ;
+    :broader :CodeAnalyzer ;
+    :definition "Application vetting report generated by an external cloud service." .
+
+:DS0042 a :ATTACKEnterpriseDataSource,
+        owl:NamedIndividual ;
+    rdfs:label "User Interface (ATT&CK DS)" ;
+    rdfs:comment "This data source currently has no mappings to digital artifacts, but may be updated in future releases." ;
+    :definition "Visual activity on the device that could alert the user to potentially malicious behavior." .
 
 :FQDNDomainName a :DomainName,
         owl:NamedIndividual ;
@@ -33968,7 +29175,8 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
 
 :GetForegroundWindow a :GetOpenWindows,
         owl:NamedIndividual ;
-    rdfs:isDefinedBy "https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getforegroundwindow" .
+    rdfs:label "Get Foreground Window" ;
+    rdfs:isDefinedBy <https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getforegroundwindow> .
 
 <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-ApproachesForSecuringAnInternetEndpointUsingFine-grainedOperatingSystemVirtualization_Bromium,Inc.> a owl:NamedIndividual,
         :PatentReference ;
@@ -34038,7 +29246,8 @@ In order to convince the potential attacker that the deception environment is th
     rdfs:label "Reference - Eviction Guidance for Networks Affected by the SolarWinds and Active Directory/M365 Compromise - CISA" ;
     :has-link "https://www.cisa.gov/news-events/analysis-reports/ar21-134a"^^xsd:anyURI ;
     :kb-organization "CISA" ;
-    :kb-reference-of :CredentialRotation ;
+    :kb-reference-of :CredentialRotation,
+        :DNSCacheEviction ;
     :kb-reference-title "Eviction Guidance for Networks Affected by the SolarWinds and Active Directory/M365 Compromise" .
 
 <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-IsolationOfApplicationsWithinAVirtualMachine_Bromium,Inc.> a owl:NamedIndividual,
@@ -34052,6 +29261,16 @@ In order to convince the potential attacker that the deception environment is th
     :kb-reference-of :Hardware-basedProcessIsolation ;
     :kb-reference-title "Isolation of applications within a virtual machine" ;
     :todo "MITRE Analysis was not found" .
+
+<http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-Remembranceofdatapassed:Astudyofdisksanitizationpractices> a :AcademicPaperReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Remembrance of data passed: A study of disk sanitization practices" ;
+    :has-link "https://www.researchgate.net/profile/Simson-Garfinkel/publication/3437324_Remembrance_of_data_passed_A_study_of_disk_sanitization_practices/links/550de6d40cf2128741677d9f/Remembrance-of-data-passed-A-study-of-disk-sanitization-practices.pdf"^^xsd:anyURI ;
+    :kb-author "Simson L Garfinkel, Abhi Shelat" ;
+    :kb-reference-of :DiskErasure,
+        :DiskFormatting,
+        :DiskPartitioning ;
+    :kb-reference-title "Remembrance of Data Passed: A Study of Disk Sanitization Practices" .
 
 <http://d3fend.mitre.org/ontologies/d3fend.owl#Reference-SupplyChainCyber-deception_Cymmetria,Inc.> a owl:NamedIndividual,
         :PatentReference ;
@@ -34441,10 +29660,6 @@ order to constitute a complete standard. For a complete definition of all requir
         :Process ;
     rdfs:label "macOS Process" .
 
-:MarketingMaterial a owl:NamedIndividual,
-        :ReferenceType ;
-    rdfs:label "Marketing Material" .
-
 :MicrosoftWordDOCBFile a :DocumentFile,
         owl:NamedIndividual ;
     rdfs:label "Microsoft Word DOCB File" .
@@ -34485,30 +29700,22 @@ order to constitute a complete standard. For a complete definition of all requir
         owl:NamedIndividual ;
     rdfs:label "NIST SP 800-53 R3" ;
     :archived-at "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2013-04-30"^^xsd:anyURI ;
-    rdfs:seeAlso "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2013-04-30" ;
+    rdfs:seeAlso <https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2013-04-30> ;
     :version 3 .
 
 :NIST_SP_800-53_R4 a :NISTSP800-53ControlCatalog,
         owl:NamedIndividual ;
     rdfs:label "NIST SP 800-53 R4" ;
     :archived-at "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2013-04-30"^^xsd:anyURI ;
-    rdfs:seeAlso "https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2015-01-22" ;
+    rdfs:seeAlso <https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/archive/2015-01-22> ;
     :version 4 .
 
 :NIST_SP_800-53_R5 a :NISTSP800-53ControlCatalog,
         owl:NamedIndividual ;
     rdfs:label "NIST SP 800-53 R5" ;
     :archived-at "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final"^^xsd:anyURI ;
-    rdfs:seeAlso "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final" ;
+    rdfs:seeAlso <https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final> ;
     :version 5 .
-
-:non-real-time-analytic a :AnalyticLatency,
-        owl:NamedIndividual ;
-    rdfs:label "non-real-time-analytic" .
-
-:non-real-time-eviction a :EvictionLatency,
-        owl:NamedIndividual ;
-    rdfs:label "non-real-time-eviction" .
 
 :PE32ExecutableFile a :ExecutableBinary,
         owl:NamedIndividual ;
@@ -34527,14 +29734,6 @@ order to constitute a complete standard. For a complete definition of all requir
     rdfs:label "Procedure 1 - T1134.001 Access Token Manipulation" ;
     :implements :T1134.001 ;
     :start :step-1 .
-
-:real-time-analytic a :AnalyticLatency,
-        owl:NamedIndividual ;
-    rdfs:label "real-time-analytic" .
-
-:real-time-eviction a :EvictionLatency,
-        owl:NamedIndividual ;
-    rdfs:label "real-time-eviction" .
 
 :Reference-AccessPermissionModification_MITRE a :ExternalKnowledgeBase,
         owl:NamedIndividual ;
@@ -34664,7 +29863,6 @@ Outlier data values which deviate from behavioral profile by more than a predete
     :kb-abstract "An apparatus is disclosed for to provide content to and query a reverse domain name system (DNS) server without depending on the kindness of domain name system registrars, registrants. DNS replies are observed by firewalls or filters, analyzed, and transmitted to a reverse domain name system server. An embodiment of the present invention can be within a DNS server or SMTP server." ;
     :kb-author "Dean Danko" ;
     :kb-mitre-analysis "This patent includes the description of a method of blocking email traffic from untrusted domains by analyzing the TCP/IP source IP addresses and blocking traffic for IPs whose reverse lookup response FQDN matches a denylist." ;
-    :kb-reference-of :ReverseResolutionDomainDenylisting ;
     :kb-reference-title "Apparatus for to provide content to and query a reverse domain name system server" .
 
 :Reference-ArchitectureOfTransparentNetworkSecurityForApplicationContainers_NeuvectorInc a owl:NamedIndividual,
@@ -35325,6 +30523,22 @@ These flaws weaken the reliability and effectiveness of encrypted Internet conne
     :kb-reference-of :NetworkTrafficPolicyMapping ;
     :kb-reference-title "Cisco ASR 9000 Series Aggregation Services Routers - Access List Commands" .
 
+:Reference-CManualIntegerInitialization_GNU a owl:NamedIndividual,
+        :UserManualReference ;
+    rdfs:label "Reference - Integer Initialization - GNU C Manual" ;
+    :has-link "https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Integer-Types"^^xsd:anyURI ;
+    :kb-organization "GNU" ;
+    :kb-reference-of :VariableInitialization ;
+    :kb-reference-title "Integer Initialization in C" .
+
+:Reference-CManualPointerArithmetic_GNU a owl:NamedIndividual,
+        :UserManualReference ;
+    rdfs:label "Reference - Memory Block Start Validation - GNU C Manual" ;
+    :has-link "https://www.gnu.org/software/c-intro-and-ref/manual/html_node/Pointer-Arithmetic.html"^^xsd:anyURI ;
+    :kb-organization "GNU" ;
+    :kb-reference-of :MemoryBlockStartValidation ;
+    :kb-reference-title "Pointer Arithmetic in C" .
+
 :Reference-CommandLaunchedFromWinLogon_MITRE a :ExternalKnowledgeBase,
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-008: Command Launched from WinLogon - MITRE" ;
@@ -35477,12 +30691,13 @@ This requires filesystem data to determine whether files have been created.""" ;
     :kb-author "Cybersecurity and Infrastructure Security Agency" ;
     :kb-mitre-analysis " " ;
     :kb-organization "Cybersecurity and Infrastructure Security Agency" ;
+    :kb-reference-of :RegistryKeyDeletion ;
     :kb-reference-title "Cybersecurity Incident & Vulnerability Response Playbooks" .
 
 :Reference-CyberVaccineAndPredictiveMalwareDefensiveMethodsAndSystems a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Cyber vaccine and predictive-malware-defense methods and systems" ;
-    :has-link "https://patents.google.com/patent/US10848519B2/" ;
+    :has-link "https://patents.google.com/patent/US10848519B2/"^^xsd:anyURI ;
     :kb-abstract "Methods and systems for Predictive Malware Defense (PMD) are described. The systems and methods can utilize advanced machine-learning (ML) techniques to generate malware defenses preemptively. Embodiments of PMD can utilize models, which are trained on features extracted from malware families, to predict possible courses of malware evolution. PMD captures these predicted future evolutions in signatures of as yet unseen malware variants to function as a malware vaccine. These signatures of predicted future malware “evolutions” can be added to the training set of a machine-learning (ML) based malware detection and/or mitigation system so that it can detect these new variants as they arrive." ;
     :kb-author "Michael Howard, Avi Pfeifer, Mukesh Dalal, Michael Reposa" ;
     :kb-organization "Charles River Analytics Inc." ;
@@ -35852,6 +31067,14 @@ In one embodiment, a response policy zone (RPZ) application generates an RPZ tha
         "No author organizations provided for reference, add one?",
         "No authors provided for reference" .
 
+:Reference-FederalPublicKeyInfrastructure101 a :GuidelineReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Federal Public Key Infrastructrure 101" ;
+    :has-link "https://www.idmanagement.gov/university/fpki/"^^xsd:anyURI ;
+    :kb-author "Identity, Credential, and Access Management Subcommittee (ICAMSC)" ;
+    :kb-reference-of :Certificate-basedAuthentication ;
+    :kb-reference-title "Federal Public Key Infrastructure 101" .
+
 :Reference-File-modifyingMalwareDetection_CrowdstrikeInc a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - File-modifying malware detection - Crowdstrike Inc" ;
@@ -36208,7 +31431,6 @@ The user interaction and the code process executed during the user session are m
     :has-link "https://www.safetydetectives.com/blog/how-does-antivirus-quarantine-work/"^^xsd:anyURI ;
     :kb-abstract "Your antivirus has just finished a regular scan and it’s asking whether you want to quarantine the virus it’s found. You click ‘yes’ without putting much thought into what’s actually happening. But what does quarantining actually mean, what does it do and is it safe for your computer? It’s important to understand the details so that you know what’s happening when you send infected files into quarantine." ;
     :kb-author "Katarina Glamoslija" ;
-    :kb-reference-of :FileRemoval ;
     :kb-reference-title "How Does Antivirus Quarantine Work?" .
 
 :Reference-HowToChangeRegistryValuesOrPermissionsFromACommandLineOrAScript a :InternetArticleReference,
@@ -36334,6 +31556,14 @@ Determining that the return address is outside memory previously allocated for a
     :kb-reference-title "Instant process termination tool to recover control of an information handling system" ;
     :todo "MITRE Analysis was not found" .
 
+:Reference-IntegerRangeValidation_SEI a :GuidelineReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Integer Range Validation" ;
+    :has-link "https://resources.sei.cmu.edu/downloads/secure-coding/assets/sei-cert-c-coding-standard-2016-v01.pdf"^^xsd:anyURI ;
+    :kb-organization "Software Engineering Institute" ;
+    :kb-reference-of :IntegerRangeValidation ;
+    :kb-reference-title "SEI CERT C Coding Standard" .
+
 :Reference-IntegrityAssuranceThroughEarlyLoadingInTheBootPhase_CrowdstrikeInc a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Integrity assurance through early loading in the boot phase - Crowdstrike Inc" ;
@@ -36347,10 +31577,23 @@ This patent describes ensuring that a driver associated with the agent is initia
     :kb-reference-of :DriverLoadIntegrityChecking ;
     :kb-reference-title "Integrity assurance through early loading in the boot phase" .
 
+:Reference-IntroducingFirefoxNewSiteIsolationArchitecture a :InternetArticleReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Introducing Firefox's new Site Isolation Architecture" ;
+    :has-link "https://hacks.mozilla.org/2021/05/introducing-firefox-new-site-isolation-security-architecture/" ;
+    :kb-abstract "" ;
+    :kb-author "Anny Gakhokidze" ;
+    :kb-mitre-analysis "" ;
+    :kb-organization "Mozilla Foundation" ;
+    :kb-reference-of :Application-basedProcessIsolation ;
+    :kb-reference-title "Site Isolation Design Document" ;
+    :release-date "May 18, 2021" ;
+    :todo "MITRE Analysis was not found" .
+
 :Reference-Intrusion_and_misuse_deterrence_system_employing_a_virtual_network a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Intrusion and misuse deterrence system employing a virtual network" ;
-    :has-link "https://patents.google.com/patent/US7240368B1" ;
+    :has-link "https://patents.google.com/patent/US7240368B1"^^xsd:anyURI ;
     :kb-reference-of :NetworkTrafficSignatureAnalysis ;
     :kb-reference-title "Intrusion and misuse deterrence system employing a virtual network" .
 
@@ -36371,6 +31614,14 @@ A disappearance of the heartbeat from the endpoint may indicate that the endpoin
     :kb-organization "Sophos Ltd" ;
     :kb-reference-of :EndpointHealthBeacon ;
     :kb-reference-title "Intrusion detection using a heartbeat" .
+
+:Reference-LeverageSecurityFrameworksLibraries_OWASP a :GuidelineReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Leverage Security Frameworks and Libraries - OWASP" ;
+    :has-link "https://top10proactive.owasp.org/archive/2018/c2-leverage-security-frameworks-libraries/"^^xsd:anyURI ;
+    :kb-organization "OWASP" ;
+    :kb-reference-of :TrustedLibrary ;
+    :kb-reference-title "Leverage Security Frameworks and Libraries" .
 
 :Reference-LibreNMSDocsNetworkMapExtension a owl:NamedIndividual,
         :UserManualReference ;
@@ -36749,7 +32000,7 @@ Some examples of data inputs:
 :Reference-NearMemoryInMemoryDetectionofFilelessMalware a :AcademicPaperReference,
         owl:NamedIndividual ;
     rdfs:label "Reference - Near-Memory & In-Memory Detection of Fileless Malware" ;
-    :has-link "https://web.inf.ufpr.br/mazalves/wp-content/uploads/sites/13/2021/03/memsys2020.pdf" ;
+    :has-link "https://web.inf.ufpr.br/mazalves/wp-content/uploads/sites/13/2021/03/memsys2020.pdf"^^xsd:anyURI ;
     :kb-abstract "Fileless malware are recent threats to computer systems that load directly into memory, and whose aim is to prevent anti-viruses (AVs) from successfully matching byte patterns against suspicious files written on disk. Their detection requires that software-based AVs continuously scan memory, which is expensive due to repeated locks and polls. However, research advances introduced near-memory and in-memory processing, which allow memory controllers to trigger basic computations without moving data to the CPU. In this paper, we address AVs performance overhead by moving them to the hardware, i.e., we propose instrumenting processors’ memory controller or smart memories (near- and in-memory malware detection, respectively) to accelerate memory scanning procedures. To do so, we present MINI-ME, the Malware Identification based on Near- and In-Memory Evaluation mechanism, a hardware-based AV accelerator that interrupts the program’s execution if malicious patterns are discovered in their memory. We prototyped MINI-ME in a simulator and tested it with a set of 21 thousand in-the-wild malware samples, which resulted in multiple signatures matching with less than 1% of performance overhead and rates of 100% detection, and zero false-positives and false-negatives." ;
     :kb-author "Marcus Botacin, André Grégio, Marco Antonio Zanata Alves" ;
     :kb-reference-of :HostShutdown ;
@@ -36799,6 +32050,13 @@ architecture using the Snort NIDS.""" ;
     :todo "MITRE Analysis was not found",
         "No section headers were given (MITRE Analysis or Document Abstract); all text placed in kb-abstract section." .
 
+:Reference-NetworkMapping a :InternetArticleReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Network Mapping" ;
+    :has-link "https://en.wikipedia.org/wiki/Network_mapping"^^xsd:anyURI ;
+    :kb-author "https://en.wikipedia.org/" ;
+    :kb-reference-title "Network Mapping" .
+
 :Reference-NIST-RMF-Quick-Start-Guide-Assess-Step-FAQ a :InternetArticleReference,
         owl:NamedIndividual ;
     rdfs:label "Reference - NIST RMF Quick Start Guide - Assess Step - Frequently Asked Questions (FAQ)" ;
@@ -36845,6 +32103,22 @@ architecture using the Snort NIDS.""" ;
     :kb-organization "NIST" ;
     :kb-reference-of :OperationalRiskAssessment ;
     :kb-reference-title "NIST Interagency Report 8011 Volume 1 - Automation Support for Security Control Assessments" .
+
+:Reference-NullPointerChecking_SEI a :GuidelineReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Null Pointer Checking - SEI" ;
+    :has-link "https://wiki.sei.cmu.edu/confluence/display/c/EXP34-C.+Do+not+dereference+null+pointers"^^xsd:anyURI ;
+    :kb-organization "Software Engineering Institute" ;
+    :kb-reference-of :NullPointerChecking ;
+    :kb-reference-title "SEI CERT C Coding Standard" .
+
+:Reference-NullPointerDereference_CWE a :ExternalKnowledgeBase,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Null Pointer Dereferencing - CWE-476" ;
+    :has-link "https://cwe.mitre.org/data/definitions/476.html"^^xsd:anyURI ;
+    :kb-organization "MITRE" ;
+    :kb-reference-of :NullPointerChecking ;
+    :kb-reference-title "CWE-476: NULL Pointer Dereference" .
 
 :Reference-OpenSourceIntelligenceDeceptions_IllusiveNetworksLtd a owl:NamedIndividual,
         :PatentReference ;
@@ -36934,6 +32208,15 @@ While this analytic does not take the user into account, doing so could generate
     :kb-reference-of :PointerAuthentication ;
     :kb-reference-title "Examining Pointer Authentication on the iPhone XS" .
 
+:Reference-PointerValidationFunction_SEI a :GuidelineReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Pointer Validation Function - SEI" ;
+    :has-link "https://wiki.sei.cmu.edu/confluence/display/c/MEM10-C.+Define+and+use+a+pointer+validation+function"^^xsd:anyURI ;
+    :kb-organization "Software Engineering Institute" ;
+    :kb-reference-of :NullPointerChecking,
+        :PointerValidation ;
+    :kb-reference-title "SEI CERT C Coding Standard" .
+
 :Reference-PostSandboxMethodsAndSystemsForDetectingAndBlockingZero-dayExploitsViaApiCallValidation_K2CyberSecurityInc a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Post sandbox methods and systems for detecting and blocking zero-day exploits via api call validation - K2 Cyber Security Inc" ;
@@ -36995,6 +32278,13 @@ Powershell can be used to hide monitored command line execution such as:
     :kb-author "Teddy David Thomas" ;
     :kb-reference-title "Privacy and security systems and methods of use" .
 
+:Reference-PrivateApplicationAccessWithBrowserIsolation a owl:NamedIndividual,
+        :PatentReference ;
+    rdfs:label "Reference - Private application access with browser isolation" ;
+    :has-link "https://patents.google.com/patent/US20210250333A1" ;
+    :kb-reference-of :Application-basedProcessIsolation ;
+    :kb-reference-title "Private application access with browser isolation" .
+
 :Reference-PrivateVirtualLocalAreaNetworkIsolation_CiscoTechnologyInc a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Private virtual local area network isolation - Cisco Technology Inc" ;
@@ -37052,6 +32342,13 @@ Powershell can be used to hide monitored command line execution such as:
     :kb-organization "Juniper Networks Inc." ;
     :kb-reference-of :InboundSessionVolumeAnalysis ;
     :kb-reference-title "Protecting against distributed network flood attacks" .
+
+:Reference-ProtectingWebApplicationsFromUntrustedEndpointsUsingRemoteBrowserIsolation a owl:NamedIndividual,
+        :PatentReference ;
+    rdfs:label "Reference - Protecting web applications from untrusted endpoints using remote browser isolation" ;
+    :has-link "https://patents.google.com/patent/US11477248B2/" ;
+    :kb-reference-of :Application-basedProcessIsolation ;
+    :kb-reference-title "Protecting web applications from untrusted endpoints using remote browser isolation" .
 
 :Reference-PsSuspend a owl:NamedIndividual,
         :SpecificationReference ;
@@ -37116,6 +32413,14 @@ Powershell can be used to hide monitored command line execution such as:
     :kb-abstract "Red Hat Enterprise Linux 8 Security Guidelines" ;
     :kb-reference-of :ApplicationConfigurationHardening ;
     :kb-reference-title "Red Hat Enterprise Linux 8 Security Technical Implementation Guide" .
+
+:Reference-ReferenceNullification_SecureSoftwareInc a :ExternalKnowledgeBase,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Reference Nullification" ;
+    :has-link "https://cwe.mitre.org/documents/sources/TheCLASPApplicationSecurityProcess.pdf"^^xsd:anyURI ;
+    :kb-organization "Secure Software, Inc." ;
+    :kb-reference-of :ReferenceNullification ;
+    :kb-reference-title "The CLASP Application Security Process" .
 
 :Reference-Reg.exeCalledFromCommandShell_MITRE a :ExternalKnowledgeBase,
         owl:NamedIndividual ;
@@ -37208,6 +32513,13 @@ This identifier is present three times during the RPC request phase. Any sensor 
     :kb-reference-title "CAR-2015-04-002: Remotely Scheduled Tasks via Schtasks" ;
     :todo "MITRE Analysis was not found" .
 
+:Reference-RemotelyTriggeredBlackHoleFiltering-Cisco a :AcademicPaperReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Remotely Triggered Black Hole FIltering - Cisco" ;
+    :has-link "https://www.cisco.com/c/dam/en_us/about/security/intelligence/blackhole.pdf"^^xsd:anyURI ;
+    :kb-organization "Cisco" ;
+    :kb-reference-title "Remotely Triggered Black Hole Filtering - Destination Based and Source Based" .
+
 :Reference-RemoteRegistry_MITRE a :ExternalKnowledgeBase,
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2014-11-005: Remote Registry - MITRE" ;
@@ -37236,22 +32548,13 @@ All of these behaviors call into the Windows API, which uses the NamedPipe WINRE
     :kb-reference-of :FileHashReputationAnalysis ;
     :kb-reference-title "Reputation of an entity associated with a content item" .
 
-:Reference-ReverseDNSBlocking_BarracudaNetworks a owl:NamedIndividual,
-        :UserManualReference ;
-    rdfs:label "Reference - Reverse DNS Blocking - Barracuda Networks" ;
-    :has-link "https://campus.barracuda.com/product/emailsecuritygateway/doc/39819732/reverse-dns-blocking/"^^xsd:anyURI ;
-    :kb-author "campus.barracuda.com" ;
-    :kb-mitre-analysis "Inbound corporate traffic SMTP traffic on port 25 can be routed through Barracuda Email Security Gateway before reaching the corporate mail server, acting as a traffic filter based on reverse DNS lookups and a denylist for blocking domains." ;
-    :kb-reference-of :ReverseResolutionDomainDenylisting ;
-    :kb-reference-title "Reverse DNS Blocking" .
-
 :Reference-RevokingaPreviouslyIssuedVerifiableCredential-Microsoft a owl:NamedIndividual,
         :SpecificationReference ;
     rdfs:label "Reference - Revoke a previously issued verifiable credential - Microsoft" ;
     :has-link "https://learn.microsoft.com/en-us/azure/active-directory/verifiable-credentials/how-to-issuer-revoke"^^xsd:anyURI ;
     :kb-author "Barclay Neira, Christer Ljung, Juan Camilo Ruiz, John Flores" ;
     :kb-organization "Microsoft" ;
-    :kb-reference-of :CredentialRevoking ;
+    :kb-reference-of :CredentialRevocation ;
     :kb-reference-title "Revoke a previously issued verifiable credential" .
 
 :Reference-RFC2289-AOne-TimePasswordSystem a owl:NamedIndividual,
@@ -37345,6 +32648,15 @@ delivery, up to message rejection.""" ;
     :todo "Could not determine reference type; TechniqueReference class used instead",
         "Document Abstract was not found",
         "MITRE Analysis was not found" .
+
+:Reference-SecretsManagementCheatSheet-OWASP a :InternetArticleReference,
+        owl:NamedIndividual ;
+    rdfs:label "Secrets Management Cheat Sheet" ;
+    :has-link "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html"^^xsd:anyURI ;
+    :kb-abstract "The OWASP Secrets Management Cheat Sheet provides clear directives for securely managing sensitive data like API keys and credentials. It emphasizes centralized control for storage, provisioning, and auditing to prevent unauthorized access. Adopting strong rotation and management protocols is essential for maintaining security and integrity in DevOps environments." ;
+    :kb-author "OWASP" ;
+    :kb-reference-of :CredentialScrubbing ;
+    :kb-reference-title "Secrets Management Cheat Sheet" .
 
 :Reference-SecureCachingOfServerCredentials_DellProductsLP a owl:NamedIndividual,
         :PatentReference ;
@@ -37505,6 +32817,17 @@ Logon events are Windows Event Code 4624 for Windows Vista and above, 518 for pr
     :kb-organization "Palo Alto Networks Inc" ;
     :kb-reference-of :DNSTrafficAnalysis ;
     :kb-reference-title "Sinkholing bad network domains by registering the bad network domains on the internet" .
+
+:Reference-SiteIsolationDesignDocument a :InternetArticleReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Site Isolation Design Document" ;
+    :has-link "https://www.chromium.org/developers/design-documents/site-isolation/" ;
+    :kb-abstract "" ;
+    :kb-mitre-analysis "" ;
+    :kb-organization "The Chromium Projects" ;
+    :kb-reference-of :Application-basedProcessIsolation ;
+    :kb-reference-title "Site Isolation Design Document" ;
+    :todo "MITRE Analysis was not found" .
 
 :Reference-SMBCopyAndExecution_MITRE a :ExternalKnowledgeBase,
         owl:NamedIndividual ;
@@ -38049,8 +33372,8 @@ In various embodiments, a name server transmits a canonical name as resolution t
     :has-link "https://www.tenable.com/sites/default/files/solution-briefs/SB-Passive-Network-Monitoring.pdf"^^xsd:anyURI ;
     :kb-abstract "Tenable Nessus® Network Monitor (NNM), a passive monitoring sensor, continuously discovers active assets on the network and assesses them for vulnerabilities. NNM is based on patented network discovery and vulnerability analysis technology that continuously monitors and profiles non-intrusively. It monitors IPv4, IPv6 and mixed network traffic at the packet layer to determine topology, services and vulnerabilities." ;
     :kb-organization "Tenable" ;
-    :kb-reference-of :PassiveLogicalLinkMapping,
-        :PassivePhysicalLinkMapping ;
+    :kb-reference-of :DirectPhysicalLinkMapping,
+        :PassiveLogicalLinkMapping ;
     :kb-reference-title "Tenable Passive Network Monitoring" .
 
 :Reference-Testing_Metrics_for_Password_Creation_Policies_by_Attacking_Large_Sets_of_Revealed_Passwords a :AcademicPaperReference,
@@ -38137,6 +33460,14 @@ This specification defines the Trusted Platform Module (TPM) a device that enabl
     :kb-organization "Microsoft Technology Licensing LLC" ;
     :kb-reference-title "Trusted Communications With Child Processes" .
 
+:Reference-TypeSystems_Princeton a :ExternalKnowledgeBase,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Type Systems" ;
+    :has-link "https://www.cs.princeton.edu/courses/archive/fall98/cs441/mainus/node4.html "^^xsd:anyURI ;
+    :kb-organization "Princeton University" ;
+    :kb-reference-of :VariableTypeValidation ;
+    :kb-reference-title "Why type checking?" .
+
 :Reference-UACBypass_MITRE a :ExternalKnowledgeBase,
         owl:NamedIndividual ;
     rdfs:label "Reference - CAR-2019-04-001: UAC Bypass - MITRE" ;
@@ -38156,6 +33487,15 @@ This specification defines the Trusted Platform Module (TPM) a device that enabl
     :has-link "https://uefi.org/sites/default/files/resources/PI_Spec_1_7_A_final_May1.pdf"^^xsd:anyURI ;
     :kb-reference-of :BootloaderAuthentication ;
     :kb-reference-title "UEFI Platform Initialization (PI) Specification" .
+
+:Reference-UnderstandingtheDomainRegistrationBehaviorofSpammers a :AcademicPaperReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Understanding the Domain Registration Behavior of Spammers" ;
+    :has-link "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=bf4d34a6f9d0168bb07433e84c1567bbe1ba8188"^^xsd:anyURI ;
+    :kb-abstract "Spammers register a tremendous number of domains to evade blacklisting and takedown efforts. Current techniques to detect such domains rely on crawling spam URLs or monitoring lookup traffic. Such detection techniques are only effective after the spammers have already launched their campaigns, and thus these countermeasures may only come into play after the spammer has already reaped significant benefits from the dissemination of large volumes of spam. In this paper we examine the registration process of such domains, with a particular eye towards features that might indicate that a given domain likely has a malicious purpose at registration time, before it is ever used for an attack. Our assessment includes exploring the characteristics of registrars, domain life cycles, registration bursts, and naming patterns. By investigating zone changes from the .com TLD over a 5-month period, we discover that spammers employ bulk registration, that they often re-use domains previously registered by others, and that they tend to register and host their domains over a small set of registrars. Our findings suggest steps that registries or registrars could use to frustrate the efforts of miscreants to acquire domains in bulk, ultimately reducing their agility for mounting large-scale attacks." ;
+    :kb-author "Hao S, Thomas M, Paxson V, Feamster N, Kreibich C, Grier C, Hollenbeck S" ;
+    :kb-reference-of :DomainRegistrationTakedown ;
+    :kb-reference-title "Understanding the Domain Registration Behavior of Spammers" .
 
 :Reference-UnifiedArchitectureFrameworkUAF a owl:NamedIndividual,
         :SpecificationReference ;
@@ -38273,6 +33613,15 @@ Could be applied to a number of different types of monitoring depending on what 
     :kb-reference-of :ActivePhysicalLinkMapping ;
     :kb-reference-title "Using spanning tree protocol (STP) to enhance layer-2 topology maps" .
 
+:Reference-VariableInitialization_CWE a :ExternalKnowledgeBase,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - Variable Initialization - CWE-457" ;
+    :has-link "https://cwe.mitre.org/data/definitions/457.html"^^xsd:anyURI ;
+    :kb-author "MITRE" ;
+    :kb-organization "MITRE" ;
+    :kb-reference-of :VariableInitialization ;
+    :kb-reference-title "CWE-457: Use of Uninitialized Variable" .
+
 :Reference-VirtualizedProcessIsolation_AdvancedMicroDevicesInc a owl:NamedIndividual,
         :PatentReference ;
     rdfs:label "Reference - Virtualized process isolation - Advanced Micro Devices Inc" ;
@@ -38386,55 +33735,68 @@ With keystroke dynamics the biometric template used to identify an individual is
     :todo "MITRE Analysis was not found" .
 
 :RegOpenKeyA a :GetSystemConfigValue,
-        owl:NamedIndividual .
+        owl:NamedIndividual ;
+    rdfs:label "RegOpenKeyA" .
 
 :RegOpenKeyExA a :GetSystemConfigValue,
-        owl:NamedIndividual .
+        owl:NamedIndividual ;
+    rdfs:label "RegOpenKeyExA" .
 
 :RegOpenKeyExW a :GetSystemConfigValue,
-        owl:NamedIndividual .
+        owl:NamedIndividual ;
+    rdfs:label "RegOpenKeyExW" .
 
 :RegOpenKeyTransactedA a :GetSystemConfigValue,
-        owl:NamedIndividual .
+        owl:NamedIndividual ;
+    rdfs:label "RegOpenKeyTransactedA" .
 
 :RegOpenKeyTransactedW a :GetSystemConfigValue,
-        owl:NamedIndividual .
+        owl:NamedIndividual ;
+    rdfs:label "RegOpenKeyTransactedW" .
 
 :RegOpenKeyW a :GetSystemConfigValue,
-        owl:NamedIndividual .
+        owl:NamedIndividual ;
+    rdfs:label "RegOpenKeyW" .
 
 :RegSetKeyValueA a owl:NamedIndividual,
-        :SetSystemConfigValue .
+        :SetSystemConfigValue ;
+    rdfs:label "RegSetKeyValueA" .
 
 :RegSetKeyValueW a owl:NamedIndividual,
-        :SetSystemConfigValue .
+        :SetSystemConfigValue ;
+    rdfs:label "RegSetKeyValueW" .
 
 :RegSetValueA a owl:NamedIndividual,
-        :SetSystemConfigValue .
+        :SetSystemConfigValue ;
+    rdfs:label "RegSetValueA" .
 
 :RegSetValueExA a owl:NamedIndividual,
-        :SetSystemConfigValue .
+        :SetSystemConfigValue ;
+    rdfs:label "RegSetValueExA" .
 
 :RegSetValueExW a owl:NamedIndividual,
-        :SetSystemConfigValue .
+        :SetSystemConfigValue ;
+    rdfs:label "RegSetValueExW" .
 
 :RegSetValueW a owl:NamedIndividual,
-        :SetSystemConfigValue .
+        :SetSystemConfigValue ;
+    rdfs:label "RegSetValueW" .
 
 :RubyScriptFile a :ExecutableScript,
         owl:NamedIndividual ;
     rdfs:label "Ruby Script File" .
 
-:step-1 a owl:NamedIndividual,
-        :Step ;
+:SecurityArchitects a owl:NamedIndividual,
+        :TargetAudience ;
+    rdfs:label "Security Architects" .
+
+:step-1 a owl:NamedIndividual ;
     rdfs:label "Step 1 - Copy Token" ;
     :invokes :CopyToken ;
     :next :step-2 .
 
-:step-2 a owl:NamedIndividual,
-        :Step ;
+:step-2 a owl:NamedIndividual ;
     rdfs:label "Step 2 - Impersonate User" ;
-    :creates :Authentication ;
     :invokes :ImpersonateUser .
 
 :WebSocketURL a owl:NamedIndividual,

--- a/src/util/update_capec.py
+++ b/src/util/update_capec.py
@@ -1,0 +1,124 @@
+from defusedxml.ElementTree import parse
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import RDF, RDFS, OWL
+
+import sys
+
+
+def get_capec_graph(capec_path):
+    D3F = Namespace("http://d3fend.mitre.org/ontologies/d3fend.owl#")
+
+    # Create a new graph
+    g = Graph()
+
+    # Load and parse the CAPEC XML file
+    capec_tree = parse(capec_path)
+    capec_root = capec_tree.getroot()
+
+    # Extract and add CAPEC entries
+    attack_patterns = capec_root.find("{http://capec.mitre.org/capec-3}Attack_Patterns")
+
+    for attack_pattern in attack_patterns.findall(
+        "{http://capec.mitre.org/capec-3}Attack_Pattern"
+    ):
+        capec_id = attack_pattern.attrib.get("ID")
+        capec_name = attack_pattern.attrib.get("Name")
+        capec_description = attack_pattern.find(
+            "{http://capec.mitre.org/capec-3}Description"
+        )
+        capec_deprecated = (
+            attack_pattern.attrib.get("Status") == "Deprecated"
+            or attack_pattern.attrib.get("Status") == "Obsolete"
+        )
+
+        if capec_description.find("{http://www.w3.org/1999/xhtml}p") is not None:
+            capec_description = capec_description.find(
+                "{http://www.w3.org/1999/xhtml}p"
+            ).text
+        elif capec_description.text is not None:
+            capec_description = capec_description.text
+
+        capec_uri = D3F[f"CAPEC-{capec_id}"]
+        g.add((capec_uri, RDF.type, D3F.CommonAttackPattern))
+        g.add((capec_uri, RDF.type, OWL.NamedIndividual))
+        g.add((capec_uri, RDF.type, OWL.Class))
+        g.add((capec_uri, RDFS.label, Literal(capec_name)))
+        g.add((capec_uri, RDFS.subClassOf, D3F.CommonAttackPattern))
+        g.add(
+            (
+                capec_uri,
+                RDFS.seeAlso,
+                URIRef(f"https://capec.mitre.org/data/definitions/{capec_id}.html"),
+            )
+        )
+        g.add((capec_uri, D3F["capec-id"], Literal(f"CAPEC-{capec_id}")))
+
+        # Add definition if it is not empty
+        if capec_description and not capec_deprecated:
+            g.add((capec_uri, D3F.definition, Literal(capec_description)))
+
+        if capec_deprecated:
+            g.add((capec_uri, OWL.deprecated, Literal(True)))
+            if capec_description:
+                g.add((capec_uri, RDFS.comment, Literal(capec_description)))
+
+        # Include relationships
+        related_patterns = attack_pattern.findall(
+            "{http://capec.mitre.org/capec-3}Related_Attack_Patterns/{http://capec.mitre.org/capec-3}Related_Attack_Pattern"
+        )
+        for related in related_patterns:
+            related_id = related.attrib.get("CAPEC_ID")
+            related_uri = D3F[f"CAPEC-{related_id}"]
+            nature = related.attrib.get("Nature")
+
+            if nature == "ParentOf":
+                g.add((related_uri, RDFS.subClassOf, capec_uri))
+                g.remove((related_uri, RDFS.subClassOf, D3F.CommonAttackPattern))
+            elif nature == "ChildOf":
+                g.add((capec_uri, RDFS.subClassOf, related_uri))
+                g.remove((capec_uri, RDFS.subClassOf, D3F.CommonAttackPattern))
+            elif nature == "PeerOf":
+                g.add((capec_uri, D3F.related, related_uri))
+                g.add((related_uri, D3F.related, capec_uri))
+
+        # Add related CWE entries
+        related_weaknesses = attack_pattern.findall(
+            "{http://capec.mitre.org/capec-3}Related_Weaknesses/{http://capec.mitre.org/capec-3}Related_Weakness"
+        )
+        for related in related_weaknesses:
+            cwe_id = related.attrib.get("CWE_ID")
+            cwe_uri = D3F[f"CWE-{cwe_id}"]
+            g.add((capec_uri, D3F.related, cwe_uri))
+
+        # Add related ATT&CK techniques
+        taxonomy_mappings = attack_pattern.findall(
+            "{http://capec.mitre.org/capec-3}Taxonomy_Mappings/{http://capec.mitre.org/capec-3}Taxonomy_Mapping"
+        )
+        for mapping in taxonomy_mappings:
+            taxonomy_name = mapping.attrib.get("Taxonomy_Name")
+            if taxonomy_name == "ATTACK":
+                attack_uri = D3F[
+                    f"T{mapping.find('{http://capec.mitre.org/capec-3}Entry_ID').text}"
+                ]
+                g.add((capec_uri, D3F.related, attack_uri))
+
+    return g
+
+
+def main(CAPEC_VERSION="3.9"):
+
+    d3fend_graph = Graph()
+    d3fend_graph.parse("src/ontology/d3fend-protege.capec.ttl")
+
+    capec_graph = get_capec_graph(f"data/capec_v{CAPEC_VERSION}.xml")
+
+    d3fend_graph += capec_graph
+
+    d3fend_graph.serialize(
+        destination="src/ontology/d3fend-protege.capec.ttl", format="turtle"
+    )
+
+
+if __name__ == "__main__":
+    version = sys.argv[1]
+    main(CAPEC_VERSION=version)

--- a/src/util/update_capec.sh
+++ b/src/util/update_capec.sh
@@ -1,0 +1,32 @@
+##
+## This script creates a D3FEND ontology update from CAPEC XML
+## After running the user must manually compare & replace d3fend-protege.capec.ttl
+##
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+
+CAPEC_VERSION=$1
+
+capec="data/capec_v${CAPEC_VERSION}.xml"
+if [ ! -f "$capec" ]; then
+    echo -e "${GREEN}No CAPEC list found"
+    echo -e "${GREEN}Running make download-capec \n"
+    make download-capec CAPEC_VERSION="${CAPEC_VERSION}"
+else
+    echo -e "${GREEN}Using ${capec} for CAPEC version ${CAPEC_VERSION} \n"
+fi
+
+cp src/ontology/d3fend-protege.ttl src/ontology/d3fend-protege.capec.ttl
+
+pipenv run python src/util/test_cases.py  || exit 1
+
+echo -e "${GREEN}All test cases passed \n"
+
+pipenv run python src/util/update_capec.py "$CAPEC_VERSION" || exit 1
+
+pipenv run ttlfmt src/ontology/d3fend-protege.capec.ttl
+
+echo -e "${YELLOW}Created new ontology file with updates here: src/ontology/d3fend-protege.capec.ttl \n"
+echo -e "Please manually review and compare to: src/ontology/d3fend-protege.ttl \n"
+echo -e "If changes acceptable, replace files \n"


### PR DESCRIPTION
Addresses #257 

This PR integrates CAPEC named individuals into the ontology. A new Python script parses CAPEC XML files, generates OWL classes, and maps related CWEs and ATT&CK techniques.

- Added a script to parse CAPEC XML data and generate OWL classes.
- Uses rdfs:subClassOf to express ChildOf/ParentOf relationships between the CAPEC patterns.
- Includes related CWEs and ATT&CK techniques for each individual.
- Automates the integration of versioned CAPEC data using Makefile.