### PR TITLE
Add D3FEND artifact restrictions for ATLAS AML.T0077

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -3596,7 +3596,13 @@ Adversaries may attempt to discover information about the services enabled throu
 :AML.T0077 a owl:Class ;
     rdfs:label "LLM Response Rendering - ATLAS" ;
     skos:prefLabel "LLM Response Rendering" ;
-    rdfs:subClassOf :ATLASExfiltrationTechnique ;
+    rdfs:subClassOf :ATLASExfiltrationTechnique,
+        [ a owl:Restriction ;
+            owl:onProperty :produces ;
+            owl:someValuesFrom :OutboundInternetWebTraffic ],
+        [ a owl:Restriction ;
+            owl:onProperty :produces ;
+            owl:someValuesFrom :URL ] ;
     :attack-id "AML.T0077" ;
     :definition """An adversary may get a large language model (LLM) to respond with private information that is hidden from the user when the response is rendered by the user's client. The private information is then exfiltrated. This can take the form of rendered images, which automatically make a request to an adversary controlled server.
 


### PR DESCRIPTION
Maps `AML.T0077` (LLM Response Rendering) to existing D3FEND artifacts:

- `:produces :OutboundInternetWebTraffic` (Outbound Internet Web Traffic) — *"make a request to an adversary controlled server"*
- `:produces :URL` (URL) — *"https://atlas.mitre.org/image.png?secrets="*

Same restriction shape as `:T1003.001`; quotes are verbatim from the technique's `d3f:definition`.