### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0088

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -3802,7 +3802,10 @@ Adversaries may use the gathered victim data to Create Deepfakes and impersonate
 :AML.T0088 a owl:Class ;
     rdfs:label "Generate Deepfakes - ATLAS" ;
     skos:prefLabel "Generate Deepfakes" ;
-    rdfs:subClassOf :ATLASAIAttackStagingTechnique ;
+    rdfs:subClassOf :ATLASAIAttackStagingTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :produces ;
+            owl:someValuesFrom :DigitalMedia ] ;
     :attack-id "AML.T0088" ;
     :definition """Adversaries may use generative artificial intelligence (GenAI) to create synthetic media (i.e. imagery, video, audio, and text) that appear authentic. These "[deepfakes]( https://en.wikipedia.org/wiki/Deepfake)" may mimic a real person or depict fictional personas. Adversaries may use deepfakes for impersonation to conduct [Phishing](/techniques/AML.T0052) or to evade AI applications such as biometric identity verification systems (see [Evade AI Model](/techniques/AML.T0015)).
 


### PR DESCRIPTION
Maps `AML.T0088` (Generate Deepfakes) to existing D3FEND artifacts:

- `:produces :DigitalMedia` (Digital Media) — *"create synthetic media (i.e. imagery, video, audio, and text)"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.