### PR TITLE
Fix missing offensive technique artifact report

### DIFF
--- a/src/queries/missing-off-tech-artifacts.rq
+++ b/src/queries/missing-off-tech-artifacts.rq
@@ -35,7 +35,7 @@ WHERE {
 
     # Filter the children whose parents have DAs defined.
 	FILTER NOT EXISTS {
-      ?pentity ?pp ?pda .
+      ?p_entity ?pp ?pda .
       ?pda rdfs:subClassOf* d3f:Artifact .
       ?pp rdfs:subPropertyOf* d3f:may-be-associated-with .
       ?entity rdfs:subClassOf* ?p_entity .


### PR DESCRIPTION
## Summary
- use the connected `?p_entity` variable when checking parent artifact associations
- restore missing-artifact findings that were hidden by the disconnected variable

## Testing
- `make reports/missing-off-tech-artifacts-report.txt` (383 findings)