### PR TITLE
Fixed InputDevice Description

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -15473,7 +15473,7 @@ Wikipedia. (n.d.). Statistical inference. [Link](https://en.wikipedia.org/wiki/S
     rdfs:subClassOf :HardwareDevice,
         :LocalResource ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Input_device> ;
-    :definition "In computing, an input device is a piece of equipment used to provide data and control signals to an information processing system such as a computer or information appliance. Examples of input devices include keyboards, mouse, scanners, digital cameras, joysticks, and microphones. Input devices can be categorized based on:" .
+    :definition "In computing, an input device is a piece of equipment used to provide data and control signals to an information processing system such as a computer or information appliance. Examples of input devices include keyboards, mouse, scanners, digital cameras, joysticks, and microphones." .
 
 :InputDeviceAnalysis a :InputDeviceAnalysis,
         owl:Class,


### PR DESCRIPTION
Removed the dangling sentence (`Input devices can be categorized based on:`) from the description of `InputDevice`.
