### PR TITLE
EX-0014.02/Bus Message Auth

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -5403,7 +5403,7 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     :kb-article """## How it works
 Bus Message Authentication functions as a continuous validation layer that operates between the physical transmission of a signal and the application layer's processing of data. Every node on a bus network is provisioned with a cryptographic key and a synchronized 'freshness' state (such as a monotonic counter). When a node prepares to transmit, it generates a Message Authentication Code (MAC) which is created by hashing the message content, the sender's unique ID, and the current freshness value using its secret key. This MAC is then appended to the outgoing frame.
 
-As messages circulate on the bus network, receiving nodes do not immediately trust the incoming data. Instead, a hardware controller intercepts the frame and performs a real-time parallel verification. The controller re-calculates the expected MAC based on its own copy of the key and the current network freshness state. If the received MAC matches the calculated one, the message is passed to the system for further action. If the MAC is missing, incorrect, or stale (indicating a replay of an older message), the hardware silently drops the frame or triggers a security alert. 
+As messages circulate on the bus network, receiving nodes do not immediately trust the incoming data. Instead, a hardware controller intercepts the frame and performs a real-time parallel verification. The controller re-calculates the expected MAC based on its own copy of the key and the current network freshness state. If the received MAC matches the calculated one, the message is passed to the system for further action. If the MAC is missing, incorrect, or stale (indicating a replay of an older message), the hardware silently drops the frame or triggers a security alert.
 
 ## Considerations
 * Bandwidth Overhead: Adding authentication tags (MACs) and freshness values reduces the effective data throughput; this requires a trade-off between the desired security level (tag length) and the available bus capacity.
@@ -39153,15 +39153,6 @@ Access is determined based on the attributes associated with subjects (requester
     rdfs:subClassOf :TechniqueReference ;
     :pref-label "User Manual" .
 
-:UserMessageHardening a owl:Class,
-        owl:NamedIndividual,
-        :UserMessageHardening ;
-    rdfs:label "User Message Hardening" ;
-    rdfs:subClassOf :MessageHardening ;
-    :d3fend-id "D3-UMH" ;
-    :definition "User message hardening includes measures taken to ensure the confidentiality and integrity of user to user computer messages." ;
-    :synonym "Email Or Messaging Hardening" .
-
 :UserProcess a owl:Class ;
     rdfs:label "User Process" ;
     rdfs:subClassOf :Process ;
@@ -45690,4 +45681,4 @@ With keystroke dynamics the biometric template used to identify an individual is
 
 <wptmp:entity#Reference%20-%20DNS%20Whitelist%20(DNSWL)%20Email%20Authentication%20Method%20Extension> :kb-author "Alessandro Vesely" .
 
-### Serialized using the ttlser deterministic serializer v1.2.1
+### Serialized using the ttlser deterministic serializer v1.2.3

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -14939,28 +14939,6 @@ Analyzing the interaction of a piece of code with a system while the code is bei
     :definition "Dynamic program analysis is the analysis of computer software that is performed by executing programs on a real or virtual processor." ;
     :todo "Find better full description; wikipedia entry is too narrow in focus after first sentence and misses a lot of the security aspects" .
 
-:DynamicBusMessageTimingOrchestration a :DynamicBusMessageTimingOrchestration,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Dynamic Bus Message Timing Orchestration" ;
-    rdfs:subClassOf :BusMessageHardening ;
-    :d3fend-id "D3-DBMTO" ;
-    :definition "Embeds synchronized, cryptographically-derived timing delays into the intervals between bus messages, using the inter-frame space as a non-data-based authentication channel." ;
-    :kb-article """## How it works
-Dynamic Bus Message Timing Orchestration functions by transforming the idle Inter-Frame Space (IFS), the silent period between two consecutive bus messages, into a dynamic authentication channel. In a standard communications bus protocol, this gap is typically a static, fixed duration used only for synchronization or bus recovery. Under this countermeasure, the gap becomes a temporal secret that changes for every message according to a pre-shared, synchronized cryptographic sequence.
-
-As bus messages are transmitted, both the sender and the designated bus monitor calculate the required delay for the next transmission using a synchronized internal state, such as a pseudo-random number generator or a rolling code. For a message to be accepted as legitimate, its arrival time relative to the previous message must deviate by a precise, sub-microsecond value that matches this calculated secret.
-
-The system serves as a temporal gatekeeper: if an attacker attempts to inject a malicious bus message, they will statistically fail to match the required timing gap because they lack the underlying cryptographic synchronization. The bus monitor identifies any message falling outside this narrow, shifting temporal window as an intrusion.
-
-## Considerations
-* Clock Drift and Synchronization: All bus network nodes must maintain a high-precision temporal lock; if a node's clock drifts beyond the "timing secret" increment, its legitimate bus messages will be rejected.
-
-* Hardware Jitter: The inherent electrical noise and processing jitter of the bus network nodes must be lower than the timing increments used for the secret, otherwise the system will experience high false-alarm rates.
-
-* Protocol Impact: While no additional data bytes are added to the payload, the intentional introduction of variable delays slightly increases the overall cycle time of the bus, which may impact strictly deterministic real-time systems.""" ;
-    :kb-reference :Reference-ZbCANAZeroByteCANDefenseSystem .
-
 :ElectricalSignal a owl:Class ;
     rdfs:label "Electrical Signal" ;
     rdfs:subClassOf :Signal ;
@@ -45568,16 +45546,6 @@ With keystroke dynamics the biometric template used to identify an individual is
     :kb-reference-of :InputDeviceAnalysis ;
     :kb-reference-title "Keystroke Dynamics" ;
     :todo "MITRE Analysis was not found" .
-
-:Reference-ZbCANAZeroByteCANDefenseSystem a :AcademicPaperReference,
-        owl:NamedIndividual ;
-    rdfs:label "Reference - ZbCAN: A Zero-Byte CAN Defense System" ;
-    :has-link "https://www.usenix.org/system/files/sec23fall-prepub-381-serag.pdf"^^xsd:anyURI ;
-    :kb-abstract "Controller Area Network (CAN) is a widely used network protocol. In addition to being the main communication medium for vehicles, it is also used in factories, medical equipment, elevators, and avionics. Unfortunately, CAN was designed without any security features. Consequently, it has come under scrutiny by the research community, showing its security weakness. Recent works have shown that a single compromised ECU on a CANbuscan launch a multitude of attacks ranging from message injection, to bus flooding, to attacks exploiting CAN's error handling mechanism. Although several works have attempted to secure CAN, we argue that none of their approaches could be widely adopted for reasons inherent in their design. In this work, we introduce ZBCAN, a defense system that uses zero bytes of the CAN frame to secure against the most common CAN attacks, including message injection, impersonation, flooding, and error handling, without using encryption or MACs, while taking into consideration performance metrics such as delay, busload, and data-rate." ;
-    :kb-author "Khaled Serag, Rohit Bhatia, Akram Faqih, Muslum Ozgur Ozmen, Vireshwar Kumar, Z. Berkay Celik, Dongyan Xu" ;
-    :kb-mitre-analysis "This paper introduces a backwards-compatible defense framework that secures Controller Area Networks (CAN) by using a secret, dynamically generated sequence of inter-frame space timings to detect and preemptively block malicious message injections without requiring cryptographic overhead or payload modifications." ;
-    :kb-reference-of :DynamicBusMessageTimingOrchestration ;
-    :kb-reference-title "ZbCAN: A Zero-Byte CAN Defense System" .
 
 :RegOpenKeyA a :GetSystemConfigValue,
         owl:NamedIndividual ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -5394,7 +5394,7 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Bus Message Authentication" ;
-    rdfs:subClassOf :BusMessageHardening,
+    rdfs:subClassOf :MessageAuthentication,
         [ a owl:Restriction ;
             owl:onProperty :authenticates ;
             owl:someValuesFrom :BusMessage ] ;
@@ -5414,17 +5414,6 @@ As messages circulate on the bus network, receiving nodes do not immediately tru
 
 * Protocol Transparency: In legacy environments, authentication must often be implemented as a shim that remains compatible with existing protocol standards to avoid breaking legacy hardware.""" ;
     :kb-reference :Reference-ControllerAreaNetworkMessageAuthentication .
