### PR TITLE
Operating Mode Refactoring

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -25337,7 +25337,10 @@ When system firmware verification fails a set of predefined responses is typical
     rdfs:label "Change Operating Mode - ATTACK ICS" ;
     skos:prefLabel "Change Operating Mode" ;
     rdfs:subClassOf :ATTACKICSEvasionTechnique,
-        :ATTACKICSExecutionTechnique ;
+        :ATTACKICSExecutionTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :modifies ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     :attack-id "T0858" ;
     :definition "Adversaries may change the operating mode of a controller to gain additional access to engineering functions such as Program Download.   Programmable controllers typically have several modes of operation that control the state of the user program and control access to the controllers API. Operating modes can be physically selected using a key switch on the face of the controller but may also be selected with calls to the controllers API. Operating modes and the mechanisms by which they are selected often vary by vendor and product line. Some commonly implemented operating modes are described below:" .
 

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -498,6 +498,11 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :d3fend-kb-object-property ;
     owl:inverseOf :member-of .
 
+:has-operating-mode a owl:ObjectProperty ;
+    rdfs:label "has-operating-mode" ;
+    rdfs:subPropertyOf :associated-with ;
+    :definition "x has-operating-mode y: The entity x is currently operating in or has the potential to be in operating mode y." .
+
 :has-output a owl:ObjectProperty ;
     rdfs:label "has-output" ;
     rdfs:subPropertyOf :has-participant ;
@@ -17521,8 +17526,8 @@ Wikipedia. (n.d.). Moment (mathematics). [Link](https://en.wikipedia.org/wiki/Mo
 
 :MotionDetector a owl:Class ;
     rdfs:label "Motion Detector" ;
-    rdfs:subClassOf :Sensor, 
-        :HardwareDevice;
+    rdfs:subClassOf :HardwareDevice,
+        :Sensor ;
     rdfs:isDefinedBy <https://dbpedia.org/page/Motion_detector> ;
     :definition "An electrical device that utilizes a sensor to detect nearby motion." .
 
@@ -18465,8 +18470,8 @@ Additionally, after the code file is printed, it could be recovered from the sys
 :OperatingMode a owl:Class ;
     rdfs:label "Operating Mode" ;
     rdfs:subClassOf :SystemPlatformVariable ;
-    :definition "The Operating Mode designates the specific, selectable state of an OT controller that delineates its operational behavior and governs access to engineering functions, commonly including Program, Run, Remote, Test, or Stop." ;
-    :synonym "Keyswitch Position" .
+    :definition "An operating mode is a user selectable option that enables a set of use-case based system capabilities which control a system, product, or service in order to achieve a specified objective." ;
+    rdfs:seeAlso <https://www.wassonstrategics.com/pdf/Wasson%20-%20System_Phases_Modes_and_States_Rev.%20D%20(10-29-14).pdf> .
 
 :OperatingModeMonitoring a :OperatingModeMonitoring,
         owl:Class,
@@ -18475,7 +18480,7 @@ Additionally, after the code file is printed, it could be recovered from the sys
     rdfs:subClassOf :PlatformMonitoring,
         [ a owl:Restriction ;
             owl:onProperty :monitors ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     :d3fend-id "D3-OMM" ;
     :definition "Detects operating modes such as Program, Run, Remote, or Stop." ;
     :kb-article """## How it works
@@ -18495,7 +18500,7 @@ The key switch position is often available as a system diagnostic function block
     rdfs:subClassOf :AccessMediation,
         [ a owl:Restriction ;
             owl:onProperty :restricts ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     :d3fend-id "D3-OPR" ;
     :definition "Restricting unauthorized changes to the operating mode prevents devices from switching into inappropriate or vulnerable states during normal use." ;
     :kb-article """## How it works
@@ -19076,7 +19081,7 @@ Key steps in operational process security monitoring are:
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -19090,10 +19095,10 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTAbortCommand ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OTAbortCommand ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :preceded-by ;
             owl:someValuesFrom :OTRunCommandEvent ] .
@@ -19263,6 +19268,9 @@ CIP: Save """,
             owl:onProperty :contains ;
             owl:someValuesFrom :OTControlProgram ],
         [ a owl:Restriction ;
+            owl:onProperty :has-operating-mode ;
+            owl:someValuesFrom :OTControllerOperatingMode ],
+        [ a owl:Restriction ;
             owl:onProperty :manages ;
             owl:someValuesFrom :OTControlLogicProcess ],
         [ a owl:Restriction ;
@@ -19270,6 +19278,12 @@ CIP: Save """,
             owl:someValuesFrom :OTPowerSupply ] ;
     rdfs:isDefinedBy <https://csrc.nist.gov/glossary/term/controller> ;
     :definition "An OT Controller is an industrial control device that automatically regulates one or more controlled variables in response to command inputs and real-time feedback signals." .
+
+:OTControllerOperatingMode a owl:Class ;
+    rdfs:label "Operating Mode" ;
+    rdfs:subClassOf :OperatingMode ;
+    :definition "The OT controller operating mode designates the specific, selectable state of an OT controller that delineates its operational behavior and governs access to engineering functions, commonly including Program, Run, Remote, Test, or Stop." ;
+    :synonym "Keyswitch Position" .
 
 :OTControlLogicProcess a owl:Class ;
     rdfs:label "OT Control Logic Process" ;
