### PR TITLE
Add reusable ontology base image target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /src
 # Ensure the path exists even if the user doesn't have a local `.local/` dir
 RUN mkdir -p /src/.local
 
-FROM rockylinux:9
+FROM rockylinux:9 AS ontology-toolchain
 
 ARG ROBOT_URL
 
@@ -30,11 +30,15 @@ RUN dnf -y install python39 java-21-openjdk-headless make python3-pip which git 
 VOLUME [ "/dist" ]
 RUN pip3 install pipenv==2022.8.5
 
+FROM ontology-toolchain AS ontology-base
+
 # Install deps in a cache-friendly layer (only depends on Pipfile.lock/Makefile)
 COPY --from=src /src/Makefile /app/Makefile
 COPY --from=src /src/Pipfile /app/Pipfile
 COPY --from=src /src/Pipfile.lock /app/Pipfile.lock
 RUN if [ -n "${ROBOT_URL}" ]; then make ROBOT_URL="${ROBOT_URL}" clean install-deps; else make clean install-deps; fi
+
+FROM ontology-base
 
 COPY --from=src /src /app
 #RUN make build extensions dist

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ JENA_VERSION := 5.6.0
 JENA_PATH := "bin/jena/apache-jena-${JENA_VERSION}/bin"
 
 ROBOT_URL ?= "https://github.com/ontodev/robot/releases/download/v1.9.8/robot.jar"
+DOCKER_NO_CACHE ?= false
+DOCKER_BUILD_NOCACHE_FLAG := $(if $(filter true,$(DOCKER_NO_CACHE)),--no-cache,)
+ONTOLOGY_BASE_IMAGE_REPO ?= d3fend-ontology-base
+ONTOLOGY_BASE_HASH ?= $(shell { printf '%s\n' '$(ROBOT_URL)'; cat Dockerfile Makefile Pipfile Pipfile.lock; if [ -d .local ]; then find .local -type f \( -name '*.crt' -o -name '*.pem' \) | sort | while read -r f; do printf '%s\n' "$$f"; cat "$$f"; done; fi; } | shasum -a 256 | cut -c1-12)
+ONTOLOGY_BASE_IMAGE ?= $(ONTOLOGY_BASE_IMAGE_REPO):$(ONTOLOGY_BASE_HASH)
+ONTOLOGY_BASE_LATEST_TAG ?= $(ONTOLOGY_BASE_IMAGE_REPO):latest
+ONTOLOGY_IMAGE_TAG ?= d3fend-ontology:latest
 
 # define standard colors
 ifneq (,$(findstring xterm,${TERM}))
@@ -128,6 +135,27 @@ bin/robot.jar: bindir
 
 install-deps: install-python-deps bin/robot.jar bin/jena ## install software deps
 	$(END)
+
+docker-build-base-image: ## build the reusable ontology base image
+	@BASE_IMAGE_TAG="$(ONTOLOGY_BASE_IMAGE)"; \
+	if [ "$(DOCKER_NO_CACHE)" = "true" ]; then \
+		echo "DOCKER_NO_CACHE=true: rebuilding ontology base image ($$BASE_IMAGE_TAG) ..."; \
+		docker build $(DOCKER_BUILD_NOCACHE_FLAG) --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg ROBOT_URL=$(ROBOT_URL) --target ontology-base -t "$$BASE_IMAGE_TAG" -t "$(ONTOLOGY_BASE_LATEST_TAG)" .; \
+	else \
+		if docker image inspect "$$BASE_IMAGE_TAG" >/dev/null 2>&1; then \
+			echo "Using cached ontology base image ($$BASE_IMAGE_TAG)"; \
+		else \
+			echo "Building ontology base image ($$BASE_IMAGE_TAG) ..."; \
+			docker build --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg ROBOT_URL=$(ROBOT_URL) --target ontology-base -t "$$BASE_IMAGE_TAG" -t "$(ONTOLOGY_BASE_LATEST_TAG)" .; \
+		fi; \
+	fi
+
+docker-build-image: docker-build-base-image ## build the ontology image
+	@docker build $(DOCKER_BUILD_NOCACHE_FLAG) \
+		--cache-from "$(ONTOLOGY_BASE_IMAGE)" \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--build-arg ROBOT_URL=$(ROBOT_URL) \
+		-t "$(ONTOLOGY_IMAGE_TAG)" .
 
 download-attack:
 	mkdir -p data


### PR DESCRIPTION
Summary
- split the Dockerfile into ontology-toolchain and reusable ontology-base stages
- add repo-owned `docker-build-base-image` and `docker-build-image` targets
- hash the ontology base image from Docker/Python inputs plus local cert files that affect dependency setup

Notes
- This is the ontology half of the cross-repo base-image work used by the builder issue.
- I did not see the same dramatic local delta here as the frontend because the old ontology Dockerfile already kept `install-deps` in a cache-friendly layer on a warm daemon; this change is mainly about repo ownership and reusable build entrypoints for builder.