### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0010.001

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2575,7 +2575,10 @@ In some instances the attacker will need secondary access to fully carry out an 
 :AML.T0010.001 a owl:Class ;
     rdfs:label "AI Software - ATLAS" ;
     skos:prefLabel "AI Software" ;
-    rdfs:subClassOf :AML.T0010 ;
+    rdfs:subClassOf :AML.T0010,
+        [ a owl:Restriction ;
+            owl:onProperty :modifies ;
+            owl:someValuesFrom :SoftwareLibrary ] ;
     :attack-id "AML.T0010.001" ;
     :definition """Adversaries may target software packages that are commonly used in AI-enabled systems or are part of the AI DevOps lifecycle. This can include deep learning frameworks used to build AI models (e.g. PyTorch, TensorFlow, Jax), generative AI integration frameworks (e.g. LangChain, LangFlow), inference engines, and AI DevOps tools. They may also target the dependency chains of any of these software packages [[pytorch]]. Additionally, adversaries may target specific components used by AI software such as configuration files [[pillar]] or example usage of AI packages, which may be distributed in Jupyter notebooks [[medium]].
 


### PR DESCRIPTION
Maps `AML.T0010.001` (AI Software) to existing D3FEND artifacts:

- `:modifies :SoftwareLibrary` (Software Library) — *"software packages that are commonly used in AI-enabled systems"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.