### PR TITLE
Feature/460 smithmj make ot iris consistent with labels (clean branch sans reverts)

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -19455,34 +19455,6 @@ GE-SRTP: RETURN CONTROLLER TYPE AND ID INFORMATION""" ;
             owl:someValuesFrom :OTDeviceDescriptionMessage ] ;
     :definition "Describe features, abilities, or performance of system components." .
 
-:OTDeviceException a owl:Class ;
-    rdfs:label "OT Exception Message" ;
-    rdfs:subClassOf :OTDiagnosticsMessage ;
-    rdfs:comment """BACnet: Reject: 1
-BACnet: Reject: 2
-BACnet: Reject: 3
-BACnet: Reject: 4
-BACnet: Reject: 5
-BACnet: Reject: 6
-BACnet: Reject: 7
-BACnet: Reject: 8
-BACnet: Reject: 9
-BACnet: Reject: 10 """,
-        """Modbus: Read Exception Status
-Modbus: Exception: Illegal Function
-Modbus: Exception: Illegal Data Address
-Modbus: Exception: Illegal Data Value
-Modbus: Exception: Slave Device Failure
-Modbus: Exception: Acknowledge
-Modbus: Exception: Slave Device Busy
-Modbus: Exception: Memory Parity Error
-Modbus: Exception: Gateway Path Unavailable
-Modbus: Exception: Gateway Target Device Failed to Respond""" ;
-    :definition "An unknown or anomalous condition occurred in the system." ;
-    rdfs:seeAlso <https://icscsi.org/library/Documents/ICS_Protocols/Control%20Microsystems%20-%20DNP3%20User%20and%20Reference%20Manual.pdf>,
-        <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
-        <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
-
 :OTDeviceFirmwareCommand a owl:Class ;
     rdfs:label "OT Device Firmware Command" ;
     rdfs:subClassOf :OTDeviceManagementMessage ;
@@ -19673,12 +19645,40 @@ BACnet: Error: 8""" ;
             owl:someValuesFrom :OTProtocolMessage ] ;
     :definition "A discrete occurrence within an operational technology environment that denotes a significant change in state, execution of a command, or transmission of information." .
 
+:OTExceptionMessage a owl:Class ;
+    rdfs:label "OT Exception Message" ;
+    rdfs:subClassOf :OTDiagnosticsMessage ;
+    rdfs:comment """BACnet: Reject: 1
+BACnet: Reject: 2
+BACnet: Reject: 3
+BACnet: Reject: 4
+BACnet: Reject: 5
+BACnet: Reject: 6
+BACnet: Reject: 7
+BACnet: Reject: 8
+BACnet: Reject: 9
+BACnet: Reject: 10 """,
+        """Modbus: Read Exception Status
+Modbus: Exception: Illegal Function
+Modbus: Exception: Illegal Data Address
+Modbus: Exception: Illegal Data Value
+Modbus: Exception: Slave Device Failure
+Modbus: Exception: Acknowledge
+Modbus: Exception: Slave Device Busy
+Modbus: Exception: Memory Parity Error
+Modbus: Exception: Gateway Path Unavailable
+Modbus: Exception: Gateway Target Device Failed to Respond""" ;
+    :definition "An unknown or anomalous condition occurred in the system." ;
+    rdfs:seeAlso <https://icscsi.org/library/Documents/ICS_Protocols/Control%20Microsystems%20-%20DNP3%20User%20and%20Reference%20Manual.pdf>,
+        <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
+        <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
+
 :OTExceptionMessageEvent a owl:Class ;
     rdfs:label "OT Exception Message Event" ;
     rdfs:subClassOf :OTDiagnosticsMessageEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OTDeviceException ] ;
