### PR TITLE
Add missing tactic to CSV cleaning script.

### DIFF
--- a/src/util/cleancsv.py
+++ b/src/util/cleancsv.py
@@ -3,7 +3,7 @@ import csv
 output_csv = []
 level_0 = []
 
-order = ["Model", "Harden", "Detect", "Isolate", "Deceive", "Evict"]
+order = ["Model", "Harden", "Detect", "Isolate", "Deceive", "Evict", "Restore"]
 
 with open("build/d3fend.csv") as csv_file:
     csv_reader = csv.DictReader(csv_file, delimiter=",")


### PR DESCRIPTION
We rely on the output of this script (i.e. https://d3fend.mitre.org/ontologies/d3fend.csv) and found it to be missing the Restore tactic.

This PR should resolve this issue.