### PR TITLE
README.md now states that Linux is required to build a distribution.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,6 @@ clean: ## cleans all build artifacts
 	rm -f reports/*
 	$(END)
 
-install-system-deps:
-	yum install make -y
-	$(END)
-
 install-python-deps:
 	pipenv install
 	$(END)

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,10 @@ clean: ## cleans all build artifacts
 	rm -f reports/*
 	$(END)
 
+install-system-deps:
+	yum install make -y
+	$(END)
+
 install-python-deps:
 	pipenv install
 	$(END)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ to many lines in the file. This enables efficient code reviews.
 
 ## System Dependencies
 
+Building the D3FEND ontology distribution must be done in a Linux or Linux-like environment.
+The following packages must be installed:
+
+- make
 - java 15.0.1, other versions may work however
 - python 3.9
 - python pipenv package with `pipenv` in your PATH
@@ -28,7 +32,7 @@ to many lines in the file. This enables efficient code reviews.
 ## Building
 
 The Makefile has all the necessary targets (commands) needed to build the D3FEND ontology.
-Once your system dependencies are installed, Run `make install-deps`, then you can run
+Once your system dependencies are installed, run `make install-deps`, then you can run
 `make all` to build the ontology.
 
 > In order to run `make build/d3fend.csv`, you need to be

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to many lines in the file. This enables efficient code reviews.
 
 ## System Dependencies
 
-Building the D3FEND ontology distribution must be done in a Linux or Linux-like environment.
+Building the D3FEND ontology distribution must be done in a posix-like environment, e.g. Redhat Linux or macOS.
 The following packages must be installed:
 
 - make


### PR DESCRIPTION
Also, the install-system-deps target has been removed from the makefile.  It was RPM-specific.  Instead, README states that `make' must be installed.