+            owl:someValuesFrom :OTExceptionMessage ] ;
     :definition "An unknown or anomalous condition occurred in the system." .
 
 :OTHumanMachineInterface a owl:Class ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -19483,14 +19483,6 @@ Modbus: Exception: Gateway Target Device Failed to Respond""" ;
         <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
         <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
 
-:OTDeviceExceptionEvent a owl:Class ;
-    rdfs:label "OT Exception Message Event" ;
-    rdfs:subClassOf :OTDiagnosticsMessageEvent,
-        [ a owl:Restriction ;
-            owl:onProperty :has-participant ;
-            owl:someValuesFrom :OTDeviceException ] ;
-    :definition "An unknown or anomalous condition occurred in the system." .
-
 :OTDeviceFirmwareCommand a owl:Class ;
     rdfs:label "OT Device Firmware Command" ;
     rdfs:subClassOf :OTDeviceManagementMessage ;
@@ -19500,7 +19492,7 @@ Modbus: Exception: Gateway Target Device Failed to Respond""" ;
         <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
 
 :OTDeviceFirmwareCommandEvent a owl:Class ;
-    rdfs:label "OT Firmware Command Event" ;
+    rdfs:label "OT Device Firmware Command Event" ;
     rdfs:subClassOf :OTDeviceManagementMessageEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
@@ -19681,6 +19673,14 @@ BACnet: Error: 8""" ;
             owl:someValuesFrom :OTProtocolMessage ] ;
     :definition "A discrete occurrence within an operational technology environment that denotes a significant change in state, execution of a command, or transmission of information." .
 
+:OTExceptionMessageEvent a owl:Class ;
+    rdfs:label "OT Exception Message Event" ;
+    rdfs:subClassOf :OTDiagnosticsMessageEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :OTDeviceException ] ;
+    :definition "An unknown or anomalous condition occurred in the system." .
+
 :OTHumanMachineInterface a owl:Class ;
     rdfs:label "OT Human Machine Interface" ;
     rdfs:subClassOf :OTEmbeddedComputer,
@@ -19835,7 +19835,7 @@ BACnet: reinitializeDevice """,
         <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
 
 :OTNetworkManagementCommandEvent a owl:Class ;
-    rdfs:label "OT Network Management Message Event" ;
+    rdfs:label "OT Network Management Command Event" ;
     rdfs:subClassOf :OTEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
@@ -20005,7 +20005,7 @@ Modbus: Read FIFO Queue""" ;
             owl:someValuesFrom :OTReadCommand ] ;
     :definition "Read or retrieve data." .
 
-:OTReadDeviceConfigurationDataCommand a owl:Class ;
+:OTReadDeviceConfigurationCommand a owl:Class ;
     rdfs:label "OT Read Device Configuration Command" ;
     rdfs:subClassOf :OTDeviceConfigurationCommand ;
     rdfs:comment "BACnet: deviceCommunicationControl",
@@ -20015,12 +20015,12 @@ Modbus: Read FIFO Queue""" ;
         <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
         <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
 
-:OTReadDeviceConfigurationDataCommandEvent a owl:Class ;
+:OTReadDeviceConfigurationCommandEvent a owl:Class ;
     rdfs:label "OT Read Device Configuration Command Event" ;
     rdfs:subClassOf :OTDeviceConfigurationCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OTReadDeviceConfigurationDataCommand ] ;
+            owl:someValuesFrom :OTReadDeviceConfigurationCommand ] ;
     :definition "Read device configuration." .
 
 :OTReadFileCommand a owl:Class ;
@@ -20047,7 +20047,24 @@ Modbus: Read FIFO Queue""" ;
             owl:someValuesFrom :OTReadFileCommand ] ;
     :definition "Reads data in specified chuncks or the contents of a specified file stored in the file device connected to the PC." .
 
-:OTReadSetValueCommand a owl:Class ;
+:OTReadTimeCommand a owl:Class ;
+    rdfs:label "OT Read Time Command" ;
+    rdfs:subClassOf :OTTimeCommand ;
+    rdfs:comment "example" ;
+    :definition "Read timing mechanisms." ;
+    rdfs:seeAlso <https://icscsi.org/library/Documents/ICS_Protocols/Control%20Microsystems%20-%20DNP3%20User%20and%20Reference%20Manual.pdf>,
+        <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
+        <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
+
+:OTReadTimeCommandEvent a owl:Class ;
+    rdfs:label "OT Read Time Command Event" ;
+    rdfs:subClassOf :OTTimeCommandEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :OTReadTimeCommand ] ;
+    :definition "Read timing mechanisms." .
+
+:OTReadValueCommand a owl:Class ;
     rdfs:label "OT Read Value Command" ;
     rdfs:subClassOf :OTReadCommand,
         [ a owl:Restriction ;
@@ -20082,7 +20099,7 @@ Modbus: Read FIFO Queue""" ;
         <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
         <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
 