-
-:BusMessageHardening a :BusMessageHardening,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Bus Message Hardening" ;
-    rdfs:subClassOf :MessageHardening,
-        [ a owl:Restriction ;
-            owl:onProperty :hardens ;
-            owl:someValuesFrom :BusMessage ] ;
-    :d3fend-id "D3-BMH" ;
-    :definition "The use of cryptographic authentication, data integrity checks, or active protocol enforcement within bus message structures to prevent the unauthorized injection, replay, or modification of bus-level communications." .
 
 :BusNetwork a owl:Class ;
     rdfs:label "Bus Network" ;
@@ -20482,6 +20471,56 @@ Email and messaging are frequently used to deliver malicious content to targets.
 Emails and messages are also complex data structures. They contain files and links, and complex data encodings which vary region to region. Thus the defensive techniques used to analyze emails and messages are highly varied ranging from deep content analysis and execution to social network graph-style analytics to analyze trust or risk.""" ;
     :synonym "Electronic Message Analysis",
         "Email Or Messaging Analysis" .
+
+:MessageAuthentication a :MessageAuthentication,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Message Authentication" ;
+    rdfs:subClassOf :MessageHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :authenticates ;
+            owl:someValuesFrom :DigitalMessage ] ;
+    :d3fend-id "D3-MAN" ;
+    :definition "Authenticating the sender of a message and ensuring message integrity." ;
+    :kb-article """## How it works
+
+### Digital Signature
+Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.
+
+### Message Authentication Code (MAC)
+MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.
+
+## Considerations
+- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.
+- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.
+- Symmetric keys must be exchanged securely via a private channel and management of new symmetric keys are needed for each pair of participants wishing to exchange messages.""" ;
+    :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
+        :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
+
+:MessageEncryption a :MessageEncryption,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Message Encryption" ;
+    rdfs:subClassOf :MessageHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :encrypts ;
+            owl:someValuesFrom :DigitalMessage ] ;
+    :d3fend-id "D3-MENCR" ;
+    :definition "Encrypting a message body using a cryptographic key." ;
+    :kb-article """## How it works
+
+### Asymmetric Cryptography
+Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement user message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.
+
+### Symmetric Cryptography
+Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient. For synchronous or low-latency environments (like a message bus), a pre-shared or dynamically derived symmetric key is typically used to minimize computational overhead.
+
+## Considerations
+- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).
+- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
+- Secure transfer of private keys between multiple devices.
+- Encryption adds latency and increases CPU utilization; while negligible for user-to-user messages, it can be a critical factor for real-time bus systems.""" ;
+    :kb-reference :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
 
 :MessageHardening a :MessageHardening,
         owl:Class,
@@ -39104,54 +39143,6 @@ Access is determined based on the attributes associated with subjects (requester
     rdfs:label "User Manual Reference" ;
     rdfs:subClassOf :TechniqueReference ;
     :pref-label "User Manual" .
-
-:UserMessageAuthentication a owl:Class,
-        owl:NamedIndividual,
-        :UserMessageAuthentication ;
-    rdfs:label "User Message Authentication" ;
-    rdfs:subClassOf :UserMessageHardening,
-        [ a owl:Restriction ;
-            owl:onProperty :authenticates ;
-            owl:someValuesFrom :UserToUserMessage ] ;
-    :d3fend-id "D3-UMAN" ;
-    :definition "Authenticating the sender of a message and ensuring message integrity." ;
-    :kb-article """## How it works
-
-### Digital Signature
-Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.
-
-### Message Authentication Code (MAC)
-MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.
-
-## Considerations
-- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.
-- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.
-- Symmetric keys must be exchanged securely via a private channel and management of new symmetric keys are needed for each pair of participants wishing to exchange messages.""" ;
-    :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
-        :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
-
-:UserMessageEncryption a owl:Class,
-        owl:NamedIndividual,
-        :UserMessageEncryption ;
-    rdfs:label "User Message Encryption" ;
-    rdfs:subClassOf :UserMessageHardening,
-        [ a owl:Restriction ;
-            owl:onProperty :encrypts ;
-            owl:someValuesFrom :UserToUserMessage ] ;
-    :d3fend-id "D3-UMENCR" ;
-    :definition "Encrypting a message body using a cryptographic key." ;
-    :kb-article """## How it works
-
-### Asymmetric Cryptography
-Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.
-### Symmetric Cryptography
-Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient.
-
-## Considerations
-- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).
-- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
-- Secure transfer of private keys between multiple devices.""" ;
-    :kb-reference :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
 
 :UserMessageHardening a owl:Class,
         owl:NamedIndividual,

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -5390,6 +5390,17 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :DigitalMessage ;
     :definition "A digital message potentially containing commands, telemetry, or status signals, encoded in a bus protocol and conveyed over a bus within one or more frames." .
 
+:BusMessageHardening a :BusMessageHardening,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bus Message Hardening" ;
+    rdfs:subClassOf :DefensiveTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :BusMessage ] ;
+    :d3fend-id "D3-BMH" ;
+    :definition "The use of cryptographic authentication, data integrity checks, or active protocol enforcement within bus message structures to prevent the unauthorized injection, replay, or modification of bus-level communications." .
+
 :BusNetwork a owl:Class ;
     rdfs:label "Bus Network" ;
     skos:altLabel "Bus",
@@ -20446,54 +20457,6 @@ Email and messaging are frequently used to deliver malicious content to targets.
 Emails and messages are also complex data structures. They contain files and links, and complex data encodings which vary region to region. Thus the defensive techniques used to analyze emails and messages are highly varied ranging from deep content analysis and execution to social network graph-style analytics to analyze trust or risk.""" ;
     :synonym "Electronic Message Analysis",
         "Email Or Messaging Analysis" .
