### PR TITLE
add serializes and deserializes tactical verbs to ontology

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -262,6 +262,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "deceives-with" ;
     rdfs:subPropertyOf :d3fend-tactical-verb-property .
 
+:decrypts a owl:ObjectProperty ;
+    rdfs:label "decrypts" ;
+    rdfs:subPropertyOf :deserializes ;
+    rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00996499-v> ;
+    :definition "x decrypts y: A subject x converts an artifact y from a serialized form back into its original form by reversing the encryption process, restoring its original state." .
+
 :deletes a owl:ObjectProperty ;
     rdfs:label "deletes" ;
     rdfs:subPropertyOf :evicts,
@@ -282,6 +288,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00729216-a> ;
     :definition "x depends-on y: The entity x is contingent on y being available; x relies on y." ;
     rdfs:seeAlso <https://www.cisa.gov/what-are-dependencies> .
+
+:deserializes a owl:ObjectProperty ;
+    rdfs:label "deserializes" ;
+    rdfs:subPropertyOf :produces ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Serialization> ;
+    :definition "x deserializes y: A subject x converts an artifact y from a serialized form back into its original form. This process involves extracting a data structure from a series of bytes to recreate a semantically identical clone of the original object." .
 
 :detects a owl:ObjectProperty ;
     rdfs:label "detects" ;
@@ -330,7 +342,8 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :encrypts a owl:ObjectProperty ;
     rdfs:label "encrypts" ;
     rdfs:subPropertyOf :associated-with,
-        :hardens ;
+        :hardens,
+        :serializes ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00996121-v> ;
     :definition "x encrypts y: The entity x converts the ordinary representation of a digital artifact y into a secret code." .
 
@@ -1097,6 +1110,13 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :semantic-relation a owl:ObjectProperty ;
     rdfs:label "semantic-relation" ;
     rdfs:subPropertyOf :associated-with .
+
+:serializes a owl:ObjectProperty ;
+    rdfs:label "serializes" ;
+    rdfs:subPropertyOf :hardens,
+        :produces ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Serialization> ;
+    :definition "x serializes y: A subject x converts an artifact y into a serialized form. This process involves translating a data structure or object state into a format that can be stored or transmitted and reconstructed later." .
 
 :spoofs a owl:ObjectProperty ;
     rdfs:label "spoofs" ;
@@ -9754,8 +9774,11 @@ Wikipedia. (n.d.). Descriptive statistics. [Link](https://en.wikipedia.org/wiki/
 
 :DeserializationFunction a owl:Class ;
     rdfs:label "Deserialization Function" ;
-    rdfs:subClassOf :Subroutine ;
-    :definition "Function with an input of serialized data which deserializes that data, usually with data parsing methods." .
+    rdfs:subClassOf :Subroutine,
+        [ a owl:Restriction ;
+            owl:onProperty :deserializes ;
+            owl:someValuesFrom :DigitalArtifact ] ;
+    :definition "A function that takes serialized data as input and deserializes it, typically using data parsing methods to reconstruct the original data structure or object." .
 
 :DesktopComputer a owl:Class ;
     rdfs:label "Desktop Computer" ;
@@ -17463,8 +17486,11 @@ Yu, L., Zhang, W., Wang, J., & Yu, Y. (2017). SeqGAN: Sequence Generative Advers
 
 :SerializationFunction a owl:Class ;
     rdfs:label "Serialization Function" ;
-    rdfs:subClassOf :Subroutine ;
-    :definition "A function which has an operation that serializes data." .
+    rdfs:subClassOf :Subroutine,
+        [ a owl:Restriction ;
+            owl:onProperty :serializes ;
+            owl:someValuesFrom :DigitalArtifact ] ;
+    :definition "A function that serializes data by translating a data structure or object state into a format that can be stored or transmitted and later reconstructed." .
 
 :Server a owl:Class ;
     rdfs:label "Server" ;


### PR DESCRIPTION
- Introduce :serializes and :deserializes
- Add restrictions to :SerializationFunction and :DeserializationFunction classes that uses the verbs
- assert :encrypts as a subproperty of :serializes
- define :decrypts as a subproperty of :deserializes

Please critique/review and I'll edit accordingly!

fixes #269 