### PR TITLE
Materialize event and agent restrictions

### DIFF
--- a/src/queries/restrictions-as-objectproperties.rq
+++ b/src/queries/restrictions-as-objectproperties.rq
@@ -10,6 +10,7 @@ WHERE {
     VALUES ?poss_subject_class {
         d3f:OffensiveTechnique d3f:OffensiveTactic d3f:DefensiveTechnique
         d3f:DefensiveTactic d3f:Artifact d3f:Weakness d3f:CommonAttackPattern
+        d3f:Event d3f:Agent
         d3f:ATTACKMobileTechnique d3f:ATTACKICSTechnique
         d3f:SPARTATechnique d3f:ATLASTechnique
     } .


### PR DESCRIPTION
The materialization query currently skips 277 Event restrictions and 14 Agent restrictions, leaving those OWL restrictions out of the compiled object property assertions.

Adds `d3f:Event` and `d3f:Agent` to the materialization roots. Plan, Goal, Group, and other ontology roots remain excluded.