### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0008.002

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2513,7 +2513,10 @@ Owning the hardware provides the adversary with complete control of the environm
 :AML.T0008.002 a owl:Class ;
     rdfs:label "Domains - ATLAS" ;
     skos:prefLabel "Domains" ;
-    rdfs:subClassOf :AML.T0008 ;
+    rdfs:subClassOf :AML.T0008,
+        [ a owl:Restriction ;
+            owl:onProperty :uses ;
+            owl:someValuesFrom :DomainName ] ;
     :attack-id "AML.T0008.002" ;
     :definition """Adversaries may acquire domains that can be used during targeting. Domain names are the human readable names used to represent one or more IP addresses. They can be purchased or, in some cases, acquired for free.
 


### PR DESCRIPTION
Maps `AML.T0008.002` (Domains) to existing D3FEND artifacts:

- `:uses :DomainName` (Domain Name) — *"Adversaries may use acquired domains for a variety of purposes"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.