-
-:MessageAuthentication a :MessageAuthentication,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Message Authentication" ;
-    rdfs:subClassOf :MessageHardening,
-        [ a owl:Restriction ;
-            owl:onProperty :authenticates ;
-            owl:someValuesFrom :UserToUserMessage ] ;
-    :d3fend-id "D3-MAN" ;
-    :definition "Authenticating the sender of a message and ensuring message integrity." ;
-    :kb-article """## How it works
-
-### Digital Signature
-Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.
-
-### Message Authentication Code (MAC)
-MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.
-
-## Considerations
-- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.
-- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.
-- Symmetric keys must be exchanged securely via a private channel and management of new symmetric keys are needed for each pair of participants wishing to exchange messages.""" ;
-    :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
-        :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
-
-:MessageEncryption a :MessageEncryption,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Message Encryption" ;
-    rdfs:subClassOf :MessageHardening,
-        [ a owl:Restriction ;
-            owl:onProperty :encrypts ;
-            owl:someValuesFrom :UserToUserMessage ] ;
-    :d3fend-id "D3-MENCR" ;
-    :definition "Encrypting a message body using a cryptographic key." ;
-    :kb-article """## How it works
-
-### Asymmetric Cryptography
-Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.
-### Symmetric Cryptography
-Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient.
-
-## Considerations
-- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).
-- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
-- Secure transfer of private keys between multiple devices.""" ;
-    :kb-reference :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
 
 :MessageHardening a :MessageHardening,
         owl:Class,
