### PR TITLE
Add OCSF-coverage and seeAlso-non-IRI quality-report queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,18 @@ reports/inconsistent-iri-report.txt:	build/d3fend-full.owl
 		--fail-on none > reports/inconsistent-iri-report.txt
 	$(END)
 
+reports/missing-ocsf-seealso-report.txt:	build/d3fend-full.owl
+	./bin/robot report -i build/d3fend-full.owl \
+		--profile src/queries/missing-ocsf-seealso-profile.txt \
+		--fail-on none > reports/missing-ocsf-seealso-report.txt
+	$(END)
+
+reports/seealso-non-iri-report.txt:	build/d3fend-full.owl
+	./bin/robot report -i build/d3fend-full.owl \
+		--profile src/queries/seealso-non-iri-profile.txt \
+		--fail-on none > reports/seealso-non-iri-report.txt
+	$(END)
+
 reports/unallowed-thing-report.txt: reportsdir build/d3fend-public.owl
 	./bin/robot report -i build/d3fend-public.owl \
 		--profile src/queries/unallowed-thing-profile.txt \
@@ -410,7 +422,7 @@ reportsdir:
 	mkdir -p reports/
 	$(END)
 
-reports:	reportsdir reports/default-robot-report.txt reports/missing-d3fend-definition-report.txt reports/bogus-direct-subclassing-of-tactic-technique-report.txt reports/missing-rdfs-label-report.txt reports/missing-attack-id-report.txt reports/inconsistent-iri-report.txt reports/missing-off-tech-artifacts-report.txt ## Generates all reports for ontology quality checks
+reports:	reportsdir reports/default-robot-report.txt reports/missing-d3fend-definition-report.txt reports/bogus-direct-subclassing-of-tactic-technique-report.txt reports/missing-rdfs-label-report.txt reports/missing-attack-id-report.txt reports/inconsistent-iri-report.txt reports/missing-ocsf-seealso-report.txt reports/seealso-non-iri-report.txt reports/missing-off-tech-artifacts-report.txt ## Generates all reports for ontology quality checks
 	$(END)
 
 

--- a/src/queries/missing-ocsf-seealso-profile.txt
+++ b/src/queries/missing-ocsf-seealso-profile.txt
@@ -1,0 +1,1 @@
+WARN	file:./src/queries/missing-ocsf-seealso.rq

--- a/src/queries/missing-ocsf-seealso.rq
+++ b/src/queries/missing-ocsf-seealso.rq
@@ -1,0 +1,35 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX d3f: <http://d3fend.mitre.org/ontologies/d3fend.owl#>
+
+# Quality report: D3FEND DigitalArtifact / DigitalEvent classes with no OCSF
+# crosswalk link (an rdfs:seeAlso to an OCSF IRI).
+#
+# The OCSF crosswalk (#494, #495; OCSF-side ocsf/ocsf-schema#1582) annotates a small set of mostly-interior
+# anchor classes; this report enumerates the artifact and event classes left
+# without a direct OCSF seeAlso, so crosswalk coverage is a repo-runnable check
+# rather than a one-off measurement. As of D3FEND v1.4.0, 69 seeAlso links cover
+# ~68 classes, while ~600 DigitalArtifact leaf classes carry none (a ~97.7%
+# leaf-orphan rate); the high-value objects (file, process, network_connection,
+# device, user, dns_query) are the ones to link first.
+#
+# Sibling of the shipped missing-*.rq family; touches no axioms, changes no
+# entailments. Paired profile severity: WARN (advisory coverage gap, not a
+# build-breaking defect).
+
+SELECT DISTINCT ?entity ?property ?value
+WHERE {
+    { ?entity rdfs:subClassOf* d3f:DigitalArtifact }
+    UNION
+    { ?entity rdfs:subClassOf* d3f:DigitalEvent }
+
+    FILTER(isIRI(?entity))
+    OPTIONAL { ?entity rdfs:label ?property }
+    BIND("missing OCSF seeAlso" AS ?value)
+
+    # The violation: no rdfs:seeAlso resolving to an OCSF IRI
+    FILTER NOT EXISTS {
+        ?entity rdfs:seeAlso ?ocsf .
+        FILTER(isIRI(?ocsf) && CONTAINS(STR(?ocsf), "ocsf.io"))
+    }
+} ORDER BY ?entity

--- a/src/queries/seealso-non-iri-profile.txt
+++ b/src/queries/seealso-non-iri-profile.txt
@@ -1,0 +1,1 @@
+ERROR	file:./src/queries/seealso-non-iri.rq

--- a/src/queries/seealso-non-iri.rq
+++ b/src/queries/seealso-non-iri.rq
@@ -1,0 +1,25 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX d3f: <http://d3fend.mitre.org/ontologies/d3fend.owl#>
+
+# Quality report: rdfs:seeAlso assertions whose object is a string literal
+# instead of an IRI (issue #439).
+#
+# D3FEND ships make-has-links-anyURI.rq to DELETE/INSERT d3f:has-link string
+# literals into xsd:anyURI; rdfs:seeAlso has no such guard, so a seeAlso pointing
+# at a CURIE string (for example "T1574.001") instead of an @id slips through.
+# This read-only report is the regression guard for #439, catching the defect on
+# every build rather than fixing it once. Scoped to rdfs:seeAlso deliberately:
+# d3f:has-link string literals are a separate, already-handled condition (the
+# make-has-links-anyURI fix), so folding them in would swamp the #439 signal.
+# Measured at 11 occurrences in D3FEND v1.4.0.
+#
+# Sibling of inconsistent-iri.rq; no reasoning impact. Paired profile severity:
+# ERROR (a seeAlso that is not an IRI is a real data defect).
+
+SELECT DISTINCT ?entity ?property ?value
+WHERE {
+    BIND(rdfs:seeAlso AS ?property)
+    ?entity rdfs:seeAlso ?value .
+    FILTER(isLiteral(?value))
+} ORDER BY ?entity


### PR DESCRIPTION
Two read-only SPARQL quality-report queries in the existing `src/queries/` pattern, each a sibling of `inconsistent-iri.rq` and wired into the `reports:` target at `--fail-on none`. Both touch no axioms and change no entailments.

`missing-ocsf-seealso.rq` (toward #571) — DigitalArtifact/DigitalEvent classes with no `rdfs:seeAlso` to an OCSF IRI, so OCSF crosswalk coverage becomes a standing report rather than a one-off audit. Against v1.4.0 it returns 1,136 classes; the DigitalArtifact leaf subset is 593 of 607 (97.7%) unlinked, while the crosswalk currently covers ~68 mostly-interior classes via 69 links. Ordered so the high-value OCSF objects to link first (file, process, network_connection, device, user, dns_query) sort to the top.

`seealso-non-iri.rq` (toward #439) — `rdfs:seeAlso` assertions whose object is a string literal instead of an IRI (11 in v1.4.0, including `d3f:T1574.002 → "T1574.001"`, a CURIE that should be an `@id`). The read-only regression guard complementing the build-time `make-has-links-anyURI.rq` fix on the `has-link` side. Scoped to `rdfs:seeAlso`; folding in `d3f:has-link` adds ~397 already-handled literals that would swamp the report.

Both are wired `--fail-on none` so the rows that exist today don't break the build; `seealso-non-iri` can move to `--fail-on ERROR` once the 11 literals are fixed.

Verified with `make -n reports` (both targets fire) and by running each query against the v1.4.0 graph for the counts above.
