### PR TITLE
Object Property Definition Cleanup

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -40,7 +40,7 @@
     rdfs:subPropertyOf :associated-with,
         :may-access ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02673854-n> ;
-    :definition "x accesses y: An subject x takes the action of reading from, writing into, or executing the stored information in the object y. Reads, writes, and executes are specific cases of accesses." .
+    :definition "x accesses y: A subject x takes the action of reading from, writing into, or executing the stored information in the object y. Reads, writes, and executes are specific cases of accesses." .
 
 :addressed-by a owl:ObjectProperty ;
     rdfs:label "addressed-by" ;
@@ -61,14 +61,14 @@
     rdfs:label "adds" ;
     rdfs:subPropertyOf :associated-with,
         :may-add ;
-    :definition "x adds y: The subject x adds a data object y, such as a file, to some other digital artifact, such as a directory. Examples include an agent or technique adding a record to a database. or a domain entry to a DNS server." .
+    :definition "x adds y: The subject x adds a data object y, such as a file, to some other digital artifact, such as a directory. Examples include an agent or technique adding a record to a database or a domain entry to a DNS server." .
 
 :analyzes a owl:ObjectProperty ;
     rdfs:label "analyzes" ;
     rdfs:subPropertyOf :associated-with,
         :detects ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00738221-v> ;
-    :definition "x analyzes y: The subject x break down object y into components or essential features, assessing y by quantitative methods, qualitative methods, or both.  Usually the analysis is done in terms of some model or framework." .
+    :definition "x analyzes y: The subject x breaks down object y into components or essential features, assessing y by quantitative methods, qualitative methods, or both.  Usually the analysis is done in terms of some model or framework." .
 
 :associated-with a owl:ObjectProperty ;
     rdfs:label "associated-with" ;
@@ -203,7 +203,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "copies" ;
     rdfs:subPropertyOf :creates ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01738810-v> ;
-    :definition "x copies y: An technique or agent x reproduces or makes and exact copy of some digital artifact y." .
+    :definition "x copies y: A technique or agent x reproduces or makes an exact copy of some digital artifact y." .
 
 :copy-of a owl:ObjectProperty ;
     rdfs:label "copy-of" ;
@@ -226,7 +226,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :associated-with,
         :may-create ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01630392-v> ;
-    :definition "x creates y: The subject x bring into existence an object y.  Some technique or agent x creates a persistent digital artifact y (as opposed to production of a consumable or transient object.); i.e., bring forth or generate" ;
+    :definition "x creates y: The subject x brings into existence an object y. Some technique or agent x creates a persistent digital artifact y (as opposed to production of a consumable or transient object.); i.e., bring forth or generate." ;
     rdfs:seeAlso :produces .
 
 :d3fend-general-object-property a owl:ObjectProperty ;
@@ -264,7 +264,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :decodes a owl:ObjectProperty ;
     rdfs:label "decodes" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "x decodes y: Entity x transforms data y to a different form, usually through decompression." .
+    :definition "x decodes y: The entity x transforms data y to a different form, usually through decompression." .
 
 :deletes a owl:ObjectProperty ;
     rdfs:label "deletes" ;
@@ -313,7 +313,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :associated-with ;
     owl:inverseOf :employs ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01161188-v> ;
-    :definition "x employed-by y: An entity x is put into service by a technique or agent y.  Inverse of y employs x." .
+    :definition "x employed-by y: An entity x is put into service by a technique or agent y. Inverse of y employs x." .
 
 :employs a owl:ObjectProperty ;
     rdfs:label "employs" ;
@@ -336,7 +336,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :encodes a owl:ObjectProperty ;
     rdfs:label "encodes" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "x encodes y: Entity x transforms data y to a different form, usually through compression." .
+    :definition "x encodes y: The entity x transforms data y to a different form, usually through compression." .
 
 :encrypts a owl:ObjectProperty ;
     rdfs:label "encrypts" ;
@@ -411,7 +411,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "extends" ;
     rdfs:subPropertyOf :modifies ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00541315-v> ;
-    :definition "x extends y: The entity x extend the scope or range or area of entity y, especially in the sense of widen the range of applications." .
+    :definition "x extends y: The entity x extends the scope or range or area of entity y, especially in the sense of widening the range of applications." .
 
 :filters a owl:ObjectProperty ;
     rdfs:label "filters" ;
@@ -532,7 +532,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "has-recipient" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://www.ontologyrepository.com/CommonCoreOntologies/has_recipient> ;
-    :definition "x has_recipient y: An agent y is the intended recipient and decoder of the information contained in communication x." ;
+    :definition "x has-recipient y: An agent y is the intended recipient and decoder of the information contained in communication x." ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/09651094-n>,
         <http://wordnet-rdf.princeton.edu/id/09788768-n> .
 
