### PR TITLE
Fix ontology typos

### DIFF
--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -18372,7 +18372,7 @@ Hardware process isolation is commonly implemented through Direct Memory Access 
     rdfs:label "Hardware Clock" ;
     rdfs:subClassOf :Clock,
         :HardwareDevice ;
-    :definition "A clock implemented using physical electronic components, typically providing timekeeping independent of system power or software state. " ;
+    :definition "A clock implemented using physical electronic components, typically providing timekeeping independent of system power or software state." ;
     rdfs:seeAlso <https://linux.die.net/man/8/clock> .
 
 :HardwareClockDeviceDriver a owl:Class ;
@@ -26580,7 +26580,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
 There are three core radiation hardening methodologies:
 
 1. Radiation Hardening by Process (RHBP): modifying the physical fabrication of a semiconductor (e.g., using SOI - Silicon on Insulator), offering the highest intrinsic protection. Usually the most expensive option as it requires a specialized semiconductor fabrication plant.
-2. Radiation Hardening by Design (RHBD): modifying circuit topology and physical layout using techniques such as Triple Modular Redundancy (TMM). A more cost-effective option, with the constraint of potentially increasing chip area and power.
+2. Radiation Hardening by Design (RHBD): modifying circuit topology and physical layout using techniques such as Triple Modular Redundancy (TMR). A more cost-effective option, with the constraint of potentially increasing chip area and power.
 3. Radiation Hardening by Shielding (RHBS): using physical materials (e.g., aluminum or tantalum) to block ionizing particles. Simple to implement, with the constraint of increasing size and weight.""" ;
     :kb-reference :Reference-ARadiationHardenedSARADCWithDelayBasedDualFeedbackFlipFlopsForSensorReadoutSystems,
         :Reference-DiagnosisOfFaultsInducedByRadiationAndCircuitLevelDesignMitigationTechniques,
@@ -26888,14 +26888,14 @@ Wikipedia. (n.d.). Range (statistics). [Link](https://en.wikipedia.org/wiki/Rang
     rdfs:label "Real-time operating system" ;
     rdfs:subClassOf :OperatingSystem ;
     rdfs:isDefinedBy <https://dbpedia.org/resource/Real-time_operating_system> ;
-    :definition "A real-time operating system (RTOS) is an operating system (OS) for real-time computing applications that processes data and events that have critically defined time constraints. " ;
+    :definition "A real-time operating system (RTOS) is an operating system (OS) for real-time computing applications that processes data and events that have critically defined time constraints." ;
     :synonym "RTOS" .
 
 :RealtimeClock a owl:Class ;
     rdfs:label "Real-time Clock" ;
     rdfs:subClassOf :HardwareClock ;
     rdfs:isDefinedBy <https://dbpedia.org/resource/Real-time_clock> ;
-    :definition "A real-time clock (RTC) is an electronic device (most often in the form of an integrated circuit) that measures the passage of time. " ;
+    :definition "A real-time clock (RTC) is an electronic device (most often in the form of an integrated circuit) that measures the passage of time." ;
     :synonym "RTC" .
 
 :REC-0001 a owl:Class ;
@@ -27844,7 +27844,7 @@ Example RPC Protocols:
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :RealtimeClock ] ;
-    :definition "An event in which a Real-Time Clock's stored time value is read from or written to its battery-backed storage." .
+    :definition "An event in which a Real-time Clock's stored time value is read from or written to its battery-backed storage." .
 
 :RTSPServer a owl:Class ;
     rdfs:label "RTSP Server" ;
@@ -40646,7 +40646,7 @@ Temporal difference learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/T
 :TimeInterval a owl:Class ;
     rdfs:label "Time Interval" ;
     rdfs:subClassOf :Time ;
-    :definition "A time interval is a one-dimensional temporal region that has duration and represents a continuous extent of time bounded by two time instants (a start instant and an end instant). " .
+    :definition "A time interval is a one-dimensional temporal region that has duration and represents a continuous extent of time bounded by two time instants (a start instant and an end instant)." .
 
 :Timer a owl:Class ;
     rdfs:label "Timer" ;

--- a/src/ontology/d3fend-protege.ttl
+++ b/src/ontology/d3fend-protege.ttl
@@ -429,7 +429,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:subPropertyOf :associated-with,
         :isolates ;
     rdfs:isDefinedBy <http://wordnet-rdf.princeton.edu/id/01461293-v> ;
-    :definition "x filters y: An technique or agent x removes some specified set of of entities from the content of a digital artifact y, by passing an artifact's content through a filter.  A filter is a device that removes something from whatever passes through it." ;
+    :definition "x filters y: A technique or agent x removes some specified set of entities from the content of a digital artifact y, by passing an artifact's content through a filter.  A filter is a device that removes something from whatever passes through it." ;
     rdfs:seeAlso <http://wordnet-rdf.princeton.edu/id/03344588-n>,
         <http://www.ontologyrepository.com/CommonCoreOntologies/Filter> .
 
@@ -819,7 +819,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-block a owl:ObjectProperty ;
     rdfs:label "may-block" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-block y: They entity x may block the thing y; that is, 'x blocks y' may be true." .
+    :definition "x may-block y: The entity x may block the thing y; that is, 'x blocks y' may be true." .
 
 :may-contain a owl:ObjectProperty,
         owl:TransitiveProperty ;
@@ -900,7 +900,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
     rdfs:label "may-isolate" ;
     rdfs:subPropertyOf :may-counter-attack ;
     :pref-label "may isolate" ;
-    :todo "There are some d3f isolation techniques H b P I and E T and M A C that use isolates directly which is different sense that this tactial isolates/may-isolates." .
+    :todo "There are some d3f isolation techniques H b P I and E T and M A C that use isolates directly which is different sense that this tactical isolates/may-isolates." .
 
 :may-map a owl:ObjectProperty ;
     rdfs:label "may-map" ;
@@ -928,7 +928,7 @@ Moving forward different distinctions of kinds of has-part (contains) relationsh
 :may-transfer a owl:ObjectProperty ;
     rdfs:label "may-transfer" ;
     rdfs:subPropertyOf :may-be-associated-with ;
-    :definition "x may-transfer y: They entity x may send the thing y; that is, 'x transfers y' may be true." .
+    :definition "x may-transfer y: The entity x may send the thing y; that is, 'x transfers y' may be true." .
 
 :mediates-access-to a owl:ObjectProperty ;
     rdfs:label "mediates-access-to" ;
@@ -2024,13 +2024,13 @@ Active learning is particularly useful in scenarios where data is abundant but l
 
 Active logical link mapping establishes awareness of logical links in the network by sending data over the network to gather information about logical connections in the network.
 
-Typically this will be achieved through network telemetry coordinated for network management and monitoring and will use a link layer discovery protocol such as LLDP and the information gathered and aggregated a higher levels using an application protocol such as SNMP.  The information may be polled by network management softare or configured once and then pushed from network sensors (or agents.)
+Typically this will be achieved through network telemetry coordinated for network management and monitoring and will use a link layer discovery protocol such as LLDP and the information gathered and aggregated at higher levels using an application protocol such as SNMP.  The information may be polled by network management software or configured once and then pushed from network sensors (or agents.)
 
-Another means of establishing network connectivity is by means of sendingn traffic through the use of a tool such as traceroute, to determine the logical paths through the network architecture.
+Another means of establishing network connectivity is by means of sending traffic through the use of a tool such as traceroute, to determine the logical paths through the network architecture.
 
 ## Considerations
 
-* Best practice is to encrypte network monitoring data and require authentication for queries or admin/management functions.
+* Best practice is to encrypt network monitoring data and require authentication for queries or admin/management functions.
 * Push notifications reduce bandwidth necessary to capture and maintain information if reliable transport is used.
 * Special consideration should be made before using of active scanning in OT networks and OT-safe options chosen where available.""" ;
     :kb-reference :Reference-IdentificationOfTracerouteNodesAndAssociatedDevices,
