### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0003

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2386,7 +2386,10 @@ AI agent configuration files come in multiple forms depending on the platform an
 :AML.T0003 a owl:Class ;
     rdfs:label "Search Victim-Owned Websites - ATLAS" ;
     skos:prefLabel "Search Victim-Owned Websites" ;
-    rdfs:subClassOf :ATLASReconnaissanceTechnique ;
+    rdfs:subClassOf :ATLASReconnaissanceTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :WebResource ] ;
     :attack-id "AML.T0003" ;
     :definition """Adversaries may search websites owned by the victim for information that can be used during targeting.
 Victim-owned websites may contain technical details about their AI-enabled products or services.


### PR DESCRIPTION
Maps `AML.T0003` (Search Victim-Owned Websites) to existing D3FEND artifacts:

- `:accesses :WebResource` (Web Resource) — *"websites owned by the victim"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.