### PR TITLE
Add Cloud Service Provider subclass

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -3430,7 +3430,7 @@ Profiling request and response payloads across multiple clients to a single serv
     rdfs:label "Cloud Configuration" ;
     skos:altLabel "Cloud Configuration Information" ;
     rdfs:subClassOf :ConfigurationResource ;
-    :definition "Information used to configure the services, parameters, and initial settings for a virtual server instance running in a cloud service.." .
+    :definition "Information used to configure the services, parameters, and initial settings for a virtual server instance running in a cloud service." .
 
 :CloudInstanceMetadata a owl:Class ;
     rdfs:label "Cloud Instance Metadata" ;
@@ -17638,6 +17638,11 @@ The organization collects and models architectural information about the service
         [ a owl:Restriction ;
             owl:onProperty :provides ;
             owl:someValuesFrom :Service ] .
+
+:CloudServiceProvider a owl:Class ;
+    rdfs:label "Cloud Service Provider" ;
+    rdfs:subClassOf :ServiceProvider ;
+    :definition "A cloud service provider is a company that offers some component of cloud computing -- typically infrastructure as a service (IaaS), software as a service (SaaS), or platform as a service (PaaS) -- to other businesses or individuals." .
 
 :Session a owl:Class ;
     rdfs:label "Session" ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -17642,7 +17642,7 @@ The organization collects and models architectural information about the service
 :CloudServiceProvider a owl:Class ;
     rdfs:label "Cloud Service Provider" ;
     rdfs:subClassOf :ServiceProvider ;
-    :definition "A cloud service provider is a company that offers some component of cloud computing -- typically infrastructure as a service (IaaS), software as a service (SaaS), or platform as a service (PaaS) -- to other businesses or individuals." .
+    :definition "A cloud service provider delivers scalable and distributed computing resources over a network, enabling clients to access infrastructure, platforms, and applications remotely." .
 
 :Session a owl:Class ;
     rdfs:label "Session" ;


### PR DESCRIPTION
Honestly, this is mostly an excuse to try writing something in TTL.

This change adds the `CloudServiceProvider` as a subclass of `ServiceProvider`. This is useful for anyone who wants to create CSP specific resources like AWS EC2 or Google Cloud Compute Engine. 

I understand not wanting to have AWS, Azure, or GCP as resources in an otherwise agnostic ontology, but we should have a resource to subclass for anyone who wants to extend the ontology for other uses.

I note that the ontology also does not have a `CloudService` resource either. I thought about adding it and its own subclasses (IAAS, PAAS, and SAAS) but then I would need to relate it to the aforementioned `CloudServiceProvider` as well as all of T1021.007 (Cloud Services), not to mention a whole lot of other cloud resources, at which point it felt like too complex a change for a first contribution. 