### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0000.002

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2304,7 +2304,10 @@ Searching pre-print repositories  provide adversaries with a relatively up-to-da
 :AML.T0000.002 a owl:Class ;
     rdfs:label "Technical Blogs - ATLAS" ;
     skos:prefLabel "Technical Blogs" ;
-    rdfs:subClassOf :AML.T0000 ;
+    rdfs:subClassOf :AML.T0000,
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :WebResource ] ;
     :attack-id "AML.T0000.002" ;
     :definition """Research labs at academic institutions and company R&D divisions often have blogs that highlight their use of artificial intelligence and its application to the organization's unique problems.
 Individual researchers also frequently document their work in blogposts.


### PR DESCRIPTION
Maps `AML.T0000.002` (Technical Blogs) to existing D3FEND artifacts:

- `:accesses :WebResource` (Web Resource) — *"blogs that highlight their use of artificial intelligence"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.