### PR TITLE
Deprecated :Reference-GuidetoOTSecurity. Fix for #502

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -39942,7 +39942,7 @@ Geolocation data for each user logon attempt is collected and used to create a b
     :kb-article """## How it works
 
 Access is determined based on the attributes associated with subjects (requesters) and the objects being accessed. Each object and subject has a set of associated attributes, such as location, time of creation, and access rights. Access to an object is authorized or denied depending on whether the required. """ ;
-    :kb-reference :Reference-GuidetoOTSecurity ;
+    :kb-reference :Reference-GuideToOTSecurity ;
     :synonym "Role Based Access Controls" .
 
 :UserInitConfigurationFile a owl:Class ;
@@ -43711,8 +43711,6 @@ specific types of information (e.g., classified matter, National Security Inform
         :PhysicalLocking,
         :UserGroupPermissions ;
     :kb-reference-title "Guide to Operational Technology (OT) Security" .
-
-:Reference-GuidetoOTSecurity a owl:NamedIndividual .
 
 :Reference-GuideToStorageEncryptionTechnologiesForEndUserDevices a :GuidelineReference,
         owl:NamedIndividual ;


### PR DESCRIPTION
* Deprecated the errant `Reference-GuidetoOTSecurity` and updated its reference