### PR TITLE
Make D3FEND technique a concatenation of label.

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -2,5 +2,7 @@
 
 1. Defensive Techniques are punned as instances of their parent classes.
 1. CamelCase  [IRIs](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier), capitalize all words in the IRI fragment.
+1. Labels for D3FEND defined terms must be in harmony with their IRI fragments.
+    1. e.g. An IRI of `Proxy-basedWebServerAccessMediation` would have the label `Proxy-based Web Server Access Mediation` 
 1. Do not use bracket characters in IRIs.
 1. Do not use unicode characters in IRIs.

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -12461,7 +12461,7 @@ Email files may propagate through many storage systems across the an organizatio
     :definition "Encrypted encapsulation of routable network traffic." ;
     :kb-reference :Reference-SecurityArchitectureForTheInternetProtocol .
 
-:EndpointBasedWebServerAccessMediation a :EndpointBasedWebServerAccessMediation,
+:Endpoint-basedWebServerAccessMediation a :Endpoint-basedWebServerAccessMediation,
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Endpoint-based Web Server Access Mediation" ;
@@ -21179,9 +21179,9 @@ Metadata collection on enterprises can yield large data sets. Storage, indexing,
     rdfs:subClassOf :Organization ;
     :definition "Providers are entities that intentionally offer, supply, or facilitate goods, services, or resources through actions of their agents." .
 
-:ProxyBasedWebServerAccessMediation a owl:Class,
+:Proxy-basedWebServerAccessMediation a owl:Class,
         owl:NamedIndividual,
-        :ProxyBasedWebServerAccessMediation ;
+        :Proxy-basedWebServerAccessMediation ;
     rdfs:label "Proxy-based Web Server Access Mediation" ;
     rdfs:subClassOf :WebSessionAccessMediation ;
     :d3fend-id "D3-PBWSAM" ;
@@ -36218,8 +36218,8 @@ architecture using the Snort NIDS.""" ;
     :has-link "https://doi.org/10.6028/NIST.SP.800-41r1"^^xsd:anyURI ;
     :kb-abstract "Firewalls are devices or programs that control the flow of network traffic between networks or hosts employing differing security postures. This publication provides an overview of several types of firewall technologies and discusses their security capabilities and their relative advantages and disadvantages in detail. It also makes recommendations for establishing firewall policies and for selecting, configuring, testing, deploying, and managing firewall solutions." ;
     :kb-organization "NIST" ;
-    :kb-reference-of :EndpointBasedWebServerAccessMediation,
-        :ProxyBasedWebServerAccessMediation,
+    :kb-reference-of :Endpoint-basedWebServerAccessMediation,
+        :Proxy-basedWebServerAccessMediation,
         :WebSessionAccessMediation ;
     :kb-reference-title "Special Publication 800-41 Revision 1 Guidelines on Firewalls and Firewall Policy" .
 
@@ -36230,10 +36230,10 @@ architecture using the Snort NIDS.""" ;
     :kb-abstract "This publication provides a catalog of security and privacy controls for information systems and organizations to protect organizational operations and assets, individuals, other organizations, and the Nation from a diverse set of threats and risks, including hostile attacks, human errors, natural disasters, structural failures, foreign intelligence entities, and privacy risks. The controls are flexible and customizable and implemented as part of an organization-wide process to manage risk. The controls address diverse requirements derived from mission and business needs, laws, executive orders, directives, regulations, policies, standards, and guidelines. Finally, the consolidated control catalog addresses security and privacy from a functionality perspective (i.e., the strength of functions and mechanisms provided by the controls) and from an assurance perspective (i.e., the measure of confidence in the security or privacy capability provided by the controls). Addressing functionality and assurance helps to ensure that information technology products and the systems that rely on those products are sufficiently trustworthy." ;
     :kb-organization "NIST" ;
     :kb-reference-of :AccessPolicyAdministration,
-        :EndpointBasedWebServerAccessMediation,
+        :Endpoint-basedWebServerAccessMediation,
         :NetworkResourceAccessMediation,
         :PasswordAuthentication,
-        :ProxyBasedWebServerAccessMediation,
+        :Proxy-basedWebServerAccessMediation,
         :RemoteFileAccessMediation,
         :WebSessionAccessMediation ;
     :kb-reference-title "NIST Special Publication 800-53 Revision 5 - Security and Privacy Controls for Information Systems and Organizations" .


### PR DESCRIPTION
Most techniques are simply a concatenation of their label.

We had an infrequent job choke on these two technique since it doesn't follow that guideline.

i.e. 
https://d3fend.mitre.org/technique/d3f:EndpointBasedWebServerAccessMediation/
https://d3fend.mitre.org/technique/d3f:ProxyBasedWebServerAccessMediation/
vs
https://d3fend.mitre.org/technique/d3f:Certificate-basedAuthentication/
https://d3fend.mitre.org/technique/d3f:Hardware-basedWriteProtection/
https://d3fend.mitre.org/technique/d3f:Token-basedAuthentication/
https://d3fend.mitre.org/technique/d3f:Application-basedProcessIsolation/
https://d3fend.mitre.org/technique/d3f:Hardware-basedProcessIsolation/
https://d3fend.mitre.org/technique/d3f:Kernel-basedProcessIsolation/