### PR TITLE
Add agent-native artifact classes for AI agent tool invocation and messaging

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -1775,6 +1775,44 @@ skos:prefLabel a owl:AnnotationProperty .
 
 ### Classes
 
+:AgentToolConfiguration a owl:Class ;
+    rdfs:label "Agent Tool Configuration" ;
+    rdfs:subClassOf :ConfigurationResource ;
+    :definition "Information that declares the tools, skills, or capabilities an AI agent may invoke, including their names, parameters, and permitted operations. Examples include an MCP (Model Context Protocol) server's tool declarations and a skill file's frontmatter and instructions." .
+
+:AgentToolManifest a owl:Class ;
+    rdfs:label "Agent Tool Manifest" ;
+    skos:altLabel "Skill File",
+        "Tool Manifest" ;
+    rdfs:subClassOf :ConfigurationFile,
+        [ a owl:Restriction ;
+            owl:onProperty :contains ;
+            owl:someValuesFrom :AgentToolConfiguration ],
+        [ a owl:Restriction ;
+            owl:onProperty :loaded-by ;
+            owl:someValuesFrom :Agent ] ;
+    :definition "A configuration file loaded by an AI agent at startup or tool-discovery time that declares available tools, skills, or capabilities. Examples include an MCP (Model Context Protocol) server manifest and a skill file (e.g. SKILL.md)." .
+
+:AgentToolInvocation a owl:Class ;
+    rdfs:label "Agent Tool Invocation" ;
+    skos:altLabel "Tool Call" ;
+    rdfs:subClassOf :DigitalMessage,
+        [ a owl:Restriction ;
+            owl:onProperty :has-sender ;
+            owl:someValuesFrom :Agent ] ;
+    :definition "A digital message by which an AI agent requests the execution of a tool or skill declared in an Agent Tool Manifest, together with any arguments supplied for that request." .
+
+:InterAgentMessage a owl:Class ;
+    rdfs:label "Inter Agent Message" ;
+    rdfs:subClassOf :DigitalMessage,
+        [ a owl:Restriction ;
+            owl:onProperty :has-sender ;
+            owl:someValuesFrom :Agent ],
+        [ a owl:Restriction ;
+            owl:onProperty :has-recipient ;
+            owl:someValuesFrom :Agent ] ;
+    :definition "A digital message exchanged between AI agents, or between an AI agent and a tool it invokes, as part of a multi-agent or agent-to-tool workflow." .
+
 :AcademicPaperReference a owl:Class ;
     rdfs:label "Academic Paper Reference" ;
     rdfs:subClassOf :TechniqueReference ;


### PR DESCRIPTION
Closes #586

Adds four artifact classes for AI agent systems, following the guidance from @ikiril01 in #586: sub-class existing artifacts where the parent semantics fit, and keep the scope to artifacts that can be attacked or defended.

AgentToolConfiguration: sub-class of ConfigurationResource. The abstract information that declares an agent's available tools/skills (an MCP server's tool declarations, a skill file's instructions).

AgentToolManifest: sub-class of ConfigurationFile. The concrete file an agent loads at startup or tool-discovery time that contains an AgentToolConfiguration (an MCP server manifest, a skill file such as SKILL.md). This mirrors the existing ApplicationConfiguration / ApplicationConfigurationFile split, which is why it lands under ConfigurationFile rather than Resource directly: File is the on-disk artifact, Resource is the abstract content it carries.

AgentToolInvocation: sub-class of DigitalMessage. A tool-call message sent by an agent (has-sender: Agent).

InterAgentMessage: sub-class of DigitalMessage. A message exchanged between agents, or between an agent and a tool it invokes (has-sender / has-recipient: Agent). Mirrors the existing UserToUserMessage pattern with Agent in place of UserAccount.

These are the two items I described in my last comment on #586 (config-artifact case and message case), kept minimal per that comment: no new object properties, no changes to existing classes or techniques.

Open question I asked in #586 and didn't get confirmation on: whether the manifest/skill-file case belongs under File or Resource. I went with File (ConfigurationFile) because that already has a Resource-side counterpart (ConfigurationResource) in the same pattern as Application/ApplicationConfiguration, so the file itself is naturally a File subclass while the content it carries is a Resource subclass. Flagging this explicitly in case the maintainers see it differently; happy to adjust before merge.

Verified locally: make all (build, extensions, test-load-owl, test-load-ttl, test-load-json, test-load-full, test-jena, test-reasoner, dist) passes clean via docker compose, matching the CI workflow. Compared src/queries/duplicate-labels.rq, missing-rdfs-label.rq, inconsistent-iri.rq, and bogus-direct-subclassing-of-tactic-technique.rq results before/after the change: zero new violations introduced (pre-existing baseline counts unchanged).