@@ -39116,6 +39079,54 @@ Access is determined based on the attributes associated with subjects (requester
     rdfs:label "User Manual Reference" ;
     rdfs:subClassOf :TechniqueReference ;
     :pref-label "User Manual" .
+
+:UserMessageAuthentication a owl:Class,
+        owl:NamedIndividual,
+        :UserMessageAuthentication ;
+    rdfs:label "User Message Authentication" ;
+    rdfs:subClassOf :UserMessageHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :authenticates ;
+            owl:someValuesFrom :UserToUserMessage ] ;
+    :d3fend-id "D3-UMAN" ;
+    :definition "Authenticating the sender of a message and ensuring message integrity." ;
+    :kb-article """## How it works
+
+### Digital Signature
+Digital signatures are used to verifying a message is from the expected sender. In email, Secure/Multipurpose Internet Mail Extensions (S/MIME) protocol is typically used to digitally sign messages. A hash value of the sender's message is created and encrypted with the sender's private key to create a digital signature. The message and the digital signature are sent to the recipient where the sender's public key is used to decrypt the digital signature and compute the hash of the message. The computed hash is compared with the hash from the received message, and any difference in the hash values signify the message did not originate from the sender and has been alerted in transit.
+
+### Message Authentication Code (MAC)
+MAC is a fixed size string that is appended to a message to provide message authentication and integrity. The sender MAC signing algorithm takes as input a secret symmetric key shared between sender and recipient and the message to calculate a short tag that is appended to the message. The recipient receives the message with the appended tag, and a MAC verification algorithm is run using the symmetric key to verify the message came from the stated sender and ensure the message has not been tampered with.
+
+## Considerations
+- Public keys associated with digital signatures should be verified by a Certification Authority (CA) to prevent impersonation. The CA verifies the owner of a public key and puts the sender's identity and public key into a certificate that is signed by the CA.
+- Digital signatures provide non-repudiation where a third party can verify the authenticity of the message using the sender's digital certificate signed by the CA.
+- Symmetric keys must be exchanged securely via a private channel and management of new symmetric keys are needed for each pair of participants wishing to exchange messages.""" ;
+    :kb-reference :Reference-DomainKeysIdentifiedMail-Signatures-IETF,
+        :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
+
+:UserMessageEncryption a owl:Class,
+        owl:NamedIndividual,
+        :UserMessageEncryption ;
+    rdfs:label "User Message Encryption" ;
+    rdfs:subClassOf :UserMessageHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :encrypts ;
+            owl:someValuesFrom :UserToUserMessage ] ;
+    :d3fend-id "D3-UMENCR" ;
+    :definition "Encrypting a message body using a cryptographic key." ;
+    :kb-article """## How it works
+
+### Asymmetric Cryptography
+Asymmetric encryption is typically accomplished using public and private key certificates based on the X.509 standard. The sender encrypts messages using the recipient's public key and the receipt decrypts the message using their private key. Standards that can be used to implement message encryption include S/MIME (Secure/Multipurpose Internet Mail Extensions) and PGP.
+### Symmetric Cryptography
+Symmetric encryption uses the same cryptographic key by both the sender and receiver to encrypt and decrypt a message. Asymmetric key exchange protocols such as Diffie-Hellman can be used to share the cryptographic key with the recipient.
+
+## Considerations
+- Separate configuration settings to enable message encryption are often needed for each messenger client (e.g. webmail, desktop client, mobile).
+- Continuous monitoring to ensure private keys are not compromised and the certificate authority (CA) is trusted.
+- Secure transfer of private keys between multiple devices.""" ;
+    :kb-reference :Reference-SecureMultipurposeInternetMailExtensionsMIME-Version3.1 .
 
 :UserMessageHardening a owl:Class,
         owl:NamedIndividual,

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -5390,11 +5390,36 @@ Ensemble learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Ensemble_lea
     rdfs:subClassOf :DigitalMessage ;
     :definition "A digital message potentially containing commands, telemetry, or status signals, encoded in a bus protocol and conveyed over a bus within one or more frames." .
 
