### PR TITLE
Add optional SSL certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data
 node_modules
 package*
 src/ontology/mappings/catalog-v001.xml
+.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,20 @@ FROM rockylinux:9
 
 ARG ROBOT_URL
 
+COPY . /app
+WORKDIR /app
+
+# if any custom SSL certs exist in .local, install them
+RUN if [ -n "$(find .local -name '*.pem' -o -name '*.crt' 2>/dev/null)" ]; then \
+  echo "Copying SSL certs from .local"; \
+  # if [ -e ] won't work here because of sh: Too Many Arguments
+  find /app/.local -name '*.crt' -exec cp {} /etc/pki/ca-trust/source/anchors \; 2>/dev/null || true; \
+  find /app/.local -name '*.pem' -exec cp {} /etc/pki/ca-trust/source/anchors \; 2>/dev/null || true; \
+  update-ca-trust extract; \
+fi
+
 RUN dnf -y install python39 java-17-openjdk-headless make python3-pip which git
 VOLUME [ "/dist" ]
 RUN pip3 install pipenv==2022.8.5
-COPY . /app
-WORKDIR /app
 RUN make ROBOT_URL=${ROBOT_URL} clean install-deps
 RUN make build extensions dist

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ in the dist/ folder running
 docker-compose up d3fend-ontology
 ```
 
+### SSL Certificates in Docker
+
+If you have custom SSL certificates needed to fetch packages and dependencies from the internet, make a directory `.local` in this project root and place your certificates in `.local/` as `.pem` or `.crt`.  The docker build will install the certificates if it finds them there.
+
+
 ## NOTICE
 
 Use of the MITRE D3FEND™ Knowledge Graph and website is subject to the Terms of Use. Use of the MITRE D3FEND website is subject to the MITRE D3FEND Privacy Policy. MITRE D3FEND is funded by the National Security Agency (NSA) Cybersecurity Directorate and managed by the National Security Engineering Center (NSEC), which is operated by The MITRE Corporation. MITRE D3FEND; and the MITRE D3FEND logo are trademarks of The MITRE Corporation. MITRE ATT&CK® and ATT&CK® are registered trademarks of The MITRE Corporation. MITRE ATT&CK content is subject to the MITRE ATT&CK terms of use.


### PR DESCRIPTION
This will enable builds to work in environments that have proxies and firewalls that require SSL certificates, without including the certs in the image.