### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0083

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -3692,7 +3692,13 @@ Adversaries may modify or disable a configuration setting related to security co
 :AML.T0083 a owl:Class ;
     rdfs:label "Credentials from AI Agent Configuration - ATLAS" ;
     skos:prefLabel "Credentials from AI Agent Configuration" ;
-    rdfs:subClassOf :ATLASCredentialAccessTechnique ;
+    rdfs:subClassOf :ATLASCredentialAccessTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :ApplicationConfigurationFile ],
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :Credential ] ;
     :attack-id "AML.T0083" ;
     :definition """Adversaries may access the credentials of other tools or services on a system from the configuration of an AI agent.
 


### PR DESCRIPTION
Maps `AML.T0083` (Credentials from AI Agent Configuration) to existing D3FEND artifacts:

- `:accesses :ApplicationConfigurationFile` (Application Configuration File) — *"stored in configuration files"*
- `:accesses :Credential` (Credential) — *"the credentials of other tools or services"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.