+:BusMessageAuthentication a :BusMessageAuthentication,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Bus Message Authentication" ;
+    rdfs:subClassOf :BusMessageHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :authenticates ;
+            owl:someValuesFrom :BusMessage ] ;
+    :d3fend-id "D3-BMA" ;
+    :definition "Applies cryptographic primitives to individual bus frames to verify the sender's identity and ensure the integrity of the data payload." ;
+    :kb-article """## How it works
+Bus Message Authentication functions as a continuous validation layer that operates between the physical transmission of a signal and the application layer's processing of data. Every node on a bus network is provisioned with a cryptographic key and a synchronized 'freshness' state (such as a monotonic counter). When a node prepares to transmit, it generates a Message Authentication Code (MAC) which is created by hashing the message content, the sender's unique ID, and the current freshness value using its secret key. This MAC is then appended to the outgoing frame.
+
+As messages circulate on the bus network, receiving nodes do not immediately trust the incoming data. Instead, a hardware controller intercepts the frame and performs a real-time parallel verification. The controller re-calculates the expected MAC based on its own copy of the key and the current network freshness state. If the received MAC matches the calculated one, the message is passed to the system for further action. If the MAC is missing, incorrect, or stale (indicating a replay of an older message), the hardware silently drops the frame or triggers a security alert. 
+
+## Considerations
+* Bandwidth Overhead: Adding authentication tags (MACs) and freshness values reduces the effective data throughput; this requires a trade-off between the desired security level (tag length) and the available bus capacity.
+
+* Real-Time Latency: Cryptographic processing must occur in hardware (e.g., via AES-NI, FPGA logic, or specialized ASICs) to meet the deterministic timing constraints of safety-critical systems.
+
+* Key Management: A robust mechanism for secure key storage and lifecycle management (e.g., rotation and revocation) is required to ensure that a single compromised node does not jeopardize the entire network.
+
+* Protocol Transparency: In legacy environments, authentication must often be implemented as a shim that remains compatible with existing protocol standards to avoid breaking legacy hardware.""" ;
+    :kb-reference :Reference-ControllerAreaNetworkMessageAuthentication .
+
 :BusMessageHardening a :BusMessageHardening,
         owl:Class,
         owl:NamedIndividual ;
     rdfs:label "Bus Message Hardening" ;