@@ -540,7 +540,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "has-sender" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://www.ontologyrepository.com/CommonCoreOntologies/has_sender> ;
-    :definition "x has_sender y: An agent y is the sender and encoder of the information contained in communication x." ;
+    :definition "x has-sender y: An agent y is the sender and encoder of the information contained in communication x." ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/10598214-n> .
 
 :has-weakness a owl:ObjectProperty ;
@@ -580,7 +580,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :implements a owl:ObjectProperty ;
     rdfs:label "implements" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "x implements y: The entity x realize entity y by putting its design or specification into effect." .
+    :definition "x implements y: The entity x realizes entity y by putting its design or specification into effect." .
 
 :initiates a owl:ObjectProperty ;
     rdfs:label "initiates" ;
@@ -607,7 +607,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "installs" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01572394-v> ;
-    :definition "x installs y: An entity x sets up a digital artifact y for subsequent use.  For example, an installation program can install application software." .
+    :definition "x installs y: An entity x sets up digital artifact y for subsequent use.  For example, an installation program can install application software." .
 
 :instructed-by a owl:ObjectProperty ;
     rdfs:label "instructed-by" ;
@@ -623,7 +623,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "interprets" ;
     rdfs:subPropertyOf :executes,
         :may-interpret ;
-    :definition "x interprets y: The subject x interprets the executable script y. The sense of interprets is here 'Parse the source code and perform its behavior directly.'" ;
+    :definition "x interprets y: The subject x interprets the executable script y. The definition of interprets here is 'Parse the source code and perform its behavior directly.'" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Interpreter_(computing)> .
 
 :inventoried-by a owl:ObjectProperty ;
@@ -650,7 +650,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :executes,
         :may-invoke ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/06599393-n> ;
-    :definition "x invokes y: The subject x invokes a system service y by use of an instruction object y that interrupts the program being executed and passes control to the operating system to perform that operation." ;
+    :definition "x invokes y: The subject x invokes a system service by use of an instruction object y that interrupts the program being executed and passes control to the operating system to perform that operation." ;
     rdfs:seeAlso <http://dbpedia.org/resource/System_call> ;
     :todo "Calls in Wordnet can be function call or system / supervisor call; we may want to make this distinction in future.  So far, we have always used this in the second sense (system call.)" .
 
@@ -679,7 +679,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     skos:altLabel "cutoff" ;
     rdfs:subPropertyOf :restricts ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/13781154-n> ;
-    :definition "x limits y: An entity x specifies a designated limit beyond which some entity y cannot function or must be terminated." ;
+    :definition "x limits y: The entity x specifies a designated limit beyond which some entity y cannot function or must be terminated." ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/13780436-n> .
 
 :loaded-by a owl:ObjectProperty ;
@@ -692,7 +692,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "loads" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02236692-v> ;
-    :definition "x loads y: The technique or process x transfers a software from a storage y to a computer's memory for subsequent execution." .
+    :definition "x loads y: The technique or process x transfers a software from storage y to a computer's memory for subsequent execution." .
 
 :manages a owl:ObjectProperty ;
     rdfs:label "manages" ;
@@ -700,13 +700,13 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
         "supervises" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02447914-v> ;
-    :definition "x manages y: The technique or agent x watches and directs the use of a digital artifact y." .
+    :definition "x manages y: The technique or agent x watches and directs the use of digital artifact y." .
 
 :mapped-by a owl:ObjectProperty ;
     rdfs:label "mapped-by" ;
     rdfs:subPropertyOf :associated-with ;
     owl:inverseOf :maps ;
-    :definition "x mapped-by y: The entity x is linked  to another entity by entity y." .
+    :definition "x mapped-by y: The entity x is linked to another entity by entity y." .
 
 :maps a owl:ObjectProperty ;
     rdfs:label "maps" ;
@@ -717,12 +717,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "may-access" ;
     rdfs:subPropertyOf :may-be-associated-with ;
     owl:inverseOf :may-be-accessed-by ;
-    :definition "x may-access y: They entity x may access the thing y; that is, 'x accesses y' may be true." .
+    :definition "x may-access y: The entity x may access the thing y; that is, 'x accesses y' may be true." .
 
 :may-add a owl:ObjectProperty ;
     rdfs:label "may-add" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-add y: They entity x may add the thing y; that is, 'x adds y' may be true." .
+    :definition "x may-add y: The entity x may add the thing y; that is, 'x adds y' may be true." .
 
 :may-be-accessed-by a owl:ObjectProperty ;
     rdfs:label "may-be-accessed-by" ;
