### PR TITLE
Fix Internet network traffic references

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -29798,7 +29798,7 @@ When system firmware verification fails a set of predefined responses is typical
             owl:someValuesFrom :URL ],
         [ a owl:Restriction ;
             owl:onProperty :produces ;
-            owl:someValuesFrom :InternetWebNetworkTraffic ],
+            owl:someValuesFrom :InternetNetworkTraffic ],
         [ a owl:Restriction ;
             owl:onProperty :uses ;
             owl:someValuesFrom :Browser ] ;
@@ -34038,7 +34038,7 @@ When system firmware verification fails a set of predefined responses is typical
             owl:someValuesFrom :ProcessSegment ],
         [ a owl:Restriction ;
             owl:onProperty :produces ;
-            owl:someValuesFrom :InternetWebNetworkTraffic ],
+            owl:someValuesFrom :InternetNetworkTraffic ],
         [ a owl:Restriction ;
             owl:onProperty :produces ;
             owl:someValuesFrom :URL ] ;


### PR DESCRIPTION
## Summary

Corrects the object-class filler used by two existing `produces` restrictions:

- `T0817` — Drive-by Compromise (ATT&CK ICS)
- `T1189` — Drive-by Compromise (ATT&CK Enterprise)

Both restrictions referenced the undeclared class `InternetWebNetworkTraffic`. They now reference the existing `InternetNetworkTraffic` class.

## Ontology changes

| Subject class | Restriction | Previous filler | Corrected filler |
| --- | --- | --- | --- |
| `T0817` | `produces some` | `InternetWebNetworkTraffic` | `InternetNetworkTraffic` |
| `T1189` | `produces some` | `InternetWebNetworkTraffic` | `InternetNetworkTraffic` |

No classes, properties, definitions, or hierarchy branches are added by this change.

## Knowledge graph integration

`InternetNetworkTraffic` is an existing subclass of `NetworkTraffic`. Reusing it preserves the established graph pattern:

```text
ATT&CK technique -> produces -> InternetNetworkTraffic -> subclass of -> NetworkTraffic
```

This keeps both ATT&CK technique classes connected to the existing network-traffic hierarchy, allows existing traffic-oriented queries and reasoning to include their output, and avoids creating a redundant web-specific intersection class. It also removes the undeclared-class references that caused the ontology's OWL 2 DL profile violation.

## Validation

- RDFLib Turtle parsing passes.
- Apache Jena validation passes.
- ROBOT OWL 2 DL profile validation passes with zero violations.