-    rdfs:subClassOf :DefensiveTechnique,
+    rdfs:subClassOf :MessageHardening,
         [ a owl:Restriction ;
             owl:onProperty :hardens ;
             owl:someValuesFrom :BusMessage ] ;
@@ -14913,6 +14938,28 @@ Analyzing the interaction of a piece of code with a system while the code is bei
     rdfs:isDefinedBy <http://dbpedia.org/resource/Dynamic_program_analysis> ;
     :definition "Dynamic program analysis is the analysis of computer software that is performed by executing programs on a real or virtual processor." ;
     :todo "Find better full description; wikipedia entry is too narrow in focus after first sentence and misses a lot of the security aspects" .
+
+:DynamicBusMessageTimingOrchestration a :DynamicBusMessageTimingOrchestration,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Dynamic Bus Message Timing Orchestration" ;
+    rdfs:subClassOf :BusMessageHardening ;
+    :d3fend-id "D3-DBMTO" ;
+    :definition "Embeds synchronized, cryptographically-derived timing delays into the intervals between bus messages, using the inter-frame space as a non-data-based authentication channel." ;
+    :kb-article """## How it works
+Dynamic Bus Message Timing Orchestration functions by transforming the idle Inter-Frame Space (IFS), the silent period between two consecutive bus messages, into a dynamic authentication channel. In a standard communications bus protocol, this gap is typically a static, fixed duration used only for synchronization or bus recovery. Under this countermeasure, the gap becomes a temporal secret that changes for every message according to a pre-shared, synchronized cryptographic sequence.
+
+As bus messages are transmitted, both the sender and the designated bus monitor calculate the required delay for the next transmission using a synchronized internal state, such as a pseudo-random number generator or a rolling code. For a message to be accepted as legitimate, its arrival time relative to the previous message must deviate by a precise, sub-microsecond value that matches this calculated secret.
+
+The system serves as a temporal gatekeeper: if an attacker attempts to inject a malicious bus message, they will statistically fail to match the required timing gap because they lack the underlying cryptographic synchronization. The bus monitor identifies any message falling outside this narrow, shifting temporal window as an intrusion.
+
+## Considerations
+* Clock Drift and Synchronization: All bus network nodes must maintain a high-precision temporal lock; if a node's clock drifts beyond the "timing secret" increment, its legitimate bus messages will be rejected.
+
+* Hardware Jitter: The inherent electrical noise and processing jitter of the bus network nodes must be lower than the timing increments used for the secret, otherwise the system will experience high false-alarm rates.
+
+* Protocol Impact: While no additional data bytes are added to the payload, the intentional introduction of variable delays slightly increases the overall cycle time of the bus, which may impact strictly deterministic real-time systems.""" ;
+    :kb-reference :Reference-ZbCANAZeroByteCANDefenseSystem .
 
 :ElectricalSignal a owl:Class ;
     rdfs:label "Electrical Signal" ;
