### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0001

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2317,7 +2317,10 @@ This will help the adversary better understand how that organization is using AI
 :AML.T0001 a owl:Class ;
     rdfs:label "Search Open AI Vulnerability Analysis - ATLAS" ;
     skos:prefLabel "Search Open AI Vulnerability Analysis" ;
-    rdfs:subClassOf :ATLASReconnaissanceTechnique ;
+    rdfs:subClassOf :ATLASReconnaissanceTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :DocumentFile ] ;
     :attack-id "AML.T0001" ;
     :definition """Much like the [Search Open Technical Databases](/techniques/AML.T0000), there is often ample research available on the vulnerabilities of common AI models. Once a target has been identified, an adversary will likely try to identify any pre-existing work that has been done for this class of models.
 This will include not only reading academic papers that may identify the particulars of a successful attack, but also identifying pre-existing implementations of those attacks. The adversary may obtain [Adversarial AI Attack Implementations](/techniques/AML.T0016.000) or develop their own [Adversarial AI Attacks](/techniques/AML.T0017.000) if necessary.""" ;


### PR DESCRIPTION
Maps `AML.T0001` (Search Open AI Vulnerability Analysis) to existing D3FEND artifacts:

- `:accesses :DocumentFile` (Document File) — *"reading academic papers that may identify the particulars of a successful attack"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.