### PR TITLE
D4S: Hardware Configuration Locking

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -17878,8 +17878,8 @@ Administrators collect information on hardware devices such as peripherals, NICs
     rdfs:label "Hardware Configuration Locking" ;
     rdfs:subClassOf :PlatformHardening,
         [ a owl:Restriction ;
-            owl:onProperty :hardens ;
-            owl:someValuesFrom :HardwareDevice ] ;
+            owl:onProperty :restricts ;
+            owl:someValuesFrom :HardwareDeviceConfiguration ] ;
     :d3fend-id "D3-HCL" ;
     :definition "Rendering the configuration registers of a hardware peripheral or subsystem immutable after initial boot-time provisioning." ;
     :kb-article """## How it works

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -17872,28 +17872,6 @@ Administrators collect information on hardware devices such as peripherals, NICs
     :synonym "Hardware Component Discovery",
         "Hardware Component Inventorying" .
 
-:HardwareConfigurationLocking a :HardwareConfigurationLocking,
-        owl:Class,
-        owl:NamedIndividual ;
-    rdfs:label "Hardware Configuration Locking" ;
-    rdfs:subClassOf :PlatformHardening,
-        [ a owl:Restriction ;
-            owl:onProperty :restricts ;
-            owl:someValuesFrom :HardwareDeviceConfiguration ] ;
-    :d3fend-id "D3-HCL" ;
-    :definition "Rendering the configuration registers of a hardware peripheral or subsystem immutable after initial boot-time provisioning." ;
-    :kb-article """## How it works
-Many hardware peripherals in embedded and OT systems expose their operational parameters through memory-mapped or bus-accessible control registers: timeout values, clock prescalers, interrupt masks, mode selectors, memory protection boundaries, encryption key slots, bus routing tables, and so on. Hardware configuration locking treats these parameters not as runtime-adjustable settings but as provisioning-time constants. The pattern is consistent across peripheral types: during the secure boot sequence, a trusted bootloader or hardware root of trust writes the intended parameter values to the relevant control registers. A lock bit, lock register, or lock sequence is then asserted. From that point forward, the hardware logic itself ignores or rejects all subsequent writes to those registers for the remainder of the power cycle (or permanently, in the case of one-time-programmable fuse-based locks). The lock is enforced below the software abstraction layer: it does not depend on an operating system, a privilege level, or a software access-control policy being intact. 
-
-The mechanism takes several physical forms depending on the peripheral and platform. Integrated peripherals on microcontrollers commonly expose a dedicated lock register into which a specific key sequence must be written to enable subsequent writes to configuration registers so that once the lock key is written and the window closes, no further changes are possible without a power-on reset. External supervisory or peripheral ICs often implement locking through hardware strap pins whose values are sampled at power-up and held in latches, making the configuration a function of PCB layout rather than software state. One-time-programmable fuse bits provide the strongest guarantee, permanently encoding a configuration that survives all power cycles and resets. 
-
-## Considerations
-* Softlock vs. hardlock distinction: A softlock, where a key sequence written to a lock register prevents further writes until a reset, still relies on the hardware correctly honoring that register state and cannot prevent an adversary who controls the reset mechanism from cycling through the lock. A hardlock, implemented via OTP fuses, strap pin latches, or dedicated supervisory hardware, cannot be reversed by any software action and provides the strongest guarantee.
-* Boot sequence trust dependency: the security guarantee provided by hardware configuration locking is only as strong as the integrity of the boot sequence that performs the provisioning. 
-* Trade-offs in operational flexibility: locking hardware configuration at boot removes the ability to reconfigure peripherals in response to changing mission conditions. 
-* Radiation and fault-injection robustness: in radiation prone environments such as space, Single Event Upsets (SEUs) can flip register bits, including lock bits and the configuration values they protect. Configuration registers that are locked should ideally reside in radiation-hardened or error-correcting memory cells.""" ;
-    :kb-reference :Reference-SecureWatchdogTimer-IntelCorp .
-
 :HardwareDevice a owl:Class ;
     rdfs:label "Hardware Device" ;
     rdfs:subClassOf :DigitalInformationBearer,
@@ -17984,6 +17962,38 @@ The mechanism takes several physical forms depending on the peripheral and platf
             owl:someValuesFrom :HardwareDevice ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Device_driver> ;
     :definition "In computing, a device driver (commonly referred to simply as a driver) is a computer program that operates or controls a particular type of device that is attached to a computer. A driver provides a software interface to hardware devices, enabling operating systems and other computer programs to access hardware functions without needing to know precise details of the hardware being used. A driver communicates with the device through the computer bus or communications subsystem to which the hardware connects. When a calling program invokes a routine in the driver, the driver issues commands to the device. Once the device sends data back to the driver, the driver may invoke routines in the original calling program. Drivers are hardware dependent and operating-system-specific. They usually provide the interrupt handling required for any necessary asynchronous time-dependent hardware interface." .
+
+:HardwareRegister a owl:Class ;
+    rdfs:label "Hardware Register" ;
+    rdfs:subClassOf :HardwareDeviceConfiguration,
+        :PrimaryStorage,
+        [ a owl:Restriction ;
+            owl:onProperty :may-be-contained-by ;
+            owl:someValuesFrom :HardwareDevice ] ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Hardware_register> ;
+    :definition "A hardware register is a small, fixed-size storage location physically embedded within peripheral hardware that holds the operational parameters, status flags, and control bits governing the behavior of that device, and which are directly read from or written to by software via memory-mapped or I/O-mapped addresses." .
+
+:HardwareRegisterLocking a :HardwareRegisterLocking,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardware Register Locking" ;
+    rdfs:subClassOf :PlatformHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :restricts ;
+            owl:someValuesFrom :HardwareRegister ] ;
+    :d3fend-id "D3-HCL" ;
+    :definition "Rendering the configuration registers of a hardware peripheral or subsystem immutable after initial boot-time provisioning." ;
+    :kb-article """## How it works
+Many hardware peripherals in embedded and OT systems expose their operational parameters through memory-mapped or bus-accessible control registers: timeout values, clock prescalers, interrupt masks, mode selectors, etc. Hardware register locking treats these parameters not as runtime-adjustable settings but as provisioning-time constants. The pattern is consistent across peripheral types: during the secure boot sequence, a trusted bootloader or hardware root of trust writes the intended parameter values to the relevant control registers. A lock bit, lock register, or lock sequence is then asserted. From that point forward, the hardware logic itself ignores or rejects all subsequent writes to those registers for the remainder of the power cycle (or permanently, in the case of one-time-programmable fuse-based locks). The lock is enforced below the software abstraction layer: it does not depend on an operating system, a privilege level, or a software access-control policy being intact. 
+
+The mechanism takes several physical forms depending on the peripheral and platform. Integrated peripherals on microcontrollers commonly expose a dedicated lock register into which a specific key sequence must be written to enable subsequent writes to configuration registers so that once the lock key is written and the window closes, no further changes are possible without a power-on reset. External supervisory or peripheral ICs often implement locking through hardware strap pins whose values are sampled at power-up and held in latches, making the configuration a function of PCB layout rather than software state. One-time-programmable fuse bits provide the strongest guarantee, permanently encoding a configuration that survives all power cycles and resets. 
+
+## Considerations
+* Softlock vs. hardlock distinction: A softlock, where a key sequence written to a lock register prevents further writes until a reset, still relies on the hardware correctly honoring that register state and cannot prevent an adversary who controls the reset mechanism from cycling through the lock. A hardlock, implemented via OTP fuses, strap pin latches, or dedicated supervisory hardware, cannot be reversed by any software action and provides the strongest guarantee.
+* Boot sequence trust dependency: the security guarantee provided by hardware configuration locking is only as strong as the integrity of the boot sequence that performs the provisioning. 
+* Trade-offs in operational flexibility: locking hardware configuration at boot removes the ability to reconfigure peripherals in response to changing mission conditions. 
+* Radiation and fault-injection robustness: in radiation prone environments such as space, Single Event Upsets (SEUs) can flip register bits, including lock bits and the configuration values they protect. Configuration registers that are locked should ideally reside in radiation-hardened or error-correcting memory cells.""" ;
+    :kb-reference :Reference-SecureWatchdogTimer-IntelCorp .
 
 :HardwareTimer a owl:Class ;
     rdfs:label "Hardware Timer" ;
@@ -25431,15 +25441,6 @@ For example, Microsoft Word may block execution of any subprocess that is not in
     rdfs:subClassOf :HardwareDevice ;
     :definition "A Processor Component is a functional subunit or module within a processor that performs specific tasks to support the processor's overall operation." ;
     rdfs:seeAlso :Processor .
-
-:HardwareRegister a owl:Class ;
-    rdfs:label "Hardware Register" ;
-    rdfs:subClassOf :PrimaryStorage, :HardwareDeviceConfiguration,
-        [ a owl:Restriction ;
-            owl:onProperty :may-be-contained-by ;
-            owl:someValuesFrom :HardwareDevice ] ;
-    rdfs:isDefinedBy <https://dbpedia.org/page/Hardware_register> ;
-    :definition "A hardware register is a small, fixed-size storage location physically embedded within peripheral hardware that holds the operational parameters, status flags, and control bits governing the behavior of that device, and which are directly read from or written to by software via memory-mapped or I/O-mapped addresses." .
 
 :ProcessorRegister a owl:Class ;
     rdfs:label "Processor Register" ;
@@ -45323,7 +45324,7 @@ To fit the scope of the Top 20 Secure PLC Coding practices list, practices need 
     :kb-author "Peter Munguia, Kyle Gilsdorf, Shailendra Jha" ;
     :kb-mitre-analysis "Foundational description of a write-once lock bit pattern applied to a peripheral enable mechanism, clearable only by power cycle or hardware reset and not by any software path." ;
     :kb-organization "Intel Corp" ;
-    :kb-reference-of :HardwareConfigurationLocking ;
+    :kb-reference-of :HardwareRegisterLocking ;
     :kb-reference-title "Secure watchdog timer" .
 
 :Reference-Securing_Web_Transactions__TLS_Server_Certificate_Management_Appendix_A_Passive_Inspection a :GuidelineReference,
@@ -46642,4 +46643,4 @@ With keystroke dynamics the biometric template used to identify an individual is
 
 <wptmp:entity#Reference%20-%20DNS%20Whitelist%20(DNSWL)%20Email%20Authentication%20Method%20Extension> :kb-author "Alessandro Vesely" .
 
-### Serialized using the ttlser deterministic serializer v1.2.1
+### Serialized using the ttlser deterministic serializer v1.2.3

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -25432,6 +25432,15 @@ For example, Microsoft Word may block execution of any subprocess that is not in
     :definition "A Processor Component is a functional subunit or module within a processor that performs specific tasks to support the processor's overall operation." ;
     rdfs:seeAlso :Processor .
 
+:HardwareRegister a owl:Class ;
+    rdfs:label "Hardware Register" ;
+    rdfs:subClassOf :PrimaryStorage,
+        [ a owl:Restriction ;
+            owl:onProperty :may-be-contained-by ;
+            owl:someValuesFrom :HardwareDevice ] ;
+    rdfs:isDefinedBy <https://dbpedia.org/page/Hardware_register> ;
+    :definition "A hardware register is a small, fixed-size storage location physically embedded within peripheral hardware that holds the operational parameters, status flags, and control bits governing the behavior of that device, and which are directly read from or written to by software via memory-mapped or I/O-mapped addresses." .
+
 :ProcessorRegister a owl:Class ;
     rdfs:label "Processor Register" ;
     rdfs:subClassOf :PrimaryStorage,

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -1758,138 +1758,6 @@ skos:prefLabel a owl:AnnotationProperty .
 
 ### Classes
 
-:Transponder a owl:Class ;
-    rdfs:label "Transponder" ;
-    rdfs:subClassOf :HardwareDevice ;
-    rdfs:isDefinedBy <http://dbpedia.org/resource/Transponder> ;
-    :definition "In telecommunications, a transponder is a device that, upon receiving a signal, emits a different signal in response." . 
-
-:SatelliteTransponder a owl:Class ;
-    rdfs:label "Satellite Transponder" ;
-    rdfs:subClassOf :Transponder ;
-    rdfs:isDefinedBy <http://dbpedia.org/resource/Transponder_(satellite_communications)> ;
-    :definition "A communications satellite's transponder is the series of interconnected units that form a communications channel between the receiving and the transmitting antennas." . 
-
-:SpacecraftSafeMode a owl:Class ;
-    rdfs:label "Spacecraft Safe Mode" ;
-    rdfs:subClassOf :SafeMode ;
-    :definition "Safe mode is an operating mode of a modern uncrewed spacecraft during which all non-essential systems are shut down and only essential functions such as thermal management, radio reception and attitude control are active." ;
-    rdfs:isDefinedBy <https://dbpedia.org/resource/Safe_mode_in_spacecraft> .
-
-:SafeMode a owl:Class ;
-    rdfs:label "Safe Mode" ;
-    rdfs:subClassOf :OperatingMode ;
-    :definition "An intentionally constrained operating mode of a system in which nonessential functions are disabled or limited and control is shifted to a minimal, well-tested configuration that prioritizes preventing harm (to the system, its environment, or data), maintaining basic stability and monitoring, and enabling diagnosis and recovery back to normal operation." ;
-    rdfs:seeAlso <http://dbpedia.org/resource/Safe_mode> .
-
-:Vehicle a owl:Class ;
-    rdfs:label "Vehicle" ;
-    rdfs:subClassOf :PhysicalArtifact ; 
-    rdfs:isDefinedBy <http://dbpedia.org/resource/Vehicle> ;
-    :definition "A vehicle is a machine designed for self-propulsion, usually to transport people, cargo, or both." .
-
-:OnboardComputer a owl:Class ;
-    rdfs:label "Onboard Computer" ;
-    rdfs:subClassOf :OTEmbeddedComputer,
-        [ a owl:Restriction ;
-            owl:onProperty :runs ;
-            owl:someValuesFrom :RealTimeOperatingSystem ],
-        [ a owl:Restriction ;
-            owl:onProperty :runs ;
-            owl:someValuesFrom :FlightSoftware ],
-        [ a owl:Restriction ;
-            owl:onProperty :runs ;
-            owl:someValuesFrom :BootLoader ],
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :FlashMemory ],
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :HardwareWatchdogTimer ],
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :HardwareClock ] ; 
-    rdfs:isDefinedBy <https://www.esa.int/Enabling_Support/Space_Engineering_Technology/Onboard_Computers_and_Data_Handling/Onboard_Computers> ;
-    :definition "A self-contained, embedded computing unit installed within a vehicle or other autonomous platform that executes real-time control, data-handling, and mission-management software. It interfaces directly with the platform's sensors, actuators, and communication links, processes and stores operational data, and issues commands to subsystems, enabling the system to function independently of external computing resources." ;
-    :synonym "OBC" ;
-    rdfs:seeAlso <https://blog.satsearch.co/2020-03-11-an-overview-of-on-board-computer-obc-systems-available-on-the-global-space-marketplace> .
-    
-:Spacecraft a owl:Class ;
-    rdfs:label "Spacecraft" ;
-    rdfs:subClassOf :Vehicle,
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :OnboardComputer ],
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :Receiver ],
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :Transmitter ],
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :GNSSReceiver ],
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :HardwareCryptographicModule ],
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :Software-definedRadioComputer],
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :BusNetwork ],
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :TransducerSensor ],
-        [ a owl:Restriction ;
-            owl:onProperty :has-operating-mode ;
-            owl:someValuesFrom :OperatingMode] ;
-    rdfs:isDefinedBy <http://dbpedia.org/resource/Spacecraft> ;
-    :definition "A spacecraft is a vehicle that is designed to fly and operate in outer space. Spacecraft are used for a variety of purposes, including communications, Earth observation, meteorology, navigation, space colonization, planetary exploration, and transportation of humans and cargo." .
-
-:GNSSSatellite a owl:Class ;
-    rdfs:label "GNSS Satellite" ;
-    rdfs:subClassOf :Satellite,
-        [ a owl:Restriction ;
-            owl:onProperty :contains ;
-            owl:someValuesFrom :AtomicClock ],
-        [ a owl:Restriction ;
-            owl:onProperty :produces ;
-            owl:someValuesFrom :GNSSSignal ] ;
-    rdfs:seeAlso <http://dbpedia.org/resource/Satellite_navigation> ;
-    :definition "A GNSS satellite is part of a space-based constellation that transmits signals, allowing receivers on Earth to determine their position, navigation, and timing (PNT) through trilateration." .
-
-:GNSSTimeRecord a owl:Class ;
-    rdfs:label "GNSS Time Record" ;
-    rdfs:subClassOf :TimeRecord ;
-    :definition "A GNSS Time Record is an information content entity encoded in a GNSS signal that represents the transmission time of that signal as determined by the transmitting satellite, expressed relative to a constellation-specific time standard and epoch." ;
-    rdfs:seeAlso <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS> .
-
-:GNSSSignal a owl:Class ;
-    rdfs:label "GNSS Signal" ;
-    rdfs:subClassOf :ElectromagneticSignal, 
-        [ a owl:Restriction ;
-            owl:onProperty :carries ;
-            owl:someValuesFrom :GNSSTimeRecord ] ;
-    :synonym "Global Navigation Satellite System Signal" ; 
-    :definition "A GNSS (Global Navigation Satellite System) signal is a low-power radio signal broadcast from satellites that contains a carrier wave, a ranging code, and a navigation message. The receiver uses the carrier wave to precisely measure the time it takes for the signal to travel from the satellite, while the navigation message provides essential information like the satellite's position (ephemeris) and clock information." ;
-    rdfs:seeAlso <https://dbpedia.org/resource/Satellite_navigation>, <https://gssc.esa.int/navipedia/index.php/GNSS_signal> .
-
-:GNSSReceiver a owl:Class ;
-    rdfs:label "GNSS Receiver" ;
-    rdfs:subClassOf :Receiver ;
-    :definition "A GNSS (Global Navigation Satellite System) receiver is an electronic device that picks up signals from one or more satellite constellations (like GPS, GLONASS, Galileo, BeiDou) to calculate precise location, velocity, and time." ;
-    rdfs:seeAlso <https://dbpedia.org/resource/Satellite_navigation> .
-
-:Satellite a owl:Class ;
-    rdfs:label "Satellite" ;
-    rdfs:subClassOf :Spacecraft,
-        [ a owl:Restriction ;
-            owl:onProperty :may-contain ;
-            owl:someValuesFrom :SatelliteTransponder ] ; 
-    rdfs:isDefinedBy <http://dbpedia.org/resource/Satellite> ;
-    :definition "A satellite or an artificial satellite is an object, typically a spacecraft, placed into orbit around a celestial body. They have a variety of uses, including communication relay, weather forecasting, navigation (GPS), broadcasting, scientific research, and Earth observation." .
-
 :AcademicPaperReference a owl:Class ;
     rdfs:label "Academic Paper Reference" ;
     rdfs:subClassOf :TechniqueReference ;
@@ -17702,6 +17570,41 @@ Wikipedia. (n.d.). Central tendency. [Link](https://en.wikipedia.org/wiki/Centra
     :definition "A type of user account in Microsoft Windows (NT) that has a domain-wide scope.defines that user's access to a logical group of network objects (computers, users, devices) that share the same Active Directory databases; that is, a user's access to the domain." ;
     rdfs:seeAlso <https://networkencyclopedia.com/global-user-account> .
 
+:GNSSReceiver a owl:Class ;
+    rdfs:label "GNSS Receiver" ;
+    rdfs:subClassOf :Receiver ;
+    :definition "A GNSS (Global Navigation Satellite System) receiver is an electronic device that picks up signals from one or more satellite constellations (like GPS, GLONASS, Galileo, BeiDou) to calculate precise location, velocity, and time." ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Satellite_navigation> .
+
+:GNSSSatellite a owl:Class ;
+    rdfs:label "GNSS Satellite" ;
+    rdfs:subClassOf :Satellite,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :AtomicClock ],
+        [ a owl:Restriction ;
+            owl:onProperty :produces ;
+            owl:someValuesFrom :GNSSSignal ] ;
+    :definition "A GNSS satellite is part of a space-based constellation that transmits signals, allowing receivers on Earth to determine their position, navigation, and timing (PNT) through trilateration." ;
+    rdfs:seeAlso <http://dbpedia.org/resource/Satellite_navigation> .
+
+:GNSSSignal a owl:Class ;
+    rdfs:label "GNSS Signal" ;
+    rdfs:subClassOf :ElectromagneticSignal,
+        [ a owl:Restriction ;
+            owl:onProperty :carries ;
+            owl:someValuesFrom :GNSSTimeRecord ] ;
+    :definition "A GNSS (Global Navigation Satellite System) signal is a low-power radio signal broadcast from satellites that contains a carrier wave, a ranging code, and a navigation message. The receiver uses the carrier wave to precisely measure the time it takes for the signal to travel from the satellite, while the navigation message provides essential information like the satellite's position (ephemeris) and clock information." ;
+    rdfs:seeAlso <https://dbpedia.org/resource/Satellite_navigation>,
+        <https://gssc.esa.int/navipedia/index.php/GNSS_signal> ;
+    :synonym "Global Navigation Satellite System Signal" .
+
+:GNSSTimeRecord a owl:Class ;
+    rdfs:label "GNSS Time Record" ;
+    rdfs:subClassOf :TimeRecord ;
+    :definition "A GNSS Time Record is an information content entity encoded in a GNSS signal that represents the transmission time of that signal as determined by the transmitting satellite, expressed relative to a constellation-specific time standard and epoch." ;
+    rdfs:seeAlso <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS> .
+
 :Goal a owl:Class ;
     rdfs:label "Goal" ;
     rdfs:subClassOf :D3FENDCore .
@@ -17968,6 +17871,28 @@ Administrators collect information on hardware devices such as peripherals, NICs
     :kb-reference :Reference-AdvancedDeviceMatchingSystem ;
     :synonym "Hardware Component Discovery",
         "Hardware Component Inventorying" .
+
+:HardwareConfigurationLocking a :HardwareConfigurationLocking,
+        owl:Class,
+        owl:NamedIndividual ;
+    rdfs:label "Hardware Configuration Locking" ;
+    rdfs:subClassOf :PlatformHardening,
+        [ a owl:Restriction ;
+            owl:onProperty :hardens ;
+            owl:someValuesFrom :HardwareDevice ] ;
+    :d3fend-id "D3-HCL" ;
+    :definition "Rendering the configuration registers of a hardware peripheral or subsystem immutable after initial boot-time provisioning." ;
+    :kb-article """## How it works
+Many hardware peripherals in embedded and OT systems expose their operational parameters through memory-mapped or bus-accessible control registers: timeout values, clock prescalers, interrupt masks, mode selectors, memory protection boundaries, encryption key slots, bus routing tables, and so on. Hardware configuration locking treats these parameters not as runtime-adjustable settings but as provisioning-time constants. The pattern is consistent across peripheral types: during the secure boot sequence, a trusted bootloader or hardware root of trust writes the intended parameter values to the relevant control registers. A lock bit, lock register, or lock sequence is then asserted. From that point forward, the hardware logic itself ignores or rejects all subsequent writes to those registers for the remainder of the power cycle (or permanently, in the case of one-time-programmable fuse-based locks). The lock is enforced below the software abstraction layer: it does not depend on an operating system, a privilege level, or a software access-control policy being intact. 
+
+The mechanism takes several physical forms depending on the peripheral and platform. Integrated peripherals on microcontrollers commonly expose a dedicated lock register into which a specific key sequence must be written to enable subsequent writes to configuration registers so that once the lock key is written and the window closes, no further changes are possible without a power-on reset. External supervisory or peripheral ICs often implement locking through hardware strap pins whose values are sampled at power-up and held in latches, making the configuration a function of PCB layout rather than software state. One-time-programmable fuse bits provide the strongest guarantee, permanently encoding a configuration that survives all power cycles and resets. 
+
+## Considerations
+* Softlock vs. hardlock distinction: A softlock, where a key sequence written to a lock register prevents further writes until a reset, still relies on the hardware correctly honoring that register state and cannot prevent an adversary who controls the reset mechanism from cycling through the lock. A hardlock, implemented via OTP fuses, strap pin latches, or dedicated supervisory hardware, cannot be reversed by any software action and provides the strongest guarantee.
+* Boot sequence trust dependency: the security guarantee provided by hardware configuration locking is only as strong as the integrity of the boot sequence that performs the provisioning. 
+* Trade-offs in operational flexibility: locking hardware configuration at boot removes the ability to reconfigure peripherals in response to changing mission conditions. 
+* Radiation and fault-injection robustness: in radiation prone environments such as space, Single Event Upsets (SEUs) can flip register bits, including lock bits and the configuration values they protect. Configuration registers that are locked should ideally reside in radiation-hardened or error-correcting memory cells.""" ;
+    :kb-reference :Reference-SecureWatchdogTimer-IntelCorp .
 
 :HardwareDevice a owl:Class ;
     rdfs:label "Hardware Device" ;
@@ -22081,6 +22006,32 @@ Programmatically checking if a pointer is NULL before use.
             owl:someValuesFrom :ImageFile ] ;
     :definition "A document file in a format associated with an d3f:OfficeApplication." ;
     rdfs:seeAlso :OfficeApplication .
+
+:OnboardComputer a owl:Class ;
+    rdfs:label "Onboard Computer" ;
+    rdfs:subClassOf :OTEmbeddedComputer,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :HardwareClock ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :FlashMemory ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :HardwareWatchdogTimer ],
+        [ a owl:Restriction ;
+            owl:onProperty :runs ;
+            owl:someValuesFrom :BootLoader ],
+        [ a owl:Restriction ;
+            owl:onProperty :runs ;
+            owl:someValuesFrom :FlightSoftware ],
+        [ a owl:Restriction ;
+            owl:onProperty :runs ;
+            owl:someValuesFrom :RealTimeOperatingSystem ] ;
+    rdfs:isDefinedBy <https://www.esa.int/Enabling_Support/Space_Engineering_Technology/Onboard_Computers_and_Data_Handling/Onboard_Computers> ;
+    :definition "A self-contained, embedded computing unit installed within a vehicle or other autonomous platform that executes real-time control, data-handling, and mission-management software. It interfaces directly with the platform's sensors, actuators, and communication links, processes and stores operational data, and issues commands to subsystems, enabling the system to function independently of external computing resources." ;
+    rdfs:seeAlso <https://blog.satsearch.co/2020-03-11-an-overview-of-on-board-computer-obc-systems-available-on-the-global-space-marketplace> ;
+    :synonym "OBC" .
 
 :One-timePassword a :One-timePassword,
         owl:Class,
@@ -27266,6 +27217,12 @@ Example RPC Protocols:
     :definition "A runtime variable is an abstract storage location paired with an associated symbolic name, which contains some known or unknown quantity of data or object referred to as a value, which can change during the execution of a computer program." ;
     rdfs:seeAlso <https://dbpedia.org/page/Variable_(computer_science)> .
 
+:SafeMode a owl:Class ;
+    rdfs:label "Safe Mode" ;
+    rdfs:subClassOf :OperatingMode ;
+    :definition "An intentionally constrained operating mode of a system in which nonessential functions are disabled or limited and control is shifted to a minimal, well-tested configuration that prioritizes preventing harm (to the system, its environment, or data), maintaining basic stability and monitoring, and enabling diagnosis and recovery back to normal operation." ;
+    rdfs:seeAlso <http://dbpedia.org/resource/Safe_mode> .
+
 :SARSA a owl:Class,
         owl:NamedIndividual ;
     rdfs:label "SARSA" ;
@@ -27275,6 +27232,21 @@ Example RPC Protocols:
     :definition "State-action-reward-state-action (SARSA) is an algorithm for learning a Markov decision process policy, used in the reinforcement learning area of machine learning." ;
     :kb-article """## References
 State-action-reward-state-action. Wikipedia.  [Link](https://en.wikipedia.org/wiki/State%E2%80%93action%E2%80%93reward%E2%80%93state%E2%80%93action).""" .
+
+:Satellite a owl:Class ;
+    rdfs:label "Satellite" ;
+    rdfs:subClassOf :Spacecraft,
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :SatelliteTransponder ] ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Satellite> ;
+    :definition "A satellite or an artificial satellite is an object, typically a spacecraft, placed into orbit around a celestial body. They have a variety of uses, including communication relay, weather forecasting, navigation (GPS), broadcasting, scientific research, and Earth observation." .
+
+:SatelliteTransponder a owl:Class ;
+    rdfs:label "Satellite Transponder" ;
+    rdfs:subClassOf :Transponder ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Transponder_(satellite_communications)> ;
+    :definition "A communications satellite's transponder is the series of interconnected units that form a communications channel between the receiving and the transmitting antennas." .
 
 :SavedInstructionPointer a owl:Class ;
     rdfs:label "Saved Instruction Pointer" ;