-:OTReadSetValueCommandEvent a owl:Class ;
+:OTReadValueCommandEvent a owl:Class ;
     rdfs:label "OT Read Value Command Event" ;
     rdfs:subClassOf :OTReadCommandEvent,
         [ a owl:Restriction ;
@@ -20090,25 +20107,8 @@ Modbus: Read FIFO Queue""" ;
             owl:someValuesFrom :OTLogicVariable ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OTReadSetValueCommand ] ;
+            owl:someValuesFrom :OTReadValueCommand ] ;
     :definition "Reads the contents of the specified number of consecutive parameter areawords starting from the specified word." .
-
-:OTReadTimeCommand a owl:Class ;
-    rdfs:label "OT Read Time Command" ;
-    rdfs:subClassOf :OTTimeCommand ;
-    rdfs:comment "example" ;
-    :definition "Read timing mechanisms." ;
-    rdfs:seeAlso <https://icscsi.org/library/Documents/ICS_Protocols/Control%20Microsystems%20-%20DNP3%20User%20and%20Reference%20Manual.pdf>,
-        <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
-        <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
-
-:OTReadTimeCommandEvent a owl:Class ;
-    rdfs:label "OT Read Time Command Event" ;
-    rdfs:subClassOf :OTTimeCommandEvent,
-        [ a owl:Restriction ;
-            owl:onProperty :has-participant ;
-            owl:someValuesFrom :OTReadTimeCommand ] ;
-    :definition "Read timing mechanisms." .
 
 :OTRemoteModeCommand a owl:Class ;
     rdfs:label "OT Remote Mode Command" ;
@@ -21332,6 +21332,14 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     rdfs:isDefinedBy <http://dbpedia.org/resource/Symbolic_link> ;
     :definition "A POSIX-compliant symbolic link.  These are often fast symbolic links, but need not be." .
 
+:PowerAndThermalDeviceEvent a owl:Class ;
+    rdfs:label "Power and Thermal Device Event" ;
+    rdfs:subClassOf :HardwareDeviceEvent,
+        [ a owl:Restriction ;
+            owl:onProperty :has-participant ;
+            owl:someValuesFrom :Sensor ] ;
+    :definition "An event involving power supplies, batteries, or thermal management devices. These events represent changes in power states, temperature thresholds, or cooling system activity." .
+
 :PowerShellProfileScript a owl:Class ;
     rdfs:label "PowerShell Profile Script" ;
     rdfs:subClassOf :UserInitScript ;
@@ -21343,14 +21351,6 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     rdfs:subClassOf :HardwareDevice ;
     :definition "A power supply is an electrical device or module that converts and regulates energy from a source (e.g., the power grid or batteries) to an appropriate voltage, current, and frequency for one or more loads. It may stand alone or be integrated into its host appliance, often providing overcurrent protection, voltage regulation, or power conditioning for safe, stable operation." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Power_supply> .
-
-:PowerThermalDeviceEvent a owl:Class ;
-    rdfs:label "Power and Thermal Device Event" ;
-    rdfs:subClassOf :HardwareDeviceEvent,
-        [ a owl:Restriction ;
-            owl:onProperty :has-participant ;
-            owl:someValuesFrom :Sensor ] ;
-    :definition "An event involving power supplies, batteries, or thermal management devices. These events represent changes in power states, temperature thresholds, or cooling system activity." .
 
 :PreAuthenticationEvent a owl:Class ;
     rdfs:label "Pre-Authentication Event" ;
@@ -41612,4 +41612,4 @@ With keystroke dynamics the biometric template used to identify an individual is
 
 <wptmp:entity#Reference%20-%20DNS%20Whitelist%20(DNSWL)%20Email%20Authentication%20Method%20Extension> :kb-author "Alessandro Vesely" .
 
-### Serialized using the ttlser deterministic serializer v1.2.3
+### Serialized using the ttlser deterministic serializer v1.2.1

--- a/src/queries/inconsistent-iri.rq
+++ b/src/queries/inconsistent-iri.rq
@@ -1,30 +1,88 @@
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX d3f: <http://d3fend.mitre.org/ontologies/d3fend.owl#>
-
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX d3f: <http://d3fend.mitre.org/ontologies/d3fend.owl#>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+PREFIX d3f:  <http://d3fend.mitre.org/ontologies/d3fend.owl#>
 
 SELECT DISTINCT ?entity ?property ?packed_label
 WHERE {
-     VALUES ?top_class { d3f:D3FENDCore d3f:D3FENDKBThing }
-     ?entity rdfs:subClassOf* ?top_class .
-     MINUS {
-         { ?entity rdfs:subClassOf* d3f:OffensiveTactic }
-         UNION
-         { ?entity rdfs:subClassOf* d3f:Weakness }
-         UNION
-         { ?entity rdfs:subClassOf* d3f:OSAPIFunction }
-     }
-     BIND(rdfs:label AS ?property)
-     ?entity ?property ?value .
-     BIND(REPLACE(?value, " ", "") AS ?packed_label)
-     FILTER NOT EXISTS {
-        FILTER regex(str(?entity), concat(".*#", ?packed_label))
-     }
-     FILTER NOT EXISTS {
-         ?tactic_technique rdfs:subClassOf d3f:OffensiveTechnique .
-	 ?entity rdfs:subClassOf+ ?tactic_technique .
-     }
+  VALUES ?top_class { d3f:D3FENDCore d3f:D3FENDKBThing }
+  ?entity rdfs:subClassOf* ?top_class .
+
+  MINUS {
+    { ?entity rdfs:subClassOf* d3f:OffensiveTactic }
+    UNION
+    { ?entity rdfs:subClassOf* d3f:Weakness }
+    UNION
+    { ?entity rdfs:subClassOf* d3f:OSAPIFunction }
+  }
+
+  BIND(rdfs:label AS ?property)
+  ?entity ?property ?value .
+
+  # Strip punctuation not allowed in IRIs; normalize whitespace
+  BIND(STR(?value) AS ?raw)
+  BIND(REPLACE(?raw, "[’']", "") AS ?p0)                  # apostrophes
+  BIND(REPLACE(?p0, "/", "") AS ?p1)                      # slashes
+  BIND(REPLACE(?p1, "_", "") AS ?p2)                      # underscores
+  #BIND(REPLACE(?p2, "-", "") AS ?p3)                      # hyphens
+  BIND(REPLACE(REPLACE(?p2, "\\(", ""), "\\)", "") AS ?p4)# parentheses
+  BIND(REPLACE(?p4, "\\s+", " ") AS ?ws1)                 # collapse spaces
+  BIND(REPLACE(?ws1, "^\\s+", "") AS ?ws2)                # trim left
+  BIND(REPLACE(?ws2, "\\s+$", "") AS ?norm0)              # trim right
+
+  # Title-case only short prepositions (<= 4 chars)
+  BIND(REPLACE(REPLACE(REPLACE(?norm0, " of ", " Of "), "^of ", "Of "), " of$", " Of") AS ?c1)
+  BIND(REPLACE(REPLACE(REPLACE(?c1, " to ", " To "), "^to ", "To "), " to$", " To") AS ?c2)
+  BIND(REPLACE(REPLACE(REPLACE(?c2, " from ", " From "), "^from ", "From "), " from$", " From") AS ?c3)
+  BIND(REPLACE(REPLACE(REPLACE(?c3, " with ", " With "), "^with ", "With "), " with$", " With") AS ?c4)
+  BIND(REPLACE(REPLACE(REPLACE(?c4, " over ", " Over "), "^over ", "Over "), " over$", " Over") AS ?c5)
+  BIND(REPLACE(REPLACE(REPLACE(?c5, " into ", " Into "), "^into ", "Into "), " into$", " Into") AS ?c6)
+  BIND(REPLACE(REPLACE(REPLACE(?c6, " onto ", " Onto "), "^onto ", "Onto "), " onto$", " Onto") AS ?c7)
+  BIND(REPLACE(REPLACE(REPLACE(?c7, " upon ", " Upon "), "^upon ", "Upon "), " upon$", " Upon") AS ?c8)
+  BIND(REPLACE(REPLACE(REPLACE(?c8, " down ", " Down "), "^down ", "Down "), " down$", " Down") AS ?c9)
+  BIND(REPLACE(REPLACE(REPLACE(?c9, " in ", " In "), "^in ", "In "), " in$", " In") AS ?c10)
+  BIND(REPLACE(REPLACE(REPLACE(?c10, " on ", " On "), "^on ", "On "), " on$", " On") AS ?c11)
+  BIND(REPLACE(REPLACE(REPLACE(?c11, " at ", " At "), "^at ", "At "), " at$", " At") AS ?c12)
+  BIND(REPLACE(REPLACE(REPLACE(?c12, " as ", " As "), "^as ", "As "), " as$", " As") AS ?c13)
+  BIND(REPLACE(REPLACE(REPLACE(?c13, " via ", " Via "), "^via ", "Via "), " via$", " Via") AS ?c14)
+  BIND(REPLACE(REPLACE(REPLACE(?c14, " per ", " Per "), "^per ", "Per "), " per$", " Per") AS ?c15)
+  BIND(REPLACE(REPLACE(REPLACE(?c15, " by ", " By "), "^by ", "By "), " by$", " By") AS ?c16)
+  BIND(REPLACE(REPLACE(REPLACE(?c16, " for ", " For "), "^for ", "For "), " for$", " For") AS ?c17)
+  BIND(REPLACE(REPLACE(REPLACE(?c17, " up ", " Up "), "^up ", "Up "), " up$", " Up") AS ?c18)
+  BIND(REPLACE(REPLACE(REPLACE(?c18, " out ", " Out "), "^out ", "Out "), " out$", " Out") AS ?c19)
+  BIND(REPLACE(REPLACE(REPLACE(?c19, " off ", " Off "), "^off ", "Off "), " off$", " Off") AS ?c20)
+  # Title-case conjunctions 
+  BIND(REPLACE(?c20, " and ", " And ") AS ?c21)
+  BIND(REPLACE(?c21, " nor ", " Nor ") AS ?c22)
+  BIND(REPLACE(?c22, " but ", " But ") AS ?norm)
+
+  # Build the default packed label (remove spaces after capitalization passes)
+  BIND(REPLACE(?norm, " ", "") AS ?packed_default)
+
+  # Manual overrides for HTTP events from the violation list (Http* instead of HTTP*)
+  OPTIONAL {
+    VALUES (?exception_label ?exception_packed) {
+      ("HTTP GET Event"     "HTTPGetEvent")
+      ("HTTP POST Event"    "HTTPPostEvent")
+      ("HTTP PUT Event"     "HTTPPutEvent")
+      ("HTTP DELETE Event"  "HTTPDeleteEvent")
+      ("HTTP OPTIONS Event" "HTTPOptionsEvent")
+      ("HTTP TRACE Event"   "HTTPTraceEvent")
+      ("HTTP CONNECT Event" "HTTPConnectEvent")
+      ("HTTP HEAD Event"    "HTTPHeadEvent")
+    }
+    FILTER(?value = ?exception_label)
+  }
+
+  BIND(COALESCE(?exception_packed, ?packed_default) AS ?packed_label)
+
+  # If an HTTP exception matched, require exact case; otherwise allow case-insensitive match
+  FILTER NOT EXISTS {
+    FILTER(regex(STR(?entity), CONCAT(".*#", ?packed_label, "$")))
+  }
+
+  # Exclude anything under OffensiveTechnique
+  FILTER NOT EXISTS {
+    ?tactic_technique rdfs:subClassOf d3f:OffensiveTechnique .
+    ?entity rdfs:subClassOf+ ?tactic_technique .
+  }
 }


### PR DESCRIPTION
Corrects many OT IRIs and some labels to make them consistent with each other for the same class and fitting their definition and siblings.  Updated inconsistent-iri.rq to reduce false positives on many corner cases.  Down to much smaller 14 violations for inconsistent IRIs in D3FEND ontology (most need correction, a few need adjudications to simplified standard or more special exceptions to query to avoid FP hits). 