### PR TITLE
Refine Auth Events

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -751,8 +751,6 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-be-tactically-associated-with a owl:ObjectProperty ;
     rdfs:label "may-be-tactically-associated-with" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    rdfs:domain :DefensiveAction ;
-    rdfs:range :OffensiveAction ;
     :comment "Most/all of these properties are (will be) realized via inference over chain property path axioms and atomic assertions. Promote this to regular comment once definitions no longer in comments." ;
     :definition "x may-be-tactically-associated-with y: the defensive action x may be a tactic that counters offensive action y." ;
     :todo "Needs name change... With the right name change to better capture definition can keep this definition" .

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -17885,7 +17885,7 @@ Wikipedia contributors. (2021, August 23). Residual neural network. In Wikipedia
 
 :ResourceAccess a owl:Class ;
     rdfs:label "Resource Access" ;
-    rdfs:subClassOf :DigitalInformationBearer ;
+    rdfs:subClassOf :UserAction ;
     :definition "Ephemeral digital artifact comprising a request of a resource and any response from that resource." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Computer_access_control> .
 

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -36,7 +36,6 @@
     rdfs:label "accesses" ;
     rdfs:subPropertyOf :associated-with,
         :may-access ;
-    rdfs:range :NetworkResource ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02673854-n> ;
     :definition "x accesses y: An subject x takes the action of reading from, writing into, or executing the stored information in the object y. Reads, writes, and executes are specific cases of accesses." .
 

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -259,9 +259,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 
 :d3fend-tactical-verb-property a owl:ObjectProperty ;
     rdfs:label "d3fend-tactical-verb-property" ;
-    rdfs:subPropertyOf :d3fend-object-property ;
-    rdfs:domain :DefensiveTechnique ;
-    rdfs:range :Artifact .
+    rdfs:subPropertyOf :d3fend-object-property .
 
 :d3fend-use-case-object-property a owl:ObjectProperty ;
     rdfs:subPropertyOf :d3fend-object-property .
@@ -753,10 +751,10 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-be-tactically-associated-with a owl:ObjectProperty ;
     rdfs:label "may-be-tactically-associated-with" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    rdfs:domain :DefensiveTechnique ;
-    rdfs:range :OffensiveTechnique ;
+    rdfs:domain :DefensiveAction ;
+    rdfs:range :OffensiveAction ;
     :comment "Most/all of these properties are (will be) realized via inference over chain property path axioms and atomic assertions. Promote this to regular comment once definitions no longer in comments." ;
-    :definition "x may-be-tactically-associated-with y: the defensive technique x may be a tactic that counters offensive technique y." ;
+    :definition "x may-be-tactically-associated-with y: the defensive action x may be a tactic that counters offensive action y." ;
     :todo "Needs name change... With the right name change to better capture definition can keep this definition" .
 
 :may-be-weakness-of a owl:ObjectProperty ;
@@ -1663,11 +1661,26 @@ skos:altLabel a owl:AnnotationProperty .
             owl:onProperty :has-mediator ;
             owl:someValuesFrom :AccessMediator ] .
 
+:AccessControlAdministrationEvent a owl:Class ;
+    rdfs:label "Access Control Administration Event" ;
+    skos:altLabel "Permission Administration Event",
+        "Permission Provisioning Event" ;
+    rdfs:subClassOf :AccessControlEvent ;
+    :definition "An event concerning the administrative actions of setting, modifying, or abolishing permissions, configuring access control settings, and managing user access rights to ensure alignment with access control policies." .
+
 :AccessControlConfiguration a owl:Class ;
     rdfs:label "Access Control Configuration" ;
     rdfs:subClassOf :ConfigurationResource ;
     :definition "Information about what access permissions are granted to particular users for particular objects" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Access-control_list> .
+
+:AccessControlEvent a owl:Class ;
+    rdfs:label "Access Control Event" ;
+    rdfs:subClassOf :AuthorizationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :AccessControlConfiguration ] ;
+    :definition "An event that captures the implementation or evaluation of access control measures, including the application of rules and policies to govern the accessibility of resources by agents within a digital system." .
 
 :AccessControlGroup a owl:Class ;
     rdfs:label "Access Control Group" ;