@@ -28418,6 +28390,45 @@ The goal is for homophones to be encoded to the same representation so that they
     rdfs:label "Source Code Reference" ;
     rdfs:subClassOf :TechniqueReference ;
     :pref-label "Source Code" .
+
+:Spacecraft a owl:Class ;
+    rdfs:label "Spacecraft" ;
+    rdfs:subClassOf :Vehicle,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :OnboardComputer ],
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :Receiver ],
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :Transmitter ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-operating-mode ;
+            owl:someValuesFrom :OperatingMode ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :BusNetwork ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :GNSSReceiver ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :HardwareCryptographicModule ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :Software-definedRadioComputer ],
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain ;
+            owl:someValuesFrom :TransducerSensor ] ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Spacecraft> ;
+    :definition "A spacecraft is a vehicle that is designed to fly and operate in outer space. Spacecraft are used for a variety of purposes, including communications, Earth observation, meteorology, navigation, space colonization, planetary exploration, and transportation of humans and cargo." .
+
+:SpacecraftSafeMode a owl:Class ;
+    rdfs:label "Spacecraft Safe Mode" ;
+    rdfs:subClassOf :SafeMode ;
+    rdfs:isDefinedBy <https://dbpedia.org/resource/Safe_mode_in_spacecraft> ;
+    :definition "Safe mode is an operating mode of a modern uncrewed spacecraft during which all non-essential systems are shut down and only essential functions such as thermal management, radio reception and attitude control are active." .
 
 :SPARTADefenseEvasionTechnique a owl:Class ;
     rdfs:label "Defense Evasion Technique - SPARTA" ;
