### PR TITLE
Fix Space ontology naming and definition inconsistencies

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -830,7 +830,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-corrupt a owl:ObjectProperty ;
     rdfs:label "may-corrupt" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-corrupt y: They entity x may corrupt y's information content; that is, 'x corrupts y' may be true." .
+    :definition "x may-corrupt y: The entity x may corrupt y's information content; that is, 'x corrupts y' may be true." .
 
 :may-counter a owl:ObjectProperty ;
     rdfs:label "may-counter" ;
@@ -4708,7 +4708,7 @@ This technique requires the ability to parse application layer protocols to unde
     :definition "A configuration of an application which is used to apply logical or data processing functions to data processed by the application." .
 
 :ApplicationRuntimeVariable a owl:Class ;
-    rdfs:label "Application Runtime Variable " ;
+    rdfs:label "Application Runtime Variable" ;
     rdfs:subClassOf :RuntimeVariable ;
     :definition "A system variable that tracks aspects of runtime of a system." .
 
@@ -17886,7 +17886,7 @@ The term "first-order" distinguishes first-order logic from higher-order logic, 
         [ a owl:Restriction ;
             owl:onProperty :may-contain ;
             owl:someValuesFrom :SoftwareWatchdogTimer ] ;
-    :definition "Flight Software (FSW) is software that runs on a processor embedded in a spacecraft's avionics. It is responsible for managing on-board activities, data processing and spacecraft health and safety. The name “flight software” reflects the location where it executes, i.e. in the spacecraft , to differentiate from “ground software”, which runs in the ground segment." ;
+    :definition "Flight Software (FSW) is software that runs on a processor embedded in a spacecraft's avionics. It is responsible for managing on-board activities, data processing and spacecraft health and safety. The name “flight software” reflects the location where it executes, i.e. in the spacecraft, to differentiate from “ground software”, which runs in the ground segment." ;
     rdfs:seeAlso <https://phxcubesat.asu.edu/subsystems/flight-software>,
         <https://www.spiedigitallibrary.org/conference-proceedings-of-spie/13546/135462R/An-evaluation-of-flight-software-platforms-for-small-satellite-missions/10.1117/12.3062481.full> ;
     :synonym "FSW",
@@ -26477,7 +26477,8 @@ Metadata collection on enterprises can yield large data sets. Storage, indexing,
     rdfs:subClassOf :PhysicalAccessAlarmEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :ProximitySensor ] .
+            owl:someValuesFrom :ProximitySensor ] ;
+    :definition "An event in which a proximity sensor detects the presence of a nearby object without physical contact." .
 
 :ProximitySensorMonitoring a owl:Class,
         owl:NamedIndividual,
@@ -26885,13 +26886,13 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
             owl:someValuesFrom :MemoryBlock ] .
 
 :Real-timeOperatingSystem a owl:Class ;
-    rdfs:label "Real-time operating system" ;
+    rdfs:label "Real-time Operating System" ;
     rdfs:subClassOf :OperatingSystem ;
     rdfs:isDefinedBy <https://dbpedia.org/resource/Real-time_operating_system> ;
     :definition "A real-time operating system (RTOS) is an operating system (OS) for real-time computing applications that processes data and events that have critically defined time constraints. " ;
     :synonym "RTOS" .
 
-:RealtimeClock a owl:Class ;
+:Real-timeClock a owl:Class ;
     rdfs:label "Real-time Clock" ;
     rdfs:subClassOf :HardwareClock ;
     rdfs:isDefinedBy <https://dbpedia.org/resource/Real-time_clock> ;
@@ -27843,7 +27844,7 @@ Example RPC Protocols:
     rdfs:subClassOf :HardwareClockEvent,
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
-            owl:someValuesFrom :RealtimeClock ] ;
+            owl:someValuesFrom :Real-timeClock ] ;
     :definition "An event in which a Real-Time Clock's stored time value is read from or written to its battery-backed storage." .
 
 :RTSPServer a owl:Class ;
@@ -28762,7 +28763,7 @@ Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
     :synonym "SDR" .
 
 :Software-definedRadioComputer a owl:Class ;