@@ -1686,6 +1699,25 @@ skos:altLabel a owl:AnnotationProperty .
             owl:someValuesFrom :UserGroup ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Access-control_list> ;
     :definition "A list of permissions attached to an object." .
+
+:AccessDeniedEvent a owl:Class ;
+    rdfs:label "Access Denied Event" ;
+    rdfs:subClassOf :AccessMediationEvent ;
+    :definition "An event indicating the refusal of access to a resource, where an access request has been evaluated and denied based on current authorization policies, preventing operations by the requesting agent." .
+
+:AccessGrantedEvent a owl:Class ;
+    rdfs:label "Access Granted Event" ;
+    rdfs:subClassOf :AccessMediationEvent ;
+    :definition "An event signifying that access to a resource has been authorized and successfully enforced, allowing the requesting agent to perform specified operations based on the access control policies." .
+
+:AccessMediationEvent a owl:Class ;
+    rdfs:label "Access Mediation Event" ;
+    skos:altLabel "Access Enforcement Event" ;
+    rdfs:subClassOf :AccessControlEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :AccessMediator ] ;
+    :definition "An event involving the intermediary control mechanism that evaluates access requests and enforces access control decisions, ensuring that subjects' resource interactions comply with the established access policies." .
 
 :AccessMediator a owl:Class ;
     rdfs:label "Access Mediator" ;