@@ -39405,6 +39416,12 @@ Transformer-XL. (n.d.). Papers with Code. [Link](https://paperswithcode.com/meth
     :definition "A device or system that takes information and generates a signal suitable for propagation. It encodes and formats the content, impresses it on a physical carrier (such as electromagnetic fields, light, electrical currents, or acoustic waves), and performs signal conditioning—such as modulation, pulse shaping, pre-emphasis, and power amplification—to meet spectral, timing, and power requirements. A transmitter may be analog or digital, implemented in hardware, software, or both, and is designed to launch the signal into the chosen medium with characteristics that enable reliable reception." ;
     rdfs:seeAlso <https://dbpedia.org/page/Signal_transmission> .
 
+:Transponder a owl:Class ;
+    rdfs:label "Transponder" ;
+    rdfs:subClassOf :HardwareDevice ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Transponder> ;
+    :definition "In telecommunications, a transponder is a device that, upon receiving a signal, emits a different signal in response." .
+
 :TransportLayerEvent a owl:Class ;
     rdfs:label "Transport Layer Event" ;
     rdfs:subClassOf :NetworkEvent ;
@@ -40108,6 +40125,12 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
             owl:onProperty :contains ;
             owl:someValuesFrom :VectorImage ] ;
     :definition "A file that contains graphics data represented by vectors." .
