### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0037

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -3016,7 +3016,19 @@ Specific common information repositories include SharePoint, Confluence, and ent
 :AML.T0037 a owl:Class ;
     rdfs:label "Data from Local System - ATLAS" ;
     skos:prefLabel "Data from Local System" ;
-    rdfs:subClassOf :ATLASCollectionTechnique ;
+    rdfs:subClassOf :ATLASCollectionTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :ConfigurationFile ],
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :Database ],
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :File ],
+        [ a owl:Restriction ;
+            owl:onProperty :accesses ;
+            owl:someValuesFrom :PrivateKey ] ;
     :attack-id "AML.T0037" ;
     :definition """Adversaries may search local system sources, such as file systems and configuration files or local databases, to find files of interest and sensitive data prior to Exfiltration.
 


### PR DESCRIPTION
Maps `AML.T0037` (Data from Local System) to existing D3FEND artifacts:

- `:accesses :ConfigurationFile` (Configuration File) — *"configuration files"*
- `:accesses :Database` (Database) — *"local databases"*
- `:accesses :File` (File) — inherited from ATT&CK **T1005**.
- `:accesses :PrivateKey` (Private Key) — *"ssh keys"*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.