@@ -19733,7 +19747,7 @@ Modbus: Exception: Gateway Target Device Failed to Respond""" ;
     rdfs:subClassOf :ApplicationConfiguration,
         [ a owl:Restriction ;
             owl:onProperty :controls ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment "An OT Mode Switch is a dedicated mechanism, implemented as either a physical keyswitch or a software control, that permits authorized users to transition an OT controller between its operating modes." ;
     :definition "Keyswitch or mode switch is the mechanism for changing the operating mode of an OT controller or device." ;
     rdfs:seeAlso <https://isagca.org/hubfs/2023%20ISA%20Website%20Redesigns/ISAGCA/PDFs/Industrial%20Cybersecurity%20Knowledge%20FINAL.pdf?hsLang=en>,
@@ -19799,7 +19813,7 @@ GE-SRTP: TOGGLE FORCE SYSTEM MEMORY""" ;
     rdfs:subClassOf :OTModifyDeviceConfigurationCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -19813,7 +19827,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceConfigurationCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTModifyDeviceOperatingModeCommand ] ;
@@ -19859,7 +19873,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -19873,7 +19887,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTPauseCommand ],
@@ -19926,7 +19940,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -19940,7 +19954,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTProgramModeCommand ] ;
@@ -20119,7 +20133,7 @@ Modbus: Read FIFO Queue""" ;
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -20136,7 +20150,7 @@ BACnet: reinitializeDevice """,
             owl:someValuesFrom :NetworkTraffic ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTRemoteModeCommand ] ;
@@ -20147,7 +20161,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -20161,7 +20175,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTRunCommand ] ;
@@ -20193,8 +20207,8 @@ BACnet: requestKey """,
 
 :OTSensor a owl:Class ;
     rdfs:label "OT Sensor" ;
-    rdfs:subClassOf :Sensor, 
-        :HardwareDevice, 
+    rdfs:subClassOf :HardwareDevice,
+        :Sensor,
         [ a owl:Restriction ;
             owl:onProperty :may-contain ;
             owl:someValuesFrom :ClientComputer ],
@@ -20230,7 +20244,7 @@ BACnet: requestKey """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -20244,7 +20258,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTStopCommand ],
@@ -20275,7 +20289,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommand,
         [ a owl:Restriction ;
             owl:onProperty :modifies ;
-            owl:someValuesFrom :OperatingMode ] ;
+            owl:someValuesFrom :OTControllerOperatingMode ] ;
     rdfs:comment """BACnet: deviceCommunicationControl
 BACnet: reinitializeDevice """,
         "GE-SRTP: SET PLC (RUN VS STOP)" ;
@@ -20289,7 +20303,7 @@ BACnet: reinitializeDevice """,
     rdfs:subClassOf :OTModifyDeviceOperatingModeCommandEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :OperatingMode ],
+            owl:someValuesFrom :OTControllerOperatingMode ],
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTTestCommand ] ;
@@ -22093,8 +22107,8 @@ Metadata collection on enterprises can yield large data sets. Storage, indexing,
 
 :ProximitySensor a owl:Class ;
     rdfs:label "Proximity Sensor" ;
-    rdfs:subClassOf :Sensor, 
-        :HardwareDevice;
+    rdfs:subClassOf :HardwareDevice,
+        :Sensor ;
     rdfs:isDefinedBy <https://dbpedia.org/page/Proximity_sensor> ;
     :definition "A sensor able to detect the presence of nearby objects without any physical contact." .
 
@@ -41621,4 +41635,4 @@ With keystroke dynamics the biometric template used to identify an individual is
 
 <wptmp:entity#Reference%20-%20DNS%20Whitelist%20(DNSWL)%20Email%20Authentication%20Method%20Extension> :kb-author "Alessandro Vesely" .
 
-### Serialized using the ttlser deterministic serializer v1.2.3
+### Serialized using the ttlser deterministic serializer v1.2.1

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -18470,7 +18470,7 @@ Additionally, after the code file is printed, it could be recovered from the sys
 :OperatingMode a owl:Class ;
     rdfs:label "Operating Mode" ;
     rdfs:subClassOf :SystemPlatformVariable ;
-    :definition "An operating mode is a user selectable option that enables a set of use-case based system capabilities which control a system, product, or service in order to achieve a specified objective." ;
+    :definition "An operating mode designates the specific way a system, product, or service functions for a particular task, configuration, or phase of operation" ;
     rdfs:seeAlso <https://www.wassonstrategics.com/pdf/Wasson%20-%20System_Phases_Modes_and_States_Rev.%20D%20(10-29-14).pdf> .
 
 :OperatingModeMonitoring a :OperatingModeMonitoring,


### PR DESCRIPTION
- Updated definition of `OperatingMode` to be more generic (i.e., for things like safe mode in spacecraft)
- Added new `OTControllerOperatingMode` as sub-class of Operating Mode
- Updated `OperatingModeMonitoring` & `OperatingModeRestriction` to point to `OTControllerOperatingMode`
- Added new `has-operating-mode` object property and updated `OTController` to have a restriction which points to `OTControllerOperatingMode`
- Added restriction to `T0858` to point to `OTControllerOperatingMode`
- Updated all OT*Command classes which pointed to `OperatingMode` to now point to `OTControllerOperatingMode`