### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0021

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -2862,7 +2862,10 @@ Poisoned data can be introduced via [AI Supply Chain Compromise](/techniques/AML
 :AML.T0021 a owl:Class ;
     rdfs:label "Establish Accounts - ATLAS" ;
     skos:prefLabel "Establish Accounts" ;
-    rdfs:subClassOf :ATLASResourceDevelopmentTechnique ;
+    rdfs:subClassOf :ATLASResourceDevelopmentTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :creates ;
+            owl:someValuesFrom :UserAccount ] ;
     :attack-id "AML.T0021" ;
     :definition "Adversaries may create accounts with various services for use in targeting, to gain access to resources needed in [AI Attack Staging](/tactics/AML.TA0001), or for victim impersonation." ;
     rdfs:seeAlso <https://atlas.mitre.org/techniques/AML.T0021> .


### PR DESCRIPTION
Maps `AML.T0021` (Establish Accounts) to existing D3FEND artifacts:

- `:creates :UserAccount` (User Account) — *"create accounts with various services"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.