@@ -817,7 +817,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-create a owl:ObjectProperty ;
     rdfs:label "may-create" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-create y: They entity x may create the entity y; that is, 'x creates y' may be true." .
+    :definition "x may-create y: The entity x may create the entity y; that is, 'x creates y' may be true." .
 
 :may-deceive a owl:ObjectProperty ;
     rdfs:label "may-deceive" ;
@@ -846,7 +846,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-execute a owl:ObjectProperty ;
     rdfs:label "may-execute" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may execute y: The subject x might take the action of carrying out (executing) y, which is a single software module, function, or instruction." .
+    :definition "x may-execute y: The subject x may take the action of carrying out (executing) y, which is a single software module, function, or instruction." .
 
 :may-harden a owl:ObjectProperty ;
     rdfs:label "may-harden" ;
@@ -863,12 +863,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-interpret a owl:ObjectProperty ;
     rdfs:label "may-interpret" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-interpret y: They entity x may interpret the thing y; that is, 'x interprets y' may be true." .
+    :definition "x may-interpret y: The entity x may interpret the thing y; that is, 'x interprets y' may be true." .
 
 :may-invoke a owl:ObjectProperty ;
     rdfs:label "may-invoke" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-invoke y: They entity x may invoke the thing y; that is, 'x invokes y' may be true." .
+    :definition "x may-invoke y: The entity x may invoke the thing y; that is, 'x invokes y' may be true." .
 
 :may-isolate a owl:ObjectProperty ;
     rdfs:label "may-isolate" ;
@@ -883,12 +883,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-modify a owl:ObjectProperty ;
     rdfs:label "may-modify" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-modify y: They entity x may modify the thing y; that is, 'x modifies y' may be true." .
+    :definition "x may-modify y: The entity x may modify the thing y; that is, 'x modifies y' may be true." .
 
 :may-produce a owl:ObjectProperty ;
     rdfs:label "may-produce" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-produce y: They entity x may produce the thing y; that is, 'x produces y' may be true." .
+    :definition "x may-produce y: The entity x may produce the thing y; that is, 'x produces y' may be true." .
 
 :may-query a owl:ObjectProperty ;
     rdfs:label "may-query" ;
@@ -897,12 +897,12 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-run a owl:ObjectProperty ;
     rdfs:label "may-run" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-run y: They entity x may run the thing y; that is, 'x runs y' may be true." .
+    :definition "x may-run y: The entity x may run the thing y; that is, 'x runs y' may be true." .
 
 :may-transfer a owl:ObjectProperty ;
     rdfs:label "may-transfer" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-transfer y: They entity x might send the thing y; that is, 'x transfers y' may be true." .
+    :definition "x may-transfer y: They entity x may send the thing y; that is, 'x transfers y' may be true." .
 
 :mediates-access-to a owl:ObjectProperty ;
     rdfs:label "mediates-access-to" ;
@@ -942,7 +942,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :associated-with,
         :detects ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02167732-v> ;
-    :definition "x monitors y: The technique or agent x keep tabs on; keeps an eye on; or keep the digital artifact y under surveillance." .
+    :definition "x monitors y: The technique or agent x keep tabs on, keeps an eye on, or keeps the digital artifact y under surveillance." .
 
 :narrower a owl:ObjectProperty ;
     rdfs:label "narrower" ;
@@ -1005,7 +1005,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "participates-in" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://purl.obolibrary.org/obo/BFO_0000056> ;
-    :definition "x participates-in y: The object x takes part in the event y, signifying that x contributes to or is affected by the event’s occurrence in some way." .
+    :definition "x participates-in y: The object x takes part in the event y, signifying that x contributes to or is affected by the event's occurrence in some way." .
 
 :powered-by a owl:ObjectProperty ;
     rdfs:label "powered-by" ;
@@ -1035,7 +1035,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
         owl:TransitiveProperty ;
     rdfs:label "process-ancestor" ;
     rdfs:subPropertyOf :process-property ;
-    :definition "x process-ancestor y: The process y is a process ancestor of process x, indicating one or more process creation events were conducted were started at process y and subsequently created process x." .
+    :definition "x process-ancestor y: The process y is a process ancestor of process x, indicating one or more process creation events were conducted at process y and subsequently created process x." .
 
 :process-image-path a owl:ObjectProperty ;
     rdfs:label "process-image-path" ;
@@ -1052,7 +1052,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :process-property a owl:ObjectProperty ;
     rdfs:label "process-property" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "x process-property y: Process x has the a process-property y.  This is generalization for specific process object properties." .
