### PR TITLE
Fixed Reference-CAR-2021-01-007

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -42566,7 +42566,6 @@ The analytic needs to be tuned. The 1.5 in the query is the number of standard d
     :has-link "https://car.mitre.org/analytics/CAR-2021-01-007/"^^xsd:anyURI ;
     :kb-abstract "In an attempt to avoid detection after compromising a machine, threat actors often try to disable Windows Defender. This is often done using “sc” [service control], a legitimate tool provided by Microsoft for managing services. This action interferes with event detection and may lead to a security event going undetected, thereby potentially leading to further compromise of the network." ;
     :kb-author "MITRE" ;
-    :kb-mitre-analysis " " ;
     :kb-organization "MITRE" ;
     :kb-reference-of :ProcessSpawnAnalysis ;
     :kb-reference-title "CAR-2021-01-007: Detecting Tampering of Windows Defender Command Prompt" ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -42566,7 +42566,7 @@ The analytic needs to be tuned. The 1.5 in the query is the number of standard d
     :has-link "https://car.mitre.org/analytics/CAR-2021-01-007/"^^xsd:anyURI ;
     :kb-abstract "In an attempt to avoid detection after compromising a machine, threat actors often try to disable Windows Defender. This is often done using “sc” [service control], a legitimate tool provided by Microsoft for managing services. This action interferes with event detection and may lead to a security event going undetected, thereby potentially leading to further compromise of the network." ;
     :kb-author "MITRE" ;
-    :kb-mitre-analysis "d" ;
+    :kb-mitre-analysis " " ;
     :kb-organization "MITRE" ;
     :kb-reference-of :ProcessSpawnAnalysis ;
     :kb-reference-title "CAR-2021-01-007: Detecting Tampering of Windows Defender Command Prompt" ;


### PR DESCRIPTION
Removed extraneous "d" in :kb-mitre-analysis for `:Reference-CAR-2021-01-007%3ADetectingTamperingOfWindowsDefenderCommandPrompt_MITRE`.