+
+:Vehicle a owl:Class ;
+    rdfs:label "Vehicle" ;
+    rdfs:subClassOf :PhysicalArtifact ;
+    rdfs:isDefinedBy <http://dbpedia.org/resource/Vehicle> ;
+    :definition "A vehicle is a machine designed for self-propulsion, usually to transport people, cargo, or both." .
 
 :VehicleOperatingMode a owl:Class ;
     rdfs:label "Vehicle Operating Mode" ;
@@ -45282,6 +45305,17 @@ To fit the scope of the Top 20 Secure PLC Coding practices list, practices need 
         :OTVariableAccessRestriction,
         :PlatformUptimeMonitoring ;
     :kb-reference-title "Secure PLC Coding Practices: Top 20 List" .
+
+:Reference-SecureWatchdogTimer-IntelCorp a owl:NamedIndividual,
+        :PatentReference ;
+    rdfs:label "Reference - Secure Watchdog Timer - Intel Corp" ;
+    :has-link "https://patents.google.com/patent/US20040250178A1"^^xsd:anyURI ;
+    :kb-abstract "A watchdog timer including a counter, a watchdog enable mechanism, and a timeout control. The watchdog enable mechanism is set to an enabled state by receiving an enabling input and set to a disabled state only by a power cycle or a hardware reset. The timeout control is coupled to the counter and to the watchdog enable mechanism. The timeout control enables a error signal if the watchdog enable mechanism is enabled and the counter is not updated before completing a count." ;
+    :kb-author "Peter Munguia, Kyle Gilsdorf, Shailendra Jha" ;
+    :kb-mitre-analysis "Foundational description of a write-once lock bit pattern applied to a peripheral enable mechanism, clearable only by power cycle or hardware reset and not by any software path." ;
+    :kb-organization "Intel Corp" ;
+    :kb-reference-of :HardwareConfigurationLocking ;
+    :kb-reference-title "Secure watchdog timer" .
 
 :Reference-Securing_Web_Transactions__TLS_Server_Certificate_Management_Appendix_A_Passive_Inspection a :GuidelineReference,
         owl:NamedIndividual ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -17874,8 +17874,10 @@ Administrators collect information on hardware devices such as peripherals, NICs
 
 :HardwareDevice a owl:Class ;
     rdfs:label "Hardware Device" ;