+    :definition "x process-property y: The process x has the a process-property y.  This is generalization for specific process object properties." .
 
 :process-user a owl:ObjectProperty ;
     rdfs:label "process-user" ;
@@ -1149,19 +1149,19 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :associated-with,
         :isolates ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00234091-v> ;
-    :definition "x restricts y: An entity x bounds the use of entity y." .
+    :definition "x restricts y: The entity x bounds the use of entity y." .
 
 :resume a owl:ObjectProperty ;
     rdfs:label "resume" ;
     rdfs:subPropertyOf :d3fend-process-object-property ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00350758-v> ;
-    :definition "The agent or technique x continues a previous action on entity y. Usually occurs after suspension on y." .
+    :definition "x resume y: The agent or technique x continues a previous action on entity y. Usually occurs after suspension on y." .
 
 :resumes a owl:ObjectProperty ;
     rdfs:label "resumes" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00350758-v> ;
-    :definition "The agent or technique x continues a previous action on entity y. Usually occurs after suspension on y." .
+    :definition "x resumes y: The agent or technique x continues a previous action on entity y. Usually occurs after suspension on y." .
 
 :runs a owl:ObjectProperty ;
     rdfs:label "runs" ;
@@ -1203,7 +1203,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :associated-with,
         :hardens ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00165779-v> ;
-    :definition "x strengthens y: The technique x make digital artifact y resistant (to harm or misuse.)" .
+    :definition "x strengthens y: The technique x makes digital artifact y resistant (to harm or misuse.)" .
 
 :summarizes a owl:ObjectProperty ;
     rdfs:label "summarizes" ;
@@ -1240,7 +1240,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :unmounts a owl:ObjectProperty ;
     rdfs:label "unmounts" ;
     rdfs:subPropertyOf :associated-with ;
-    :definition "x unmounts y: An operation x removes the access via computer system's file system the availability of files and directories on a storage artifact y.  Unmounts reverse or undo prior mount operations." ;
+    :definition "x unmounts y: An operation x removes the access via computer system's file system the availability of files and directories on storage artifact y.  Unmounts reverse or undo prior mount operations." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Mount_(computing)> .
 
 :updates a owl:ObjectProperty ;
@@ -1252,20 +1252,20 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :use-limits a owl:ObjectProperty ;
     rdfs:label "use-limits" ;
     rdfs:subPropertyOf :limits ;
-    :definition "x use-limits y: An entity x specifies a designated number of uses beyond which some entity y cannot function or must be terminated." ;
+    :definition "x use-limits y: The entity x specifies a designated number of uses beyond which some entity y cannot function or must be terminated." ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/13781154-n> .
 
 :used-by a owl:ObjectProperty ;
     rdfs:label "used-by" ;
     rdfs:subPropertyOf :associated-with ;
     owl:inverseOf :uses ;
-    :definition "x used-by y: is inverse of y uses x." .
+    :definition "x used-by y: The inverse of y uses x." .
 
 :uses a owl:ObjectProperty ;
     rdfs:label "uses" ;
     rdfs:subPropertyOf :associated-with ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01161188-v> ;
-    :definition "x uses y: An entity x puts into service a resource or implement y; makes y work or employ for a particular purpose or for its inherent or natural purpose." .
+    :definition "x uses y: The entity x puts into service a resource or implement y; makes y work or employ for a particular purpose or for its inherent or natural purpose." .
 
 :validated-by a owl:ObjectProperty ;
     rdfs:label "validated-by" ;
@@ -1285,7 +1285,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :analyzes,
         :associated-with ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/00666401-v> ;
-    :definition "x verifies y: A technique x confirms the truth of a digital artifact y." ;
+    :definition "x verifies y: The technique x confirms the truth of a digital artifact y." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Formal_verification>,
         <http://dbpedia.org/resource/Runtime_verification>,
         <http://wordnet-rdf.princeton.edu/id/00665271-v> ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -40,7 +40,7 @@
     rdfs:subPropertyOf :associated-with,
         :may-access ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/02673854-n> ;
-    :definition "x accesses y: A subject x takes the action of reading from, writing into, or executing the stored information in the object y. Reads, writes, and executes are specific cases of accesses." .
+    :definition "x accesses y: The subject x takes the action of reading from, writing into, or executing the stored information in the object y. Reads, writes, and executes are specific cases of accesses." .
 
 :addressed-by a owl:ObjectProperty ;
     rdfs:label "addressed-by" ;


### PR DESCRIPTION
Went through all existing object property definitions and fixed:

1. Typos
2. Grammar issues
3. In a few cases, there were textual changes to the definition to make it clearer