@@ -41989,6 +42036,17 @@ In addition to looking for RAR or 7z program names, command line usage of 7Zip o
     :kb-reference-of :ContainerImageAnalysis ;
     :kb-reference-title "Kubernetes Hardening Guide" .
 
+:Reference-ControllerAreaNetworkMessageAuthentication a owl:NamedIndividual,
+        :PatentReference ;
+    rdfs:label "Reference - Controller area network message authentication - Ford Global Technologies LLC" ;
+    :has-link "https://patents.google.com/patent/US20180131522A1"^^xsd:anyURI ;
+    :kb-abstract "Method and apparatus are disclosed for controller area network message authentication. An example disclosed vehicle includes a data bus and a first control unit communicatively coupled to the data bus. The example first control unit generates a secured message by (a) calculating a message authentication code, (b) truncating the message authentication code, (c) truncating a freshness value used to generate the message authentication code, and (d) placing portions of the truncated message authentication code and the truncated freshness value in separate portions of the secured message." ;
+    :kb-author "James Martin Lawlis, Douglas A. Oliver, Xin Ye" ;
+    :kb-mitre-analysis "This patent describes a method for securing communication by calculating a MAC, truncating it, and also truncating a freshness value (counter) to fit within the restricted data field of a CAN frame (8 bytes)." ;
+    :kb-organization "Ford Global Technologies LLC" ;
+    :kb-reference-of :BusMessageAuthentication ;
+    :kb-reference-title "Controller area network message authentication " .
+
 :Reference-ControlLogix5570and5560Controllers a owl:NamedIndividual,
         :UserManualReference ;
     rdfs:label "Reference - ControlLogix 5570 and 5560 Controllers" ;
@@ -45510,6 +45568,16 @@ With keystroke dynamics the biometric template used to identify an individual is
     :kb-reference-of :InputDeviceAnalysis ;
     :kb-reference-title "Keystroke Dynamics" ;
     :todo "MITRE Analysis was not found" .
+
+:Reference-ZbCANAZeroByteCANDefenseSystem a :AcademicPaperReference,
+        owl:NamedIndividual ;
+    rdfs:label "Reference - ZbCAN: A Zero-Byte CAN Defense System" ;
+    :has-link "https://www.usenix.org/system/files/sec23fall-prepub-381-serag.pdf"^^xsd:anyURI ;
+    :kb-abstract "Controller Area Network (CAN) is a widely used network protocol. In addition to being the main communication medium for vehicles, it is also used in factories, medical equipment, elevators, and avionics. Unfortunately, CAN was designed without any security features. Consequently, it has come under scrutiny by the research community, showing its security weakness. Recent works have shown that a single compromised ECU on a CANbuscan launch a multitude of attacks ranging from message injection, to bus flooding, to attacks exploiting CAN's error handling mechanism. Although several works have attempted to secure CAN, we argue that none of their approaches could be widely adopted for reasons inherent in their design. In this work, we introduce ZBCAN, a defense system that uses zero bytes of the CAN frame to secure against the most common CAN attacks, including message injection, impersonation, flooding, and error handling, without using encryption or MACs, while taking into consideration performance metrics such as delay, busload, and data-rate." ;
+    :kb-author "Khaled Serag, Rohit Bhatia, Akram Faqih, Muslum Ozgur Ozmen, Vireshwar Kumar, Z. Berkay Celik, Dongyan Xu" ;
+    :kb-mitre-analysis "This paper introduces a backwards-compatible defense framework that secures Controller Area Networks (CAN) by using a secret, dynamically generated sequence of inter-frame space timings to detect and preemptively block malicious message injections without requiring cryptographic overhead or payload modifications." ;
+    :kb-reference-of :DynamicBusMessageTimingOrchestration ;
+    :kb-reference-title "ZbCAN: A Zero-Byte CAN Defense System" .
 
 :RegOpenKeyA a :GetSystemConfigValue,
         owl:NamedIndividual ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -15708,7 +15708,16 @@ Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Li
 :EX-0014.02 a owl:Class ;
     rdfs:label "Bus Traffic Spoofing - SPARTA" ;
     skos:prefLabel "Bus Traffic Spoofing" ;
