### PR TITLE
Add missing-def-tech-artifacts quality report (defensive analog of missing-off-tech-artifacts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,12 @@ reports/inconsistent-iri-report.txt:	build/d3fend-full.owl
 		--fail-on none > reports/inconsistent-iri-report.txt
 	$(END)
 
+reports/missing-def-tech-artifacts-report.txt:	build/d3fend-full.owl
+	./bin/robot report -i build/d3fend-full.owl \
+		--profile src/queries/missing-def-tech-artifacts-profile.txt \
+		--fail-on none > reports/missing-def-tech-artifacts-report.txt
+	$(END)
+
 reports/unallowed-thing-report.txt: reportsdir build/d3fend-public.owl
 	./bin/robot report -i build/d3fend-public.owl \
 		--profile src/queries/unallowed-thing-profile.txt \
@@ -410,7 +416,7 @@ reportsdir:
 	mkdir -p reports/
 	$(END)
 
-reports:	reportsdir reports/default-robot-report.txt reports/missing-d3fend-definition-report.txt reports/bogus-direct-subclassing-of-tactic-technique-report.txt reports/missing-rdfs-label-report.txt reports/missing-attack-id-report.txt reports/inconsistent-iri-report.txt reports/missing-off-tech-artifacts-report.txt ## Generates all reports for ontology quality checks
+reports:	reportsdir reports/default-robot-report.txt reports/missing-d3fend-definition-report.txt reports/bogus-direct-subclassing-of-tactic-technique-report.txt reports/missing-rdfs-label-report.txt reports/missing-attack-id-report.txt reports/inconsistent-iri-report.txt reports/missing-def-tech-artifacts-report.txt reports/missing-off-tech-artifacts-report.txt ## Generates all reports for ontology quality checks
 	$(END)
 
 

--- a/src/queries/missing-def-tech-artifacts-profile.txt
+++ b/src/queries/missing-def-tech-artifacts-profile.txt
@@ -1,0 +1,1 @@
+WARN	file:./src/queries/missing-def-tech-artifacts.rq

--- a/src/queries/missing-def-tech-artifacts.rq
+++ b/src/queries/missing-def-tech-artifacts.rq
@@ -1,0 +1,58 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX d3f: <http://d3fend.mitre.org/ontologies/d3fend.owl#>
+
+# Quality report: D3FEND DefensiveTechnique classes with no digital-artifact
+# relation. A defensive technique that relates to no d3f:Artifact (via any
+# sub-property of d3f:may-be-associated-with) cannot share an artifact with any
+# offensive technique, so it can never appear in the inferred offense-defense
+# matrix. This is the defensive-side analog of the shipped
+# missing-off-tech-artifacts.rq, and a machine-checkable acceptance criterion
+# for new defensive techniques (issue #569).
+#
+# Sibling of missing-off-tech-artifacts.rq; touches no axioms, changes no
+# entailments. Paired profile severity: WARN (advisory coverage gap, not a
+# build-breaking defect).
+
+SELECT DISTINCT ?entity ?property ?value
+
+WHERE {
+
+    # Select defensive techniques where:
+    #   Ignore the top-level base techniques
+    #   Ignore parents whose children have DA relationships defined
+    #   Ignore children whose parents have DA relationships defined
+
+    ?entity rdfs:subClassOf* d3f:DefensiveTechnique .
+    OPTIONAL{ ?entity rdfs:label ?property  }
+    OPTIONAL{ ?entity d3f:d3fend-id ?value  }
+
+    # The violation: the technique has no artifact relation of its own.
+    FILTER NOT EXISTS {
+        ?entity ?p ?da .
+        ?da rdfs:subClassOf* d3f:Artifact .
+        ?p rdfs:subPropertyOf* d3f:may-be-associated-with .
+    }
+
+    # Filter the top-level base techniques.
+    FILTER NOT EXISTS {
+        ?entity rdfs:subClassOf d3f:DefensiveTechnique .
+    }
+
+    # Filter the parents whose children have DAs defined.
+    FILTER NOT EXISTS {
+        ?subt rdfs:subClassOf* ?entity .
+        ?subt ?sp ?sda .
+        ?sda rdfs:subClassOf* d3f:Artifact .
+        ?sp rdfs:subPropertyOf* d3f:may-be-associated-with .
+    }
+
+    # Filter the children whose parents have DAs defined.
+    FILTER NOT EXISTS {
+        ?pentity ?pp ?pda .
+        ?pda rdfs:subClassOf* d3f:Artifact .
+        ?pp rdfs:subPropertyOf* d3f:may-be-associated-with .
+        ?entity rdfs:subClassOf* ?pentity .
+    }
+
+} ORDER BY ?value


### PR DESCRIPTION
A read-only SPARQL quality report listing `d3f:DefensiveTechnique` classes with no digital-artifact relation — the defensive-side analog of the shipped `missing-off-tech-artifacts.rq`. A defensive technique that relates to no `d3f:Artifact` (via any sub-property of `d3f:may-be-associated-with`) can't share an artifact with any offensive technique, so it never appears in the inferred offense-defense matrix.

Against v1.4.0 it flags 14 techniques today (e.g. Decoy Persona `D3-DP`, TPM Boot Integrity `D3-TBI`, Authentication Event Thresholding `D3-ANET`).

- Mirrors `missing-off-tech-artifacts.rq` exactly, with `d3f:DefensiveTechnique` substituted; all 42 defensive→artifact relations are sub-properties of `d3f:may-be-associated-with`, so the same idiom applies.
- Wired into the `reports:` target at `--fail-on none` (advisory). Touches no axioms, changes no entailments.
- Doubles as a machine-checkable acceptance criterion for new defensive techniques (#569): every new technique should carry at least one artifact relation.

Verified with `make -n reports` (the target fires) and by running the query against the v1.4.0 graph for the count above.
