### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0000.000

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2282,7 +2282,10 @@ Research and technical materials may exist as academic papers published in [Jour
 :AML.T0000.000 a owl:Class ;
     rdfs:label "Journals and Conference Proceedings - ATLAS" ;
     skos:prefLabel "Journals and Conference Proceedings" ;
-    rdfs:subClassOf :AML.T0000 ;
+    rdfs:subClassOf :AML.T0000,
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :DocumentFile ] ;
     :attack-id "AML.T0000.000" ;
     :definition """Many of the publications accepted at premier artificial intelligence conferences and journals come from commercial labs.
 Some journals and conferences are open access, others may require paying for access or a membership.


### PR DESCRIPTION
Maps `AML.T0000.000` (Journals and Conference Proceedings) to existing D3FEND artifacts:

- `:accesses :DocumentFile` (Document File) — *"publications accepted at premier artificial intelligence conferences and journals"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.