-    rdfs:subClassOf :EX-0014 ;
+    rdfs:subClassOf :EX-0014,
+        [ a owl:Restriction ;
+            owl:onProperty :produces ;
+            owl:someValuesFrom :BusNetworkTraffic ],
+        [ a owl:Restriction ;
+            owl:onProperty :spoofs ;
+            owl:someValuesFrom :BusMessage ],
+        [ a owl:Restriction ;
+            owl:onProperty :uses ;
+            owl:someValuesFrom :BusNetworkNode ] ;
     :attack-id "EX-0014.02" ;
     :definition "Threat actors may attempt to target the main or secondary bus onboard the victim spacecraft and spoof their data. The spacecraft bus often directly processes and sends messages from the ground controllers to the various subsystems within the spacecraft and between the subsystems themselves. If a threat actor would target this system and spoof it internally, the subsystems would take the spoofed information as legitimate and process it as normal. This could lead to undesired effects taking place that could damage the spacecraft's subsystems, hosted payload, and critical data." ;
     rdfs:seeAlso <https://sparta.aerospace.org/technique/EX-0014/02/> .

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -20504,9 +20504,8 @@ Symmetric encryption uses the same cryptographic key by both the sender and rece
             owl:onProperty :enables ;
             owl:someValuesFrom :Harden ] ;
     :d3fend-id "D3-MH" ;
-    :definition "Email or Messaging Hardening includes measures taken to ensure the confidentiality and integrity of user to user computer messages." ;
-    :enables :Harden ;
-    :synonym "Email Or Messaging Hardening" .
+    :definition "The application of security controls to user-to-user and system-to-system communications so messages remain confidential, unaltered, and verifiable while resisting injection, replay, and tampering." ;
+    :enables :Harden .
 
 :MessageTransferAgent a owl:Class ;
     rdfs:label "Message Transfer Agent" ;
@@ -39118,6 +39117,15 @@ Access is determined based on the attributes associated with subjects (requester
     rdfs:subClassOf :TechniqueReference ;
     :pref-label "User Manual" .
 
+:UserMessageHardening a owl:Class,
+        owl:NamedIndividual,
+        :UserMessageHardening ;
+    rdfs:label "User Message Hardening" ;
+    rdfs:subClassOf :MessageHardening ;
+    :d3fend-id "D3-UMH" ;
+    :definition "User message hardening includes measures taken to ensure the confidentiality and integrity of user to user computer messages." ;
+    :synonym "Email Or Messaging Hardening" .
+
 :UserProcess a owl:Class ;
     rdfs:label "User Process" ;
     rdfs:subClassOf :Process ;
@@ -45635,4 +45643,4 @@ With keystroke dynamics the biometric template used to identify an individual is
 
 <wptmp:entity#Reference%20-%20DNS%20Whitelist%20(DNSWL)%20Email%20Authentication%20Method%20Extension> :kb-author "Alessandro Vesely" .
 
-### Serialized using the ttlser deterministic serializer v1.2.3
+### Serialized using the ttlser deterministic serializer v1.2.1


### PR DESCRIPTION
* Refactored `MessageHardening` and its scos so that they're oriented towards digital messages vs user messages.
* Added `BusMessageAuthentication` CM as new sco of `MessageAuthentication`.
* Slightly updated text in `MessageEncryption` so that it applies to machine messages (e.g., bus messages) as well as user messages.