### PR TITLE
Add OCSF crosswalk-coverage (#571) and non-IRI seeAlso (#439) report checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,23 @@ reports/inconsistent-iri-report.txt:	build/d3fend-full.owl
 		--fail-on none > reports/inconsistent-iri-report.txt
 	$(END)
 
+# OCSF crosswalk coverage check (issue #571): DigitalArtifact/DigitalEvent classes
+# with no rdfs:seeAlso to an OCSF IRI. WARN-level advisory coverage gap, not a defect.
+reports/missing-ocsf-seealso-report.txt:	build/d3fend-full.owl
+	./bin/robot report -i build/d3fend-full.owl \
+		--profile src/queries/missing-ocsf-seealso-profile.txt \
+		--fail-on none > reports/missing-ocsf-seealso-report.txt
+	$(END)
+
+# rdfs:seeAlso to a string literal instead of an IRI (issue #439). ERROR-level data
+# defect; --fail-on none for now since pre-existing violations exist (tighten to
+# ERROR once #439's cases are fixed).
+reports/seealso-non-iri-report.txt:	build/d3fend-full.owl
+	./bin/robot report -i build/d3fend-full.owl \
+		--profile src/queries/seealso-non-iri-profile.txt \
+		--fail-on none > reports/seealso-non-iri-report.txt
+	$(END)
+
 reports/unallowed-thing-report.txt: reportsdir build/d3fend-public.owl
 	./bin/robot report -i build/d3fend-public.owl \
 		--profile src/queries/unallowed-thing-profile.txt \
@@ -410,7 +427,7 @@ reportsdir:
 	mkdir -p reports/
 	$(END)
 
-reports:	reportsdir reports/default-robot-report.txt reports/missing-d3fend-definition-report.txt reports/bogus-direct-subclassing-of-tactic-technique-report.txt reports/missing-rdfs-label-report.txt reports/missing-attack-id-report.txt reports/inconsistent-iri-report.txt reports/missing-off-tech-artifacts-report.txt ## Generates all reports for ontology quality checks
+reports:	reportsdir reports/default-robot-report.txt reports/missing-d3fend-definition-report.txt reports/bogus-direct-subclassing-of-tactic-technique-report.txt reports/missing-rdfs-label-report.txt reports/missing-attack-id-report.txt reports/inconsistent-iri-report.txt reports/missing-ocsf-seealso-report.txt reports/seealso-non-iri-report.txt reports/missing-off-tech-artifacts-report.txt ## Generates all reports for ontology quality checks
 	$(END)
 
 
@@ -419,6 +436,8 @@ REPORT_FILES = default-robot-report.txt \
                bogus-direct-subclassing-of-tactic-technique-report.txt \
                missing-attack-id-report.txt \
                inconsistent-iri-report.txt \
+               missing-ocsf-seealso-report.txt \
+               seealso-non-iri-report.txt \
                missing-off-tech-artifacts-report.txt
 
 

--- a/src/queries/missing-ocsf-seealso-profile.txt
+++ b/src/queries/missing-ocsf-seealso-profile.txt
@@ -1,0 +1,1 @@
+WARN	file:./src/queries/missing-ocsf-seealso.rq

--- a/src/queries/missing-ocsf-seealso.rq
+++ b/src/queries/missing-ocsf-seealso.rq
@@ -1,0 +1,35 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX d3f: <http://d3fend.mitre.org/ontologies/d3fend.owl#>
+
+# Quality report: D3FEND DigitalArtifact / DigitalEvent classes with no OCSF
+# crosswalk link (an rdfs:seeAlso to an OCSF IRI).
+#
+# The OCSF crosswalk (#494, #495; OCSF-side ocsf/ocsf-schema#1582) annotates a small set of mostly-interior
+# anchor classes; this report enumerates the artifact and event classes left
+# without a direct OCSF seeAlso, so crosswalk coverage is a repo-runnable check
+# rather than a one-off measurement. As of D3FEND v1.4.0, 69 seeAlso links cover
+# ~68 classes, while ~600 DigitalArtifact leaf classes carry none (a ~97.7%
+# leaf-orphan rate); the high-value objects (file, process, network_connection,
+# device, user, dns_query) are the ones to link first.
+#
+# Sibling of the shipped missing-*.rq family; touches no axioms, changes no
+# entailments. Paired profile severity: WARN (advisory coverage gap, not a
+# build-breaking defect).
+
+SELECT DISTINCT ?entity ?property ?value
+WHERE {
+    { ?entity rdfs:subClassOf* d3f:DigitalArtifact }
+    UNION
+    { ?entity rdfs:subClassOf* d3f:DigitalEvent }
+
+    FILTER(isIRI(?entity))
+    OPTIONAL { ?entity rdfs:label ?property }
+    BIND("missing OCSF seeAlso" AS ?value)
+
+    # The violation: no rdfs:seeAlso resolving to an OCSF IRI
+    FILTER NOT EXISTS {
+        ?entity rdfs:seeAlso ?ocsf .
+        FILTER(isIRI(?ocsf) && CONTAINS(STR(?ocsf), "ocsf.io"))
+    }
+} ORDER BY ?entity

--- a/src/queries/seealso-non-iri-profile.txt
+++ b/src/queries/seealso-non-iri-profile.txt
@@ -1,0 +1,1 @@
+ERROR	file:./src/queries/seealso-non-iri.rq

--- a/src/queries/seealso-non-iri.rq
+++ b/src/queries/seealso-non-iri.rq
@@ -1,0 +1,25 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX d3f: <http://d3fend.mitre.org/ontologies/d3fend.owl#>
+
+# Quality report: rdfs:seeAlso assertions whose object is a string literal
+# instead of an IRI (issue #439).
+#
+# D3FEND ships make-has-links-anyURI.rq to DELETE/INSERT d3f:has-link string
+# literals into xsd:anyURI; rdfs:seeAlso has no such guard, so a seeAlso pointing
+# at a CURIE string (for example "T1574.001") instead of an @id slips through.
+# This read-only report is the regression guard for #439, catching the defect on
+# every build rather than fixing it once. Scoped to rdfs:seeAlso deliberately:
+# d3f:has-link string literals are a separate, already-handled condition (the
+# make-has-links-anyURI fix), so folding them in would swamp the #439 signal.
+# Measured at 11 occurrences in D3FEND v1.4.0.
+#
+# Sibling of inconsistent-iri.rq; no reasoning impact. Paired profile severity:
+# ERROR (a seeAlso that is not an IRI is a real data defect).
+
+SELECT DISTINCT ?entity ?property ?value
+WHERE {
+    BIND(rdfs:seeAlso AS ?property)
+    ?entity rdfs:seeAlso ?value .
+    FILTER(isLiteral(?value))
+} ORDER BY ?entity


### PR DESCRIPTION
Wires two ROBOT report targets into the build — the OCSF crosswalk-coverage check from #571 and the non-IRI `seeAlso` guard from #439 — and carries a reviewed proposal for the fillable part of the #571 coverage gap.

## The checks

**`missing-ocsf-seealso.rq` (rides #571, WARN).** Walks `d3f:DigitalArtifact`/`d3f:DigitalEvent` and flags every class with no `rdfs:seeAlso` to an OCSF IRI, turning crosswalk coverage from a one-off measurement into a standing report. ~1,114 orphans on v1.4.0; leaf subset 593/607 = 97.7%. Advisory coverage gap, not a defect → `--fail-on none`.

**`seealso-non-iri.rq` (rides #439, ERROR).** Flags `rdfs:seeAlso` whose object is a string literal instead of an IRI (e.g. `T1574.002 → "T1574.001"`). 11 cases on v1.4.0. The read-only guard for the `seeAlso` side of the defect `make-has-links-anyURI.rq` already fixes for `d3f:has-link`. Wired `--fail-on none` for now because the 11 violations pre-exist; tighten to `--fail-on ERROR` once they're resolved (the point of #439).

Both touch no axioms and change no entailments; added to the `reports:` aggregate and `REPORT_FILES`.

## A reviewed proposal for the #571 gap

Finding the gap is cheap; the harder half is what the missing links should be. I ran a schema-verified pass over the orphans and propose **100 candidate `seeAlso` links** — every target verified to exist in OCSF (against the ~68 existing links plus the CIM→OCSF crosswalk; 0 invented) — split **10 HIGH** (adoptable as-is) / **90 MEDIUM** (need a maintainer call on whether a sub-class→parent or event→object link is wanted). The 10 HIGH:

| D3FEND class | Proposed OCSF `seeAlso` | Evidence |
|---|---|---|
| `:CreateProcess` | `classes/process_activity` | Process creation is the defining activity of OCSF Process Activity; corroborated by the existing `ProcessEvent → classes/process_activity` link. |
| `:OSAPICreateProcess` | `classes/process_activity` | OS-API-abstract sibling of `:CreateProcess`. |
| `:WindowsNtCreateProcess` | `classes/process_activity` | NT-syscall layer beneath `CreateProcess`. |
| `:InternetDNSLookup` | `objects/dns_query` | `DNSLookup → objects/dns_query` (near-exact name); subtype of `DNSLookup`. |
| `:LoginSession` | `objects/session` | `Session → objects/session`; a login session is a session instance. |
| `:LogonEvent` | `classes/authentication` | A logon is an authentication event; `AuthenticationEvent` is already linked to `classes/authentication`. |
| `:LogonUser` | `objects/user` | `UserAccount → objects/user`; `LogonUser` is the user principal in a logon event. |
| `:ScheduledJobCreationEvent` | `classes/scheduled_job_activity` | Sub-class of `ScheduledJobEvent → classes/scheduled_job_activity`; Create is an activity_id sub-state. |
| `:ScheduledJobDeletionEvent` | `classes/scheduled_job_activity` | Sub-class of `ScheduledJobEvent`; Delete is an activity_id sub-state. |
| `:ScheduledJobStartEvent` | `classes/scheduled_job_activity` | Sub-class of `ScheduledJobEvent`; Start is an activity_id sub-state. |

**Honest accounting:** 100 proposed against **~1,014 that stay unmapped** — 139 examined and confirmed to have no OCSF analogue at their granularity, and ~875 fine-grained leaves not individually examined but expected residual by the same argument. That residual *is* the 97.7% leaf-orphan finding: D3FEND's artifact taxonomy descends below the level OCSF's object model carries, so most leaves correctly have nothing to point at. This is a proposal for review, not asserted-correct mappings. The full 100-row table (10 HIGH + 90 MEDIUM) is in the #571 discussion.

## Follow-on (not in this PR)

A third query, `ocsf-crosswalk-reciprocity.rq` (each D3FEND→OCSF link with no reciprocal OCSF→D3FEND back-reference), is ready but needs a merged D3FEND ⊕ OCSF-crosswalk graph to run meaningfully, so it's not wired into the standard build here. Happy to add it as a CI scaffold if you'd want the reciprocity check.

Contributes to #571 and #439.
