### PR TITLE
Fixed a few object property definitions

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -354,7 +354,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :enumerates a owl:ObjectProperty ;
     rdfs:label "enumerates" ;
     rdfs:subPropertyOf :reads ;
-    :definition "definition \"x enumerates y: The subject x takes the action of reading from a digital source y to acquire data and create a list of its contents." .
+    :definition "x enumerates y: The subject x takes the action of reading from a digital source y to acquire data and create a list of its contents." .
 
 :erases a owl:ObjectProperty ;
     rdfs:label "erases" ;
@@ -576,12 +576,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :instructed-by a owl:ObjectProperty ;
     rdfs:label "instructed-by" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "definition \"x instructed-by y: A subject x takes machine instructions from object y.\"" .
+    :definition "x instructed-by y: A subject x takes machine instructions from object y." .
 
 :instructs a owl:ObjectProperty ;
     rdfs:label "instructs" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "definition \"x instructs y: A subject x delivers machine instructions to object y.\"" .
+    :definition "x instructs y: A subject x delivers machine instructions to object y." .
 
 :interprets a owl:ObjectProperty ;
     rdfs:label "interprets" ;


### PR DESCRIPTION
Fixes for a few object property definitions that included the redundant `definition:` in the their `:definition` values.