### PR TITLE
Fix dashboard publish directory setup

### DIFF
--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -27,6 +27,7 @@ jobs:
     - name: Publish gh-pages branch
       run: |
         set -euo pipefail
+        mkdir -p dist/dashboard
         cd dist/dashboard
         touch .nojekyll
         git init


### PR DESCRIPTION
attempts to fix problem with dashboard CI/CD by making sure the containing folder exists with write permissions by the user