-    rdfs:label "Software-Defined Radio Computer" ;
+    rdfs:label "Software-defined Radio Computer" ;
     rdfs:subClassOf :OTEmbeddedComputer,
         [ a owl:Restriction ;
             owl:onProperty :contains ;
@@ -28784,7 +28785,7 @@ Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
     rdfs:seeAlso <https://www.analog.com/media/en/training-seminars/design-handbooks/Software-Defined-Radio-for-Engineers-2018/SDR4Engineers.pdf> .
 
 :Software-definedRadioDevice a owl:Class ;
-    rdfs:label "Software-Defined Radio Device" ;
+    rdfs:label "Software-defined Radio Device" ;
     rdfs:subClassOf :Software-definedRadio ;
     :definition "A hardware device that functions primarily as an RF front end plus data conversion and transport, relying on an external host computer to run most waveform/DSP processing and to control operation. It is commonly connected via USB, PCIe, or similar links and behaves like a high-speed radio peripheral." ;
     rdfs:seeAlso <https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR> ;
@@ -28819,7 +28820,7 @@ Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
     :synonym "SDR waveform",
         "Waveform Software" .
 
-:Software-definedRadioWaveformConfigurationEvent a owl:Class ;
+:Software-definedRadioWaveformApplicationConfigurationEvent a owl:Class ;
     rdfs:label "Software-defined Radio Waveform Application Configuration Event" ;
     rdfs:subClassOf :Software-definedRadioEvent,
         [ a owl:Restriction ;
@@ -28830,7 +28831,7 @@ Wikipedia. (n.d.). Skewness. [Link](https://en.wikipedia.org/wiki/Skewness)""" .
             owl:someValuesFrom :Software-definedRadioWaveformApplication ] ;
     :definition "An SDR event where the waveform application's operational parameters have been applied and validated (e.g., sample rate, bandwidth, channel selection, framing/modulation options), placing the waveform in a state ready to run." .
 
-:Software-definedRadioWaveformLoadEvent a owl:Class ;
+:Software-definedRadioWaveformApplicationLoadEvent a owl:Class ;
     rdfs:label "Software-defined Radio Waveform Application Load Event" ;
     rdfs:subClassOf :Software-definedRadioEvent,
         [ a owl:Restriction ;
@@ -28970,7 +28971,7 @@ Application-layer discovery:
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :SoftwareTimer ] ;
-    :definition "A clock event involving a software-based timekeeping mechanism maintained by an operating system or application." .
+    :definition "A timer event involving a software timer managed by an operating system or application to schedule tasks, implement timeouts, or trigger periodic operations." .
 
 :SoftwareUpdate a owl:Class,
         owl:NamedIndividual,


### PR DESCRIPTION
## Summary

- align the `Real-time` and `Software-defined` Space class IRIs and labels
- include `Application` in the two waveform-application event IRIs
- add the missing `ProximitySensorEvent` definition and distinguish `SoftwareTimerEvent` from a clock event
- remove trailing label whitespace and fix two definition typos

## IRI consistency query

`src/queries/inconsistent-iri.rq` checks entities under `D3FENDCore` and `D3FENDKBThing`. It normalizes each `rdfs:label` by removing unsupported punctuation, collapsing and trimming whitespace, capitalizing configured connector words, and packing the result. It then reports entities whose IRI suffix does not match that packed label, excluding the explicitly configured ontology branches and HTTP-event exceptions.

Before this change, the report contained 20 violations. Six were from the Space additions:

- `Real-timeOperatingSystem`
- `RealtimeClock`
- `Software-definedRadioComputer`
- `Software-definedRadioDevice`
- `Software-definedRadioWaveformConfigurationEvent`
- `Software-definedRadioWaveformLoadEvent`

After this change, `make reports/inconsistent-iri-report.txt` reports 14 violations, all pre-existing and unrelated to the Space additions.

## Validation

- `make reports/inconsistent-iri-report.txt reports/missing-d3fend-definition-report.txt`
- `robot validate-profile --profile DL --input build/d3fend-full.owl`
- `robot reason --reasoner ELK --input build/d3fend-full.owl`