@@ -4453,7 +4453,7 @@ In a more general sense, ASP includes all applications of answer sets to knowled
     :d3fend-id "D3-ABPI" ;
     :definition "Application code which prevents its own subroutines from accessing intra-process / internal memory space." ;
     :kb-article """## How it works
-Some applications implement logic to permit or deny a particular subroutine access to other data within the same applicaition process. This is intended to prevent critical application process data from being tampered with.
+Some applications implement logic to permit or deny a particular subroutine access to other data within the same application process. This is intended to prevent critical application process data from being tampered with.
 
 ### Application-based Process Isolation in web browsers.
 
@@ -4588,7 +4588,7 @@ Monitoring timer and counter failures or exceedances can reveal issues with the 
 :ApplicationFailureCountVariable a owl:Class ;
     rdfs:label "Application Failure Count Variable" ;
     rdfs:subClassOf :RuntimeVariable ;
-    rdfs:comment "Differenct controller brands have different system tags to monitor various aspects, for example in Allen-Bradley you might use S:ERR, T4:0.DN, C5:0.OV; respectively System error, timer/counter status bits" ;
+    rdfs:comment "Different controller brands have different system tags to monitor various aspects, for example in Allen-Bradley you might use S:ERR, T4:0.DN, C5:0.OV; respectively System error, timer/counter status bits" ;
     :definition "Variables that keep count of various failures and errors." .
 
 :ApplicationHardening a :ApplicationHardening,
@@ -4753,7 +4753,7 @@ This technique requires the ability to parse application layer protocols to unde
     rdfs:label "Approximate String Matching" ;
     rdfs:subClassOf :PartialMatching ;
     :d3fend-id "D3A-ASM" ;
-    :definition "Approximate string matching is a form of string matching that allows errrors." ;
+    :definition "Approximate string matching is a form of string matching that allows errors." ;
     :kb-article """## References
 1. Navarro, G. (2001). A guided tour to approximate string matching. _ACM Computing Surveys_, 33(1), 31-88. [Link](https://doi.org/10.1145/375360.375365)""" .
 
@@ -5813,7 +5813,7 @@ Bootstrap aggregating. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Bootstra
     :kb-article """## How it works
 Software Defined Networking, or other network encapsulation technologies intercept host broadcast traffic then route it to a specified destination per a configured policy.
 
-This can be implemented within hypervisors, networking hardware (WAPs, switches, routers), or virutal hardware.
+This can be implemented within hypervisors, networking hardware (WAPs, switches, routers), or virtual hardware.
 
 ## Considerations
 This technique is highly dependent on network infrastructure and networking requirements.""" ;
@@ -6347,7 +6347,7 @@ There is no single theory on how to map algorithms onto problem types; instead, 
       both verification (developmental test) and operational test
       stages use:
 
-    - **Accuracy**: The fraction of predictions that were corret.
+    - **Accuracy**: The fraction of predictions that were correct.
 
     - **Precision**: The proportion of positive identifications that were correct.
 
@@ -6398,7 +6398,7 @@ There is no single theory on how to map algorithms onto problem types; instead, 
 	- **Proxy variables**: Model features may be highly
         correlated.
 
-  - **Overfitting and Underfitting**: Overfitting occurs when the the
+  - **Overfitting and Underfitting**: Overfitting occurs when the
     model built corresponds too closely or exactly to a particular
     set of data, and thus may fail to fit to predict additional data
     reliably. An overfitted model is a mathematical model that
@@ -6916,7 +6916,7 @@ Another approach passively inspects network traffic with application protocol an
 ## Considerations
 
 * Implementations that rely on analysis of unallocated IP address space increase in their complexity with network size and decentralized network infrastructure.
-* Inventory of unallocated IP space should should be continuously updated to mitigate the risk of false positives.
+* Inventory of unallocated IP space should be continuously updated to mitigate the risk of false positives.
 * IPv6 also introduces challenges including IPv6 traffic bypassing IPv4 specific protection systems (ex. firewalls and IDS) and complexity in managing both IPv6 and IPv4 addresses.""" ;
     :kb-reference :Reference-DetectingNetworkReconnaissanceByTrackingIntranetDark-netCommunications_VECTRANETWORKSInc ;
     :synonym "Network Scan Detection" .
@@ -6992,7 +6992,7 @@ This admission controller
 
 * Image scanning is key to ensuring deployed containers are secure.
 * Using trusted repositories to build containers is a critical part of the container build workflow.
-* This technique does not necessarly prevent the build process to add insecure or unsecured
+* This technique does not necessarily prevent the build process to add insecure or unsecured
   files to the Image.
 """ ;
     :kb-reference :Reference-ContainerImageAnalysis ;
@@ -7033,7 +7033,7 @@ This admission controller
     :definition "Removing specific, potentially malicious, parts of content" ;
     :kb-article """## How it works
 
-If malicious or unecessary elements is discovered within the content, or if a specific embedded portion does not comply with policy, it may be removed to ensure safety.""" ;
+If malicious or unnecessary elements is discovered within the content, or if a specific embedded portion does not comply with policy, it may be removed to ensure safety.""" ;
     :kb-reference :Reference-MethodForContentDisarmandReconstruction_OPSWATInc .
 
 :ContentFiltering a :ContentFiltering,
@@ -7051,7 +7051,7 @@ If malicious or unecessary elements is discovered within the content, or if a sp
             owl:onProperty :filters ;
             owl:someValuesFrom :File ] ;
     :d3fend-id "D3-CF" ;
-    :definition "Content Filtering techniques aid in the process of analyzing an input file for malicious or erroneous content and outputing a sanitized version." ;
+    :definition "Content Filtering techniques aid in the process of analyzing an input file for malicious or erroneous content and outputting a sanitized version." ;
     :kb-reference :Reference-MethodForContentDisarmandReconstruction_OPSWATInc .
 
 :ContentFormatConversion a :ContentFormatConversion,
@@ -7135,7 +7135,7 @@ If inputted content is divided up into components for further scrutiny, the comp
     :definition "Modifies specific digital content information by replacing it with something else." ;
     :kb-article """## How it works
 
-If malicious or unecessary elements is discovered within the content, or if a specific embedded portion does not comply with policy, it may be replaced with alternatives to ensure safety.""" ;
+If malicious or unnecessary elements is discovered within the content, or if a specific embedded portion does not comply with policy, it may be replaced with alternatives to ensure safety.""" ;
     :kb-reference :Reference-MethodForContentDisarmandReconstruction_OPSWATInc .
 
 :ContentValidation a :ContentValidation,
@@ -14257,7 +14257,7 @@ While the basic underlying model is that of a decision tree, the decision tree n
 
    - **Use a variety of data sets**: where available and applicable, to
       reflect different operating and environment conditions that are
-      likley to be be encountered.
+      likely to be encountered.
 
   - **Use software libraries**: and tools built for ML where possible, so
       that the underlying code is verified by prior use.**
@@ -14273,7 +14273,7 @@ While the basic underlying model is that of a decision tree, the decision tree n
       both verification (developmental test) and operational test
       stages use:
 
-    - **Accuracy**: The fraction of predictions that were corret.
+    - **Accuracy**: The fraction of predictions that were correct.
 
     - **Precision**: The proportion of positive identifications that were correct.
 
@@ -14326,7 +14326,7 @@ While the basic underlying model is that of a decision tree, the decision tree n
 
 - **Supervised Learning**:
 
-  - **Overfitting and Underfitting**: Overfitting occurs when the the
+  - **Overfitting and Underfitting**: Overfitting occurs when the
     model built corresponds too closely or exactly to a particular
     set of data, and thus may fail to fit to predict additional data
     reliably. An overfitted model is a mathematical model that
@@ -14683,7 +14683,7 @@ Google Developers. (n.d.). Clustering algorithms. [Link](https://developers.goog
     rdfs:label "Density-weighted Method" ;
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-DWM" ;
-    :definition "An Actvie Learning technique that uses a density estimate meta-parameter to avoid sampling sparsely populated regions of the feature space and can be based parametrically or from a parameter free model." ;
+    :definition "An Active Learning technique that uses a density estimate meta-parameter to avoid sampling sparsely populated regions of the feature space and can be based parametrically or from a parameter free model." ;
     :kb-article """## References
 Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
 
@@ -15495,7 +15495,7 @@ Most nameserver hosts and domain name registrars comply with internationally rec
 Attackers will create infrastructure from which to carry out their operations and this may include registering domain names to be used in the various attacks. Known misuse cases include:
 
 - Registering domain names that are similar to the victim's. This is known as typosquatting or URL hijacking. Legitimate looking mails or URLs could be sent using this domain in phishing campaigns.
-- Registring domain names that are used in C2 beacons.""" ;
+- Registering domain names that are used in C2 beacons.""" ;
     :kb-reference :Reference-UnderstandingtheDomainRegistrationBehaviorofSpammers .
 
 :DomainTrustPolicy a :DomainTrustPolicy,
@@ -15646,7 +15646,7 @@ For threats at higher energy levels or involving ionizing radiation, such as nuc
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :ElectronicCombinationLock ] ;
-    rdfs:comment "An event occuring when combination lock's bolt changes position." ;
+    rdfs:comment "An event occurring when combination lock's bolt changes position." ;
     rdfs:seeAlso "NRC Regulatory Guide 5.12 Rev1" .
 
 :ElectronicLockMonitoring a :ElectronicLockMonitoring,
@@ -15760,7 +15760,7 @@ For email that needs to be removed, an infosec organization may choose to take a
 
 For the case where users detect likely suspicious email files, the organization should consider implementing a means for reporting these emails to their infosec organization.
 
-Email files may propagate through many storage systems across the an organization's systems over time, so early detection and blocking helps avoid residual, latent stores of malicous email content in the enterprise.""" ;
+Email files may propagate through many storage systems across an organization's systems over time, so early detection and blocking helps avoid residual, latent stores of malicious email content in the enterprise.""" ;
     :kb-reference :Reference-SystemAndMethodForScanningRemoteServicesToLocateStoredObjectsWithMalware ;
     :synonym "Email Deletion" .
 
@@ -15921,7 +15921,7 @@ Equality is a relationship between two quantities or, more generally two mathema
 Programming languages can have multiple senses of equality that may include, but are not limited to:
 
 - Identity: The objects are identical; often indicated by having values indicating the same logical address.
-- Equality: The values of the expessions and properties are equivalent when evaluated; they do not need to have the same logical address.
+- Equality: The values of the expressions and properties are equivalent when evaluated; they do not need to have the same logical address.
 
 ## References
 1. Equality (mathematics). (2023, May 31). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Equality_(mathematics)]
@@ -15935,7 +15935,7 @@ Programming languages can have multiple senses of equality that may include, but
     :definition "Estimation represents ways or a process of learning and determining the population parameter based on the model fitted to the data." ;
     :kb-article """## References
 Pennsylvania State University. (n.d.). Statistical Inference and Estimation. [Link](https://online.stat.psu.edu/stat504/lesson/statistical-inference-and-estimation)""" ;
-    :todo "Seems like there should be more than just interval and pont estimation in here." .
+    :todo "Seems like there should be more than just interval and point estimation in here." .
 
 :EvalFunction a owl:Class ;
     rdfs:label "Eval Function" ;
@@ -16712,7 +16712,7 @@ In architectures where component identity is derived solely from message identif
     :kb-article """## How It Works
 When a process encounters an exception, it calls an exception handler to deal with the exception.  The method by which this exception handler is determined varies by the operating system.  The exception handler is called, even if it is the default exception handler to terminate the program and display a message that the program stopped working.  In the case that no valid exception handler is found, the program would fail to proceed as normal and could be programmed to terminate.
 
-In Windows, the address of the exception registration record is stored at the very start of the the Thread Information Block; the GS register points to this structure.
+In Windows, the address of the exception registration record is stored at the very start of the Thread Information Block; the GS register points to this structure.
 
 The exception registration record contains two pointers: a pointer to the next exception registration record should this handler fail to handle the exception, and a pointer to the handler.
 
@@ -17081,7 +17081,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
     rdfs:subClassOf :ActiveLearning ;
     :d3fend-id "D3A-EMC" ;
     :definition "Supervised learning establishes a relationship between the known input and output variables to conduct a predictive analysis." ;
-    :kb-article """nal Consiterations
+    :kb-article """## Additional Considerations
 
 ## References
 Intro to Active Learning. inovex Blog. [Link](https://www.inovex.de/de/blog/intro-to-active-learning/).""" .
@@ -17247,7 +17247,7 @@ Analyzing a piece of code without it being executed in a sandbox, virtual machin
     :definition "Checking if compressed or encoded data sections can be successfully decompressed or decoded. Can follow with further analysis with semantic knowledge" ;
     :kb-article """## How it works
 
-Some file formats such as JPEGs include encoded or compressed sections. This technique verfies that those expected sections are present and can be properly decoded according to the spec.""" ;
+Some file formats such as JPEGs include encoded or compressed sections. This technique verifies that those expected sections are present and can be properly decoded according to the spec.""" ;
     :kb-reference :Reference-CarvingContiguousandFragmentedFilesWithFastObjectValidation,
         :Reference-GatheringEvidenceModel-DrivenSoftwareEngineeringinAutomatedDigitalForensics .
 
@@ -17499,7 +17499,7 @@ Unix - Unix systems have a file integrity checker tool called tripwire. Tripwire
 Windows - In Microsoft Azure, file integrity monitoring can be enabled which can track file and registry key creation, removals, and modifications of specific files.
 
 ## Considerations
-Files can change constantly due to the non-static nature of a computer system. File Integrity Monitoring works best when pointed at a narrow scope of critical files to limit the number of unneccessary files that may be modified over the course of normal use. The accuracy and precision of defined policies also affect the efficacy of this technique.""" ;
+Files can change constantly due to the non-static nature of a computer system. File Integrity Monitoring works best when pointed at a narrow scope of critical files to limit the number of unnecessary files that may be modified over the course of normal use. The accuracy and precision of defined policies also affect the efficacy of this technique.""" ;
     :kb-reference :Reference-FileIntegrityMonitoringinMicrosoftDefenderforCloud-Microsoft,
         :Reference-Tripwire .
 
@@ -18403,7 +18403,7 @@ Hardware process isolation is commonly implemented through Direct Memory Access 
     :d3fend-id "D3-HCI" ;
     :definition "Hardware component inventorying identifies and records the hardware items in the organization's architecture." ;
     :kb-article """## How it works
-Administrators collect information on hardware devices such as peripherals, NICs, processors, and memory devices that are components of the computers in their architecture using a variety of administrative and management tools that query for this information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through remote adminstration tools and system commands, either manually or using scripts.
+Administrators collect information on hardware devices such as peripherals, NICs, processors, and memory devices that are components of the computers in their architecture using a variety of administrative and management tools that query for this information.  In some cases, where such queries are not supported or provide specific information of interest, an administrator may also collect this information through remote administration tools and system commands, either manually or using scripts.
 
 ## Considerations
 * Scanning and probing techniques using mapping tools can result in side effects to information technology (IT) and operational technology (OT) systems.
@@ -19151,7 +19151,7 @@ Wikipedia. (n.d.). Statistical hypothesis testing. [Link](https://en.wikipedia.o
     rdfs:subClassOf :DecisionTree ;
     :d3fend-id "D3A-ID3" ;
     :definition "ID3 stands for Iterative Dichotomiser 3 and is named such because the algorithm iteratively (repeatedly) dichotomizes(divides) features into two or more groups at each step." ;
-    :kb-article """## Addtional Consiterations
+    :kb-article """## Additional Considerations
 ID3 is the basis of C4.5, and is best used in natural language processing.
 
 ## References
@@ -19268,7 +19268,7 @@ MathWorks. (n.d.). Get Started with GANs for Image-to-Image Translation. [Link](
     rdfs:label "Image Synthesis GAN" ;
     rdfs:subClassOf :GenerativeAdversarialNetwork ;
     :d3fend-id "D3A-ISG" ;
-    :definition "Image synthesis thorugh the application of Generative Adversarial Networks." ;
+    :definition "Image synthesis through the application of Generative Adversarial Networks." ;
     :kb-article """## References
 
 Zhang, Q., Wang, H., Lu, H., Won, D., & Yoon, S. W. (2018). Medical Image Synthesis with Generative Adversarial Networks for Tissue Recognition. 2018 IEEE International Conference on Healthcare Informatics (ICHI), 199-207. doi: 10.1109/ICHI.2018.00030. [Link](https://ieeexplore.ieee.org/document/8419363)""" .
@@ -19620,7 +19620,7 @@ Identification of potential ROP exploit execution includes:
 
 ## Considerations
 
-* May be operating system dependent since specific system calls are used to scope branching behavoir
+* May be operating system dependent since specific system calls are used to scope branching behavior
 * Processors need to support access to a Last Branch Recording list feature
 * The size of the LBR stack can limit the expected size of the analyzed execution stack
 * If processor does not support LBR then overhead costs for the analysis can be significant""" ;
@@ -20161,7 +20161,7 @@ Potential for false positives from anomalies that are not associated with malici
     :definition "K-center Clustering is a type of clustering based on an combinatorial optimization methods.  It clusters a set of points so as to minimize the maximum intercluster distance." ;
     :kb-article """## How it works
 
-An example K-center Clustering problem is to mimimize the number of points in a set that are necessary so that a every other point in the set is within some fixed distance of those points.  For instance, given n cities with specified distances, one wants to build k warehouses in different cities and minimize the maximum distance of a city to a warehouse.
+An example K-center Clustering problem is to minimize the number of points in a set that are necessary so that every other point in the set is within some fixed distance of those points.  For instance, given n cities with specified distances, one wants to build k warehouses in different cities and minimize the maximum distance of a city to a warehouse.
 
 ## Considerations
 
@@ -21140,7 +21140,7 @@ Many operating systems, software frameworks and programs include a logging syste
     :definition "A logical rule matches event data or set of values to a conditional expression and results in the determination of a truth value, which may be used to determine the next action or step to take." ;
     :kb-article """## How it works
 
-Logic rules define a set of patterns that in some patterns must match input data. If the the conditions are met, then the rule will "fire" and some action will be taken, usually notifying a person or another system that the event being monitored needs further processing or attention.
+Logic rules define a set of patterns that in some patterns must match input data. If the conditions are met, then the rule will "fire" and some action will be taken, usually notifying a person or another system that the event being monitored needs further processing or attention.
 
 ## Key Test Considerations
 
@@ -21760,7 +21760,7 @@ Model-free (reinforcement learning). Wikipedia. [Link](https://en.wikipedia.org/
     rdfs:label "Moments" ;
     rdfs:subClassOf :DistributionProperties ;
     :d3fend-id "D3A-MOM" ;
-    :definition "With a probability distribution function, the the first moment is the expected value, the second central moment is the variance, the third standardized moment is the skewness, and the fourth standardized moment is the kurtosis." ;
+    :definition "With a probability distribution function, the first moment is the expected value, the second central moment is the variance, the third standardized moment is the skewness, and the fourth standardized moment is the kurtosis." ;
     :kb-article """## References
 Wikipedia. (n.d.). Moment (mathematics). [Link](https://en.wikipedia.org/wiki/Moment_(mathematics))""" ;
     :todo "Split out the different moments as leaves under moments instead of having them and moments at the same level" .
@@ -21829,7 +21829,7 @@ Motion sensors generate events when movement is detected within their coverage p
     rdfs:subClassOf :TimeSeriesAnalysis ;
     :d3fend-id "D3A-MAM" ;
     :definition "the moving-average model (MA model) is an approach for modeling univariate time series and specifies that the output variable is cross-correlated with a non-identical to itself random-variable." ;
-    :kb-article """## Refrences
+    :kb-article """## References
 Wikipedia. (n.d.). Moving average model. [Link](https://en.wikipedia.org/wiki/Moving_average_model)""" ;
     :synonym "MA Model" .
 
@@ -22510,7 +22510,7 @@ Wikipedia. (n.d.). Nonlinear regression. [Link](https://en.wikipedia.org/wiki/No
     rdfs:subClassOf :NTFSLink,
         :SymbolicLink ;
     rdfs:isDefinedBy <http://dbpedia.org/resource/NTFS_links> ;
-    :definition "NTFS junction points are are similar to NTFS symlinks but are defined only for directories. Only accepts local absolute paths." .
+    :definition "NTFS junction points are similar to NTFS symlinks but are defined only for directories. Only accepts local absolute paths." .
 
 :NTFSLink a owl:Class ;
     rdfs:label "NTFS Link" ;
@@ -22979,7 +22979,7 @@ Key steps in operational process security monitoring are:
 
 3. Display the aggregated data to a device such as an HMI or process historian, and write those records to event logs and/or to the OT process data historian for traceability and incident reconstruction.
 
-4. Monitor the procees and detect incidents or indicators of tampering such as:
+4. Monitor the process and detect incidents or indicators of tampering such as:
 - malfunctions
 - unauthorized commands,
 - unsafe setpoint changes,
@@ -23164,7 +23164,7 @@ Key steps in operational process security monitoring are:
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :Exec ] ;
-    :definition "An OS API function that replaces the current process image with a new processs image, executing a specified program." .
+    :definition "An OS API function that replaces the current process image with a new process image, executing a specified program." .
 
 :OSAPIFreeMemory a owl:Class ;
     rdfs:label "OS API Free Memory" ;
@@ -23305,7 +23305,7 @@ Key steps in operational process security monitoring are:
         [ a owl:Restriction ;
             owl:onProperty :invokes ;
             owl:someValuesFrom :TerminateProcess ] ;
-    rdfs:seeAlso "An OS API function taht stops the execution of a process." .
+    rdfs:seeAlso "An OS API function that stops the execution of a process." .
 
 :OSAPITraceProcess a owl:Class ;
     rdfs:label "OS API Trace Process" ;
@@ -24323,7 +24323,7 @@ Modbus: Read FIFO Queue""" ;
             owl:someValuesFrom :File ] ;
     rdfs:comment "BACnet: atomicReadFile",
         "Modbus: Read File Record" ;
-    :definition "Reads data in specified chuncks or the contents of a specified file stored in the file device connected to the PC." ;
+    :definition "Reads data in specified chunks or the contents of a specified file stored in the file device connected to the PC." ;
     rdfs:seeAlso <https://icscsi.org/library/Documents/ICS_Protocols/Control%20Microsystems%20-%20DNP3%20User%20and%20Reference%20Manual.pdf>,
         <https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf>,
         <https://nvlpubs.nist.gov/nistpubs/TechnicalNotes/NIST.TN.2023.pdf> .
@@ -24337,7 +24337,7 @@ Modbus: Read FIFO Queue""" ;
         [ a owl:Restriction ;
             owl:onProperty :has-participant ;
             owl:someValuesFrom :OTReadFileCommand ] ;
-    :definition "Reads data in specified chuncks or the contents of a specified file stored in the file device connected to the PC." .
+    :definition "Reads data in specified chunks or the contents of a specified file stored in the file device connected to the PC." .
 
 :OTReadTimeCommand a owl:Class ;
     rdfs:label "OT Read Time Command" ;
@@ -25014,7 +25014,7 @@ Log integrity is verified by log auditors. Auditors make use of log proofs are u
     rdfs:label "Passive Logical Link Mapping" ;
     rdfs:subClassOf :LogicalLinkMapping ;
     :d3fend-id "D3-PLLM" ;
-    :definition "Passive logical link mapping only listens to network traffic as a means to map the the whole data link layer, where the links represent logical data flows rather than physical connections." ;
+    :definition "Passive logical link mapping only listens to network traffic as a means to map the whole data link layer, where the links represent logical data flows rather than physical connections." ;
     :kb-reference :Reference-TenablePassiveNetworkMonitoring ;
     :synonym "Passive Logical Layer Mapping" .
 
@@ -25218,7 +25218,7 @@ Collection and analysis of large network packet captures requires large storage 
     :d3fend-id "D3-PFV" ;
     :definition "Cryptographically verifying peripheral firmware integrity." ;
     :kb-article """# How it works
-Peripherial firmware is collected and  analyzed on a host either periodically or on demand. This information may be collected for future comparisons.
+Peripheral firmware is collected and  analyzed on a host either periodically or on demand. This information may be collected for future comparisons.
 
 Changes in firmware hash values may indicate that the firmware has been tampered with or that firmware images are not maintained to current baselined versions, or even known vulnerable versions are deployed.
 
@@ -25294,7 +25294,7 @@ Engelen, S., & Hoos, H. (2020). A survey on semi-supervised learning. Machine Le
 :PhysicalAccessAlarmEvent a owl:Class ;
     rdfs:label "Physical Access Alarm Event" ;
     rdfs:subClassOf :DigitalEvent ;
-    rdfs:comment "An event occuring when a physical threshold is crossed." .
+    rdfs:comment "An event occurring when a physical threshold is crossed." .
 
 :PhysicalAccessMediation a owl:Class,
         owl:NamedIndividual,
@@ -25405,9 +25405,9 @@ System designers or operators make physical changes to a computer enclosure whic
         [ a owl:Restriction ;
             owl:onProperty :carries ;
             owl:someValuesFrom :Signal ] ;
-    :definition """A physical link is a dedicated connection for communication that uses some physical media (electrical, electromagnetic, optical, to include clear spaces or vacuums.)  A physical link represents only a single hop (link) in any larger communcations path, circuit, or network.
+    :definition """A physical link is a dedicated connection for communication that uses some physical media (electrical, electromagnetic, optical, to include clear spaces or vacuums.)  A physical link represents only a single hop (link) in any larger communications path, circuit, or network.
 
-NOTE: not synonymous with data link as a data link can be over a telecommunications circuit, which may be a virtual circuit composed of multiple phyical links.""" ;
+NOTE: not synonymous with data link as a data link can be over a telecommunications circuit, which may be a virtual circuit composed of multiple physical links.""" ;
     rdfs:seeAlso <https://dbpedia.org/resource/Physical_layer> ;
     :synonym "Layer-1 Link" .
 
@@ -25546,7 +25546,7 @@ A physical mechanism which has a associated credential which when entered enable
     rdfs:label "Pix2Pix" ;
     rdfs:subClassOf :Image-to-ImageTranslationGAN ;
     :d3fend-id "D3A-PIX" ;
-    :definition "Pix2Pix is based on condtional GAN architecture and are trained on paired set of images or scenes from two domains to be used for translation." ;
+    :definition "Pix2Pix is based on conditional GAN architecture and are trained on paired set of images or scenes from two domains to be used for translation." ;
     :kb-article """## References
 Esri. (n.d.). How Pix2Pix Works. [Link](https://developers.arcgis.com/python/guide/how-pix2pix-works/)""" .
 
@@ -25747,7 +25747,7 @@ Policy Gradients in a Nutshell. Towards Data Science.  [Link](https://towardsdat
     rdfs:label "Predicate Logic" ;
     rdfs:subClassOf :SymbolicAI ;
     :d3fend-id "D3A-PL" ;
-    :definition "Predicate logic is is collection of formal systems used in mathematics, philosophy, linguistics, and computer science. First-order logic and Higher-order logic both incorporate predicate logic." ;
+    :definition "Predicate logic is a collection of formal systems used in mathematics, philosophy, linguistics, and computer science. First-order logic and Higher-order logic both incorporate predicate logic." ;
     :kb-article """## References
 1. First-order logic. (2023, May 26). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/First-order_logic)
 2. Higher-order logic. (2023, May 13)
@@ -26579,7 +26579,7 @@ Intro to Active Learning. inovex Blog.  [Link](https://www.inovex.de/de/blog/int
 
 There are three core radiation hardening methodologies:
 
-1. Radiation Hardening by Process (RHBP): modifying the physical fabrication of a semiconductor (e.g., using SOI - Silicon on Insulator), offering the highest intrinsic protection. Usually the most expensive option as it requires a specialized semiconducter fabrication plant.
+1. Radiation Hardening by Process (RHBP): modifying the physical fabrication of a semiconductor (e.g., using SOI - Silicon on Insulator), offering the highest intrinsic protection. Usually the most expensive option as it requires a specialized semiconductor fabrication plant.
 2. Radiation Hardening by Design (RHBD): modifying circuit topology and physical layout using techniques such as Triple Modular Redundancy (TMM). A more cost-effective option, with the constraint of potentially increasing chip area and power.
 3. Radiation Hardening by Shielding (RHBS): using physical materials (e.g., aluminum or tantalum) to block ionizing particles. Simple to implement, with the constraint of increasing size and weight.""" ;
     :kb-reference :Reference-ARadiationHardenedSARADCWithDelayBasedDualFeedbackFlipFlopsForSensorReadoutSystems,
@@ -27251,7 +27251,7 @@ A regular expression (shortened as regex or regexp) is a sequence of characters 
 
 ## Key Test Considerations
 
-- **External review of regular expressions**: Regular expressions used in rules should be reviewed by a independent developer SME.  Regex testing and visualization tools may be used to aid this review.  Back-tests for failure modes identified during the review shoud be developed.  Regular expressions are easy to get wrong and may appear to work on limited tests; small mistakes can lead to unintended misses and matches.]
+- **External review of regular expressions**: Regular expressions used in rules should be reviewed by an independent developer SME.  Regex testing and visualization tools may be used to aid this review.  Back-tests for failure modes identified during the review should be developed.  Regular expressions are easy to get wrong and may appear to work on limited tests; small mistakes can lead to unintended misses and matches.
 
 - **Processing Performance Review**: Review of resource-intensive rules may be necessary if system performance degraded.  Look for cases of “exponential backtracking”  Some regexes are computationally expensive.
 
@@ -27309,7 +27309,7 @@ Reinforcement learning. Wikipedia.  [Link](https://en.wikipedia.org/wiki/Reinfor
             owl:onProperty :restores ;
             owl:someValuesFrom :Credential ] ;
     :d3fend-id "D3-RIC" ;
-    :definition "Issue a new credential to a user which supercedes their old credential." ;
+    :definition "Issue a new credential to a user which supersedes their old credential." ;
     :kb-reference :Reference-CybersecurityIncidentandVulnerabilityResponsePlaybooks .
 
 :Relational-basedTransferLearning a owl:Class,
@@ -29542,7 +29542,7 @@ Wolfram MathWorld. (n.d.). Statistics. [Link](https://mathworld.wolfram.com/Stat
 :StringFormatFunction a owl:Class ;
     rdfs:label "String Format Function" ;
     rdfs:subClassOf :Subroutine ;
-    :definition "A function which creates a new string based on a format specification and correspondingi specified values." .
+    :definition "A function which creates a new string based on a format specification and corresponding specified values." .
 
 :StringPatternMatching a owl:Class,
         owl:NamedIndividual ;
@@ -29588,7 +29588,7 @@ Wikipedia. (n.d.). StyleGAN. [Link](https://en.wikipedia.org/wiki/StyleGAN)""" ;
 :Subroutine a owl:Class ;
     rdfs:label "Subroutine" ;
     rdfs:subClassOf :Software ;
-    :comment "This class is intented to capture \"semantic subroutines\", thus, every subclass should imply a very specific function such as \"copy file\", \"eval\", or \"format string\"." ;
+    :comment "This class is intended to capture \"semantic subroutines\", thus, every subclass should imply a very specific function such as \"copy file\", \"eval\", or \"format string\"." ;
     :definition "In different programming languages, a subroutine may be called a procedure, a function, a routine, a method, or a subprogram. The generic term callable unit is sometimes used." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Subroutine> ;
     :synonym "Method",
@@ -29679,7 +29679,7 @@ About Support Vector Machine (SVM). IBM SPSS Modeler SaaS Documentation. [Link](
 Symbolic artificial intelligence is used in tools such as logic programming, production rules, semantic nets and frames, and it developed applications such as knowledge-based systems (in particular, expert systems), symbolic mathematics, automated theorem provers, ontologies, the semantic web, and automated planning and scheduling systems. The Symbolic AI paradigm led to seminal ideas in search, symbolic programming languages, agents, multi-agent systems, the semantic web, and the strengths and limitations of formal knowledge and reasoning systems.
 
 ## References
-1. Symbolic artifical intelligence. (2023, May 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Symbolic_artificial_intelligence)""" ;
+1. Symbolic artificial intelligence. (2023, May 23). In _Wikipedia_. [Link](https://en.wikipedia.org/wiki/Symbolic_artificial_intelligence)""" ;
     :synonym "Symbolic Artificial Intelligence" .
 
 :SymbolicLink a owl:Class ;
@@ -29720,7 +29720,7 @@ Day, O., & Khoshgoftaar, T.M. (2017). A survey on heterogeneous transfer learnin
 :SymmetricKey a owl:Class ;
     rdfs:label "Symmetric Key" ;
     rdfs:subClassOf :CryptographicKey ;
-    :definition "A symmetric key is a single key used for both encryption and decryption and used with a symmetric-key algorithm. Symmetric-key algorithms are algorithms for cryptography that use the same cryptographic keys for both encryption of plaintext and decryption of ciphertext. The keys may be identical or there may be a simple transformation to go between the two keys. The keys, in practice, represent a shared secret between two or more parties that can be used to maintain a private information link. This requirement that both parties have access to the secret key is one of the main drawbacks of symmetric key encryption, in comparison to public-key encrytption (also known as asymmetric key encryption)." ;
+    :definition "A symmetric key is a single key used for both encryption and decryption and used with a symmetric-key algorithm. Symmetric-key algorithms are algorithms for cryptography that use the same cryptographic keys for both encryption of plaintext and decryption of ciphertext. The keys may be identical or there may be a simple transformation to go between the two keys. The keys, in practice, represent a shared secret between two or more parties that can be used to maintain a private information link. This requirement that both parties have access to the secret key is one of the main drawbacks of symmetric key encryption, in comparison to public-key encryption (also known as asymmetric key encryption)." ;
     rdfs:seeAlso <http://dbpedia.org/resource/Symmetric-key_algorithm> .
 
 :System a owl:Class ;
@@ -29951,7 +29951,7 @@ The organization collects and models architectural information about the softwar
 ## Considerations
 * Data exchanges identified in the network mapping efforts usually indicate such dependencies, but may not be part of the intended design.
 * Architectural design artifacts and SMEs may need to be consulted to determine if dependencies are intended or otherwise essential.
-* System depedency mapping can identify internal dependencies of standard and pre-built systems that should be incorporated into a complete system dependency model.
+* System dependency mapping can identify internal dependencies of standard and pre-built systems that should be incorporated into a complete system dependency model.
 * System dependencies for critical systems--those supporting critical organizational activities--should be prioritized for supply chain risk analysis.
 * System dependencies should identify the integral components of a given named system and their structure to form a system.
 * System dependencies with a given system may be fixed by a particular product's configuration, and leveraging external knowledge bases about dependencies available (e.g., from package managers) is essential.""" ;


### PR DESCRIPTION
## Summary
- correct unambiguous spelling errors in definitions, comments, todo notes, and knowledge-base articles
- remove accidental duplicated words and a few transcription artifacts
- leave class IRIs, labels, imported CWE/ATT&CK text, and quoted reference abstracts unchanged

## Scope
Examples:
- `softare` -> `software`
- `sendingn` -> `sending`
- `correspondingi` -> `corresponding`
- `Consiterations` -> `Considerations`
- duplicated `the the` and `should should` -> single words

## Validation
- `make build/d3fend-full.owl`
- `robot validate-profile --profile DL --input build/d3fend-full.owl`
- `robot reason --reasoner ELK --input build/d3fend-full.owl`
- filtered codespell 2.4.2 pass
- `git diff --check`