@@ -2432,16 +2464,6 @@ ANN Classification. [Link](http://uc-r.github.io/ann_classification).""" .
         :Reference-SecurityVulnerabilityInformationAggregation,
         :Reference-SystemAndMethodForVulnerabilityRiskAssessment .
 
-:AssignGroupsEvent a owl:Class ;
-    rdfs:label "Assign Groups Event" ;
-    rdfs:subClassOf :SessionAuthorizationEvent ;
-    :definition "An event where a user is assigned to specific groups, which collectively determine their permissions and access rights. Group assignments often facilitate role-based access control (RBAC) by associating users with predefined policies or functional roles." .
-
-:AssignPrivilegesEvent a owl:Class ;
-    rdfs:label "Assign Privileges Event" ;
-    rdfs:subClassOf :SessionAuthorizationEvent ;
-    :definition "An event where specific privileges or rights are granted to a user or session, defining their ability to perform sensitive operations or access restricted resources within a system." .
-
 :AssignPrivilegesToGroupEvent a owl:Class ;
     rdfs:label "Assign Privileges to Group Event" ;
     rdfs:subClassOf :GroupManagementEvent ;
@@ -2518,7 +2540,7 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
 
 :Authentication a owl:Class ;
     rdfs:label "Authentication" ;
-    rdfs:subClassOf :UserAction,
+    rdfs:subClassOf :DefensiveAction,
         [ a owl:Restriction ;
             owl:onProperty :authenticates ;
             owl:someValuesFrom :User ],
@@ -2556,11 +2578,18 @@ Windows Credential Management API""" ;
 
 :AuthenticationEvent a owl:Class ;
     rdfs:label "Authentication Event" ;
+    skos:altLabel "Agent Authentication Event" ;
     rdfs:subClassOf :DigitalEvent,
         [ a owl:Restriction ;
             owl:onProperty :caused-by ;
-            owl:someValuesFrom :Authentication ] ;
-    :definition "An event involving the systematic process of verifying the identity of an account, user, or entity within a system. Authentication events ensure that only authorized entities gain access to protected resources by validating credentials, tokens, or cryptographic evidence." ;
+            owl:someValuesFrom :Authentication ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Agent ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Credential ] ;
+    :definition "An event capturing the systematic process of verifying an agent's identity within a system, involving credential validation and identity confirmation." ;
     rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/authentication> .
 
 :AuthenticationEventThresholding a :AuthenticationEventThresholding,
@@ -2634,17 +2663,23 @@ This technique covers statistical outliers. Though depending on the complexity o
 
 :Authorization a owl:Class ;
     rdfs:label "Authorization" ;
-    rdfs:subClassOf :UserAction,
+    rdfs:subClassOf :DefensiveAction,
         [ a owl:Restriction ;
             owl:onProperty :authorizes ;
-            owl:someValuesFrom :NetworkResourceAccess ] ;
+            owl:someValuesFrom :Access ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Authorization> ;
     :definition "Authorization is the function of specifying access rights to resources related to information security and computer security in general and to access control in particular. More formally, \"to authorize\" is to define an access policy. For example, human resources staff is normally authorized to access employee records and this policy is usually formalized as access control rules in a computer system. During operation, the system uses the access control rules to decide whether access requests from (authenticated) consumers shall be approved (granted) or disapproved (rejected). Resources include individual files or an item's data, computer programs, computer devices and functionality provided by computer applications. Examples of consumers are computer users, computer program" .
 
 :AuthorizationEvent a owl:Class ;
     rdfs:label "Authorization Event" ;
-    rdfs:subClassOf :DigitalEvent ;
-    :definition "An event regarding access adjudication decisions." .
+    rdfs:subClassOf :DigitalEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :caused-by ;
+            owl:someValuesFrom :Authorization ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Agent ] ;
+    :definition "An event reflecting the decision-making process and actions concerning access control, recording whether agents are permitted or denied access to resources based on pre-defined access control policies." .
 
 :AuthorizationEventThresholding a :AuthorizationEventThresholding,
         owl:Class,
@@ -14253,13 +14288,22 @@ Wikipedia. (n.d.). Logistic regression. [Link](https://en.wikipedia.org/wiki/Log
 
 :LogoffEvent a owl:Class ;
     rdfs:label "Logoff Event" ;
-    rdfs:subClassOf :AuthenticationEvent ;
-    :definition "An event where a subject terminates an active authentication session, formally ending their access to a system, application, or resource. This event ensures the deallocation of session tokens and secures the system against unauthorized continuation of access." .
+    rdfs:subClassOf :AuthenticationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Session ],
+        [ a owl:Restriction ;
+            owl:onProperty :preceded-by ;
+            owl:someValuesFrom :LogonEvent ] ;
+    :definition "An authentication event where an active session is conclusively terminated, resulting in the cessation of access and deallocation of resources associated with the session, ensuring that the connection to the system, application, or resource no longer exists." .
 
 :LogonEvent a owl:Class ;
     rdfs:label "Logon Event" ;
-    rdfs:subClassOf :AuthenticationEvent ;
-    :definition "An event where a subject initiates an authentication session to gain access to a system, application, or resource. This process typically includes credential validation, token issuance, and session establishment, marking the beginning of the subject's authenticated state." .
+    rdfs:subClassOf :AuthenticationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Session ] ;
+    :definition "An authentication event where a new session is initiated, signifying the successful validation of credentials and establishment of an authorized connection to a system, application, or resource. This marks the beginning of the subject’s authenticated interaction with the system." .
 
 :LogonUser a owl:Class ;
     rdfs:label "Logon User" ;
@@ -16426,6 +16470,16 @@ Changes in firmware hash values may indicate that the firmware has been tampered
     :definition "Firmware that is installed on peripheral hub device such as a USB or Firewire hub." ;
     rdfs:seeAlso <http://dbpedia.org/resource/USB_hub> .
 
+:PermissionGrantingEvent a owl:Class ;
+    rdfs:label "Permission Granting Event" ;
+    rdfs:subClassOf :AccessControlAdministrationEvent ;
+    :definition "An administrative event where authorization is given, allowing a subject to perform specific operations on a protected resource, effectuating a policy decision to allow access rights." .
+
+:PermissionRevokingEvent a owl:Class ;
+    rdfs:label "Permission Revoking Event" ;
+    rdfs:subClassOf :AccessControlAdministrationEvent ;
+    :definition "An administrative event entailing the withdrawal of previously granted access rights, reconfiguring permissions to prevent a subject from performing specific actions on a resource, in accordance with updated access policies." .
+
 :PersistenceTechnique a owl:Class ;
     rdfs:label "Persistence Technique" ;
     rdfs:subClassOf :ATTACKEnterpriseTechnique,
@@ -16693,7 +16747,10 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
 
 :PreAuthenticationEvent a owl:Class ;
     rdfs:label "Pre-Authentication Event" ;
-    rdfs:subClassOf :AuthenticationEvent ;
+    rdfs:subClassOf :AuthenticationEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :precedes ;
+            owl:someValuesFrom :Authentication ] ;
     :definition "An event representing preparatory steps or processes conducted prior to the primary authentication operation. Pre-authentication often involves initial protocol exchanges, cryptographic challenges, or the validation of supplemental factors (e.g., pre-shared keys) to ensure the readiness and security of the authentication workflow." .
 
 :PredicateLogic a owl:Class,
@@ -17828,7 +17885,7 @@ Wikipedia contributors. (2021, August 23). Residual neural network. In Wikipedia
 
 :ResourceAccess a owl:Class ;
     rdfs:label "Resource Access" ;
-    rdfs:subClassOf :UserAction ;
+    rdfs:subClassOf :DigitalInformationBearer ;
     :definition "Ephemeral digital artifact comprising a request of a resource and any response from that resource." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Computer_access_control> .
 
@@ -18690,15 +18747,6 @@ The organization collects and models architectural information about the service
     rdfs:isDefinedBy <http://dbpedia.org/resource/Session_(computer_science)> ;
     :definition "In computer science, in particular networking, a session is a semi-permanent interactive information interchange, also known as a dialogue, a conversation or a meeting, between two or more communicating devices, or between a computer and user (see Login session). A session is set up or established at a certain point in time, and then torn down at some later point. An established communication session may involve more than one message in each direction. A session is typically, but not always, stateful, meaning that at least one of the communicating parts needs to save information about the session history in order to be able to communicate, as opposed to stateless communication, where the communication consists of independent requests with responses." ;
     rdfs:seeAlso <https://schema.ocsf.io/objects/session> .
-
-:SessionAuthorizationEvent a owl:Class ;
-    rdfs:label "Session Authorization Event" ;
-    rdfs:subClassOf :AuthorizationEvent,
-        [ a owl:Restriction ;
-            owl:onProperty :caused-by ;
-            owl:someValuesFrom :Authorization ] ;
-    :definition "An event representing the assignment of privileges, roles, or group memberships to a user session, typically during the initiation of a session. Authorization events determine the scope of access and control a user or entity has within a system or application, ensuring compliance with access policies and security principles." ;
-    rdfs:seeAlso <https://schema.ocsf.io/1.3.0/classes/authorize_session> .
 
 :SessionCookie a owl:Class ;
     rdfs:label "Session Cookie" ;
@@ -27389,9 +27437,11 @@ URL analysis may trigger follow-on analytics such as **File Analysis**
 
 :UserAction a owl:Class ;
     rdfs:label "User Action" ;
-    rdfs:subClassOf :DigitalInformationBearer ;
-    :definition "An action performed by a user. Executing commands, granting permissions, and accessing resources are examples of user actions." ;
-    :todo "Subclasses are incorrect" .
+    rdfs:subClassOf :DigitalInformationBearer,
+        [ a owl:Restriction ;
+            owl:onProperty :records ;
+            owl:someValuesFrom :Action ] ;
+    :definition "An action performed by a user. Executing commands, granting permissions, and accessing resources are examples of user actions." .
 
 :UserApplication a owl:Class ;
     rdfs:label "User Application" ;


### PR DESCRIPTION
closes #327 

Refine auth events for alignment with access control semantics

- Removed domain and range constraints for `d3fend-tactical-verb-property`.
- Removed domain and range of `may-be-tactically-associated-with`.
- Introduced and detailed `AccessControlAdministrationEvent`, `AccessControlEvent`, `AccessGrantedEvent`, `AccessDeniedEvent`, `AccessMediationEvent`, `PermissionGrantingEvent`, and `PermissionRevokingEvent`.
- Refactored `LogonEvent` and `LogoffEvent` with causal relationships and session participation.
- Adjusted hierarchy of `Authentication`, `Authorization`, and `ResourceAccess` under `DefensiveAction`.
- Refined `AuthenticationEvent` to include `Agent` and `Credential` participants.
- Removed obsolete events such as `AssignGroupsEvent` and `SessionAuthorizationEvent`.
- Updated `UserAction` with precise subclass restrictions.