-    rdfs:subClassOf :DigitalInformationBearer,
-        :PhysicalArtifact ;
+    rdfs:subClassOf :DigitalInformationBearer, :PhysicalArtifact,
+        [ a owl:Restriction ;
+            owl:onProperty :may-contain;
+            owl:someValuesFrom :HardwareRegister ] ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/Computer_hardware> ;
     :definition "Hardware devices are the physical artifacts that constitute a network or computer system. Hardware devices are the physical parts or components of a computer, such as the monitor, keyboard, computer data storage, hard disk drive (HDD), graphic cards, sound cards, memory (RAM), motherboard, and so on, all of which are tangible physical objects. By contrast, software is instructions that can be stored and run by hardware. Hardware is directed by the software to execute any command or instruction. A combination of hardware and software forms a usable computing system." ;
     rdfs:seeAlso <https://schema.ocsf.io/objects/device_hw_info> .

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -25434,7 +25434,7 @@ For example, Microsoft Word may block execution of any subprocess that is not in
 
 :HardwareRegister a owl:Class ;
     rdfs:label "Hardware Register" ;
-    rdfs:subClassOf :PrimaryStorage,
+    rdfs:subClassOf :PrimaryStorage, :HardwareDeviceConfiguration,
         [ a owl:Restriction ;
             owl:onProperty :may-be-contained-by ;
             owl:someValuesFrom :HardwareDevice ] ;


### PR DESCRIPTION
* Added `HardwareConfigurationLocking` - a new countermeasure around rendering hardware configuration parameters immutable. This is relevant to devices such as hardware watchdog timers, real-